### PR TITLE
feat: add document versioning and update detection

### DIFF
--- a/src/core/documents.ts
+++ b/src/core/documents.ts
@@ -10,6 +10,7 @@ export interface Document {
   title: string;
   content: string;
   url: string | null;
+  contentHash: string | null;
   submittedBy: string;
   createdAt: string;
   updatedAt: string;
@@ -20,7 +21,7 @@ export function getDocument(db: Database.Database, documentId: string): Document
   const row = db
     .prepare(
       `
-    SELECT id, source_type, library, version, topic_id, title, content, url, submitted_by, created_at, updated_at
+    SELECT id, source_type, library, version, topic_id, title, content, url, content_hash, submitted_by, created_at, updated_at
     FROM documents WHERE id = ?
   `,
     )
@@ -34,6 +35,7 @@ export function getDocument(db: Database.Database, documentId: string): Document
         title: string;
         content: string;
         url: string | null;
+        content_hash: string | null;
         submitted_by: string;
         created_at: string;
         updated_at: string;
@@ -53,6 +55,7 @@ export function getDocument(db: Database.Database, documentId: string): Document
     title: row.title,
     content: row.content,
     url: row.url,
+    contentHash: row.content_hash,
     submittedBy: row.submitted_by,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -91,7 +94,7 @@ export function listDocuments(
   },
 ): Document[] {
   let sql = `
-    SELECT id, source_type, library, version, topic_id, title, content, url, submitted_by, created_at, updated_at
+    SELECT id, source_type, library, version, topic_id, title, content, url, content_hash, submitted_by, created_at, updated_at
     FROM documents WHERE 1=1
   `;
   const params: unknown[] = [];
@@ -121,6 +124,7 @@ export function listDocuments(
     title: string;
     content: string;
     url: string | null;
+    content_hash: string | null;
     submitted_by: string;
     created_at: string;
     updated_at: string;
@@ -135,6 +139,7 @@ export function listDocuments(
     title: row.title,
     content: row.content,
     url: row.url,
+    contentHash: row.content_hash,
     submittedBy: row.submitted_by,
     createdAt: row.created_at,
     updatedAt: row.updated_at,

--- a/src/core/indexing.ts
+++ b/src/core/indexing.ts
@@ -1,5 +1,5 @@
 import type Database from "better-sqlite3";
-import { randomUUID } from "node:crypto";
+import { randomUUID, createHash } from "node:crypto";
 import type { EmbeddingProvider } from "../providers/embedding.js";
 import { ValidationError } from "../errors.js";
 import { getLogger } from "../logger.js";
@@ -99,15 +99,29 @@ export async function indexDocument(
     throw new ValidationError("Document content is required");
   }
 
-  // Check for duplicate by URL
+  // Compute content hash for versioning
+  const contentHash = createHash("sha256").update(input.content).digest("hex");
+
+  // Check for duplicate by URL with content hash comparison
   if (input.url) {
-    const existing = db.prepare("SELECT id FROM documents WHERE url = ?").get(input.url) as
-      | { id: string }
-      | undefined;
+    const existing = db
+      .prepare("SELECT id, content_hash FROM documents WHERE url = ?")
+      .get(input.url) as { id: string; content_hash: string | null } | undefined;
     if (existing) {
-      throw new ValidationError(
-        `Document with URL already exists (id: ${existing.id}). Delete it first or use a different URL.`,
-      );
+      if (existing.content_hash === contentHash) {
+        log.info({ docId: existing.id, url: input.url }, "Document unchanged, skipping re-index");
+        return { id: existing.id, chunkCount: 0 };
+      }
+      // Document updated — delete old version and re-index
+      log.info({ docId: existing.id, url: input.url }, "Document updated, re-indexing");
+      try {
+        db.prepare(
+          "DELETE FROM chunk_embeddings WHERE chunk_id IN (SELECT id FROM chunks WHERE document_id = ?)",
+        ).run(existing.id);
+      } catch {
+        // chunk_embeddings table may not exist
+      }
+      db.prepare("DELETE FROM documents WHERE id = ?").run(existing.id);
     }
   }
 
@@ -132,8 +146,8 @@ export async function indexDocument(
 
   // Store everything in a transaction
   const insertDoc = db.prepare(`
-    INSERT INTO documents (id, source_type, library, version, topic_id, title, content, url, submitted_by)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO documents (id, source_type, library, version, topic_id, title, content, url, submitted_by, content_hash)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
 
   const insertChunk = db.prepare(`
@@ -157,6 +171,7 @@ export async function indexDocument(
       input.content,
       input.url ?? null,
       input.submittedBy ?? "manual",
+      contentHash,
     );
 
     for (let i = 0; i < chunks.length; i++) {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -2,7 +2,7 @@ import type Database from "better-sqlite3";
 import { DatabaseError } from "../errors.js";
 import { getLogger } from "../logger.js";
 
-const SCHEMA_VERSION = 2;
+const SCHEMA_VERSION = 3;
 
 const MIGRATIONS: Record<number, string> = {
   1: `
@@ -86,6 +86,13 @@ const MIGRATIONS: Record<number, string> = {
     END;
 
     INSERT INTO schema_version (version) VALUES (2);
+  `,
+  3: `
+    ALTER TABLE documents ADD COLUMN content_hash TEXT;
+
+    CREATE INDEX IF NOT EXISTS idx_documents_url ON documents(url);
+
+    INSERT INTO schema_version (version) VALUES (3);
   `,
 };
 

--- a/tests/unit/documents.test.ts
+++ b/tests/unit/documents.test.ts
@@ -3,7 +3,6 @@ import { createTestDb, createTestDbWithVec } from "../fixtures/test-db.js";
 import { getDocument, deleteDocument, listDocuments } from "../../src/core/documents.js";
 import { indexDocument, type IndexDocumentInput } from "../../src/core/indexing.js";
 import { MockEmbeddingProvider } from "../fixtures/mock-provider.js";
-import { ValidationError } from "../../src/errors.js";
 import type Database from "better-sqlite3";
 
 describe("documents", () => {
@@ -143,24 +142,30 @@ describe("documents", () => {
       provider = new MockEmbeddingProvider();
     });
 
-    it("should reject duplicate URL", async () => {
+    it("should skip re-indexing for unchanged document with same URL", async () => {
       await indexDocument(vecDb, provider, baseInput);
 
-      await expect(
-        indexDocument(vecDb, provider, {
-          ...baseInput,
-          title: "Different Title",
-          content: "Different content",
-        }),
-      ).rejects.toThrow(ValidationError);
+      const result = await indexDocument(vecDb, provider, {
+        ...baseInput,
+        title: "Different Title",
+      });
 
-      await expect(
-        indexDocument(vecDb, provider, {
-          ...baseInput,
-          title: "Different Title",
-          content: "Different content",
-        }),
-      ).rejects.toThrow("Document with URL already exists");
+      // Same content → same hash → skip
+      expect(result.chunkCount).toBe(0);
+    });
+
+    it("should re-index updated document with same URL", async () => {
+      const first = await indexDocument(vecDb, provider, baseInput);
+
+      const result = await indexDocument(vecDb, provider, {
+        ...baseInput,
+        title: "Different Title",
+        content: "Completely different content",
+      });
+
+      // Different content → different hash → re-index
+      expect(result.id).not.toBe(first.id);
+      expect(result.chunkCount).toBeGreaterThan(0);
     });
 
     it("should reject duplicate title + content length", async () => {

--- a/tests/unit/schema.test.ts
+++ b/tests/unit/schema.test.ts
@@ -35,7 +35,7 @@ describe("database schema", () => {
       const version = db.prepare("SELECT MAX(version) as v FROM schema_version").get() as {
         v: number;
       };
-      expect(version.v).toBe(2);
+      expect(version.v).toBe(3);
     });
 
     it("should create expected indexes", () => {


### PR DESCRIPTION
Closes #47

- Added migration v3: content_hash column on documents table
- Compute SHA-256 hash of document content before indexing
- Skip re-indexing when document content is unchanged (same URL + same hash)
- Automatically delete and re-index when document content changes (same URL + different hash)
- Updated Document interface and queries to include contentHash