### PR TITLE
feat: add retry with exponential backoff for embedding providers

### DIFF
--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -1,4 +1,5 @@
 import { EmbeddingError } from "../errors.js";
+import { withRetry } from "../utils/retry.js";
 import type { EmbeddingProvider } from "./embedding.js";
 
 /**
@@ -22,27 +23,29 @@ export class OllamaEmbeddingProvider implements EmbeddingProvider {
       throw new EmbeddingError("Input text must not be empty");
     }
     try {
-      const response = await fetch(`${this.baseUrl}/api/embed`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ model: this.model, input: text }),
+      return await withRetry<number[]>(async () => {
+        const response = await fetch(`${this.baseUrl}/api/embed`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ model: this.model, input: text }),
+        });
+
+        if (!response.ok) {
+          throw new Error(`Ollama API returned ${response.status}: ${await response.text()}`);
+        }
+
+        const data = (await response.json()) as { embeddings: number[][] };
+        const embedding = data.embeddings[0];
+        if (!embedding) {
+          throw new Error("Ollama returned empty embeddings");
+        }
+        if (embedding.length !== this.dimensions) {
+          throw new EmbeddingError(
+            `Expected embedding dimension ${this.dimensions}, got ${embedding.length}`,
+          );
+        }
+        return embedding;
       });
-
-      if (!response.ok) {
-        throw new Error(`Ollama API returned ${response.status}: ${await response.text()}`);
-      }
-
-      const data = (await response.json()) as { embeddings: number[][] };
-      const embedding = data.embeddings[0];
-      if (!embedding) {
-        throw new Error("Ollama returned empty embeddings");
-      }
-      if (embedding.length !== this.dimensions) {
-        throw new EmbeddingError(
-          `Expected embedding dimension ${this.dimensions}, got ${embedding.length}`,
-        );
-      }
-      return embedding;
     } catch (err) {
       if (err instanceof EmbeddingError) throw err;
       throw new EmbeddingError(
@@ -63,30 +66,32 @@ export class OllamaEmbeddingProvider implements EmbeddingProvider {
     }
     // Ollama supports batch input
     try {
-      const response = await fetch(`${this.baseUrl}/api/embed`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ model: this.model, input: texts }),
-      });
+      return await withRetry<number[][]>(async () => {
+        const response = await fetch(`${this.baseUrl}/api/embed`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ model: this.model, input: texts }),
+        });
 
-      if (!response.ok) {
-        throw new Error(`Ollama API returned ${response.status}: ${await response.text()}`);
-      }
+        if (!response.ok) {
+          throw new Error(`Ollama API returned ${response.status}: ${await response.text()}`);
+        }
 
-      const data = (await response.json()) as { embeddings: number[][] };
-      if (data.embeddings.length !== texts.length) {
-        throw new EmbeddingError(
-          `Ollama returned ${data.embeddings.length} embeddings for ${texts.length} inputs`,
-        );
-      }
-      for (const emb of data.embeddings) {
-        if (emb.length !== this.dimensions) {
+        const data = (await response.json()) as { embeddings: number[][] };
+        if (data.embeddings.length !== texts.length) {
           throw new EmbeddingError(
-            `Expected embedding dimension ${this.dimensions}, got ${emb.length}`,
+            `Ollama returned ${data.embeddings.length} embeddings for ${texts.length} inputs`,
           );
         }
-      }
-      return data.embeddings;
+        for (const emb of data.embeddings) {
+          if (emb.length !== this.dimensions) {
+            throw new EmbeddingError(
+              `Expected embedding dimension ${this.dimensions}, got ${emb.length}`,
+            );
+          }
+        }
+        return data.embeddings;
+      });
     } catch (err) {
       if (err instanceof EmbeddingError) throw err;
       throw new EmbeddingError(

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -1,5 +1,6 @@
 import OpenAI from "openai";
 import { EmbeddingError } from "../errors.js";
+import { withRetry } from "../utils/retry.js";
 import type { EmbeddingProvider } from "./embedding.js";
 
 /**
@@ -24,20 +25,22 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
       throw new EmbeddingError("Input text must not be empty");
     }
     try {
-      const response = await this.client.embeddings.create({
-        model: this.model,
-        input: text,
+      return await withRetry<number[]>(async () => {
+        const response = await this.client.embeddings.create({
+          model: this.model,
+          input: text,
+        });
+        const embedding = response.data[0]?.embedding;
+        if (!embedding) {
+          throw new Error("OpenAI returned empty embedding");
+        }
+        if (embedding.length !== this.dimensions) {
+          throw new EmbeddingError(
+            `Expected embedding dimension ${this.dimensions}, got ${embedding.length}`,
+          );
+        }
+        return embedding;
       });
-      const embedding = response.data[0]?.embedding;
-      if (!embedding) {
-        throw new Error("OpenAI returned empty embedding");
-      }
-      if (embedding.length !== this.dimensions) {
-        throw new EmbeddingError(
-          `Expected embedding dimension ${this.dimensions}, got ${embedding.length}`,
-        );
-      }
-      return embedding;
     } catch (err) {
       if (err instanceof EmbeddingError) throw err;
       throw new EmbeddingError(
@@ -57,24 +60,26 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
       }
     }
     try {
-      const response = await this.client.embeddings.create({
-        model: this.model,
-        input: texts,
-      });
-      if (response.data.length !== texts.length) {
-        throw new EmbeddingError(
-          `OpenAI returned ${response.data.length} embeddings for ${texts.length} inputs`,
-        );
-      }
-      const embeddings = response.data.map((d) => d.embedding);
-      for (const emb of embeddings) {
-        if (emb.length !== this.dimensions) {
+      return await withRetry<number[][]>(async () => {
+        const response = await this.client.embeddings.create({
+          model: this.model,
+          input: texts,
+        });
+        if (response.data.length !== texts.length) {
           throw new EmbeddingError(
-            `Expected embedding dimension ${this.dimensions}, got ${emb.length}`,
+            `OpenAI returned ${response.data.length} embeddings for ${texts.length} inputs`,
           );
         }
-      }
-      return embeddings;
+        const embeddings = response.data.map((d) => d.embedding);
+        for (const emb of embeddings) {
+          if (emb.length !== this.dimensions) {
+            throw new EmbeddingError(
+              `Expected embedding dimension ${this.dimensions}, got ${emb.length}`,
+            );
+          }
+        }
+        return embeddings;
+      });
     } catch (err) {
       if (err instanceof EmbeddingError) throw err;
       throw new EmbeddingError(

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -1,0 +1,29 @@
+import { getLogger } from "../logger.js";
+
+export interface RetryOptions {
+  maxRetries?: number;
+  baseDelayMs?: number;
+}
+
+export async function withRetry<T>(fn: () => Promise<T>, options?: RetryOptions): Promise<T> {
+  const maxRetries = options?.maxRetries ?? 3;
+  const baseDelayMs = options?.baseDelayMs ?? 100;
+  const logger = getLogger();
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      if (attempt < maxRetries) {
+        const delay = baseDelayMs * Math.pow(2, attempt);
+        logger.warn(
+          `Retry ${attempt + 1}/${maxRetries} after ${delay}ms: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+  }
+  throw lastError;
+}

--- a/tests/unit/retry.test.ts
+++ b/tests/unit/retry.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from "vitest";
+import { withRetry } from "../../src/utils/retry.js";
+
+describe("withRetry", () => {
+  it("should return result on first success", async () => {
+    const fn = vi.fn().mockResolvedValue("ok");
+    const result = await withRetry(fn);
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("should retry on failure and succeed", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("fail1"))
+      .mockRejectedValueOnce(new Error("fail2"))
+      .mockResolvedValue("ok");
+    const result = await withRetry(fn, { baseDelayMs: 1 });
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("should throw after max retries exhausted", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("always fails"));
+    await expect(withRetry(fn, { maxRetries: 2, baseDelayMs: 1 })).rejects.toThrow("always fails");
+    expect(fn).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+
+  it("should use default options", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("fail"));
+    await expect(withRetry(fn, { baseDelayMs: 1 })).rejects.toThrow("fail");
+    expect(fn).toHaveBeenCalledTimes(4); // initial + 3 retries (default)
+  });
+
+  it("should handle non-Error thrown values", async () => {
+    const fn = vi.fn().mockRejectedValueOnce("string error").mockResolvedValue("ok");
+    const result = await withRetry(fn, { baseDelayMs: 1 });
+    expect(result).toBe("ok");
+  });
+});


### PR DESCRIPTION
Adds a withRetry() utility and applies it to Ollama and OpenAI embed/embedBatch calls.

Closes #42