### PR TITLE
fix: add foreign key validation in topics and ratings

### DIFF
--- a/src/core/ratings.ts
+++ b/src/core/ratings.ts
@@ -43,6 +43,18 @@ export function rateDocument(db: Database.Database, input: RateDocumentInput): R
     throw new DocumentNotFoundError(input.documentId);
   }
 
+  // Verify chunk belongs to the document if provided
+  if (input.chunkId) {
+    const chunk = db
+      .prepare("SELECT id FROM chunks WHERE id = ? AND document_id = ?")
+      .get(input.chunkId, input.documentId) as { id: string } | undefined;
+    if (!chunk) {
+      throw new ValidationError(
+        `Chunk '${input.chunkId}' not found for document '${input.documentId}'`,
+      );
+    }
+  }
+
   const id = randomUUID();
   const ratedBy = input.ratedBy ?? "user";
 

--- a/src/core/topics.ts
+++ b/src/core/topics.ts
@@ -30,6 +30,16 @@ export function createTopic(db: Database.Database, input: CreateTopicInput): Top
       .replace(/[^a-z0-9]+/g, "-")
       .replace(/^-|-$/g, "") || randomUUID();
 
+  // Verify parent exists if provided
+  if (input.parentId) {
+    const parent = db.prepare("SELECT id FROM topics WHERE id = ?").get(input.parentId) as
+      | { id: string }
+      | undefined;
+    if (!parent) {
+      throw new ValidationError(`Parent topic '${input.parentId}' not found`);
+    }
+  }
+
   // Check for duplicate
   const existing = db.prepare("SELECT id FROM topics WHERE id = ?").get(id) as
     | { id: string }


### PR DESCRIPTION
Validates parentId exists before creating topic, and validates chunkId belongs to document before rating.

Closes #37