### PR TITLE
fix: add logging to silent catch blocks

### DIFF
--- a/src/core/indexing.ts
+++ b/src/core/indexing.ts
@@ -169,9 +169,8 @@ export async function indexDocument(
       try {
         const vecBuffer = Buffer.from(new Float32Array(embedding).buffer);
         insertEmbedding.run(chunkId, vecBuffer);
-      } catch {
-        // Vector table might not exist — skip silently
-        log.debug({ chunkId }, "Skipped vector insertion (sqlite-vec may not be loaded)");
+      } catch (err) {
+        log.debug({ chunkId, err }, "Skipped vector insertion (sqlite-vec may not be loaded)");
       }
     }
   });

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -121,8 +121,8 @@ export async function searchDocuments(
       score: 1 - row.distance, // Convert distance to similarity
       avgRating: row.avg_rating,
     }));
-  } catch {
-    log.warn("Vector search unavailable, falling back to keyword search");
+  } catch (err) {
+    log.warn({ err }, "Vector search unavailable, falling back to keyword search");
     return keywordSearch(db, options, limit);
   }
 }
@@ -139,8 +139,8 @@ function keywordSearch(
   // Try FTS5 first
   try {
     return fts5Search(db, options, limit);
-  } catch {
-    log.debug("FTS5 unavailable, falling back to LIKE search");
+  } catch (err) {
+    log.debug({ err }, "FTS5 unavailable, falling back to LIKE search");
   }
 
   const words = options.query.split(/\s+/).filter((w) => w.length > 2);

--- a/src/core/url-fetcher.ts
+++ b/src/core/url-fetcher.ts
@@ -60,7 +60,10 @@ export async function fetchAndConvert(url: string): Promise<FetchedDocument> {
     };
   } catch (err) {
     if (err instanceof FetchError) throw err;
-    throw new FetchError(`Failed to fetch URL: ${url} — ${String(err)}`, err);
+    throw new FetchError(
+      `Failed to fetch URL: ${url} — ${err instanceof Error ? err.message : String(err)}`,
+      err,
+    );
   }
 }
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -85,13 +85,14 @@ const MIGRATIONS: Record<number, string> = {
       VALUES (new.content, new.id, new.document_id);
     END;
 
-    -- Backfill existing chunks into FTS
-    INSERT INTO chunks_fts(content, chunk_id, document_id)
-    SELECT content, id, document_id FROM chunks;
-
     INSERT INTO schema_version (version) VALUES (2);
   `,
 };
+
+const FTS_BACKFILL_SQL = `
+  INSERT INTO chunks_fts(content, chunk_id, document_id)
+  SELECT content, id, document_id FROM chunks;
+`;
 
 /** Run pending migrations on the database. */
 export function runMigrations(db: Database.Database): void {
@@ -130,6 +131,13 @@ export function runMigrations(db: Database.Database): void {
     });
 
     migrate();
+
+    try {
+      db.exec(FTS_BACKFILL_SQL);
+    } catch (err) {
+      log.warn({ err }, "FTS backfill failed — new chunks will still be indexed via triggers");
+    }
+
     log.info("Database migrations complete");
   } catch (err) {
     if (err instanceof DatabaseError) throw err;


### PR DESCRIPTION
Adds debug/warn logging to catch blocks that previously swallowed errors silently.

Closes #38