### PR TITLE
feat: add search result pagination

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -164,28 +164,36 @@ program
   .option("--topic <topicId>", "Filter by topic")
   .option("--library <name>", "Filter by library")
   .option("--limit <n>", "Max results", "5")
-  .action(async (query: string, opts: { topic?: string; library?: string; limit: string }) => {
-    const { db, provider } = initializeAppWithEmbedding();
+  .option("--offset <n>", "Offset for pagination", "0")
+  .action(
+    async (
+      query: string,
+      opts: { topic?: string; library?: string; limit: string; offset: string },
+    ) => {
+      const { db, provider } = initializeAppWithEmbedding();
 
-    const results = await searchDocuments(db, provider, {
-      query,
-      topic: opts.topic,
-      library: opts.library,
-      limit: parseInt(opts.limit, 10),
-    });
+      const { results, totalCount } = await searchDocuments(db, provider, {
+        query,
+        topic: opts.topic,
+        library: opts.library,
+        limit: parseInt(opts.limit, 10),
+        offset: parseInt(opts.offset, 10),
+      });
 
-    if (results.length === 0) {
-      console.log("No results found.");
-    } else {
-      for (const r of results) {
-        console.log(`\n── ${r.title} (score: ${r.score.toFixed(2)}) ──`);
-        if (r.library) console.log(`  Library: ${r.library}`);
-        if (r.url) console.log(`  Source: ${r.url}`);
-        console.log(`  ${r.content.slice(0, 200)}${r.content.length > 200 ? "..." : ""}`);
+      if (results.length === 0) {
+        console.log("No results found.");
+      } else {
+        console.log(`\nShowing ${results.length} of ${totalCount} results:\n`);
+        for (const r of results) {
+          console.log(`\n── ${r.title} (score: ${r.score.toFixed(2)}) ──`);
+          if (r.library) console.log(`  Library: ${r.library}`);
+          if (r.url) console.log(`  Source: ${r.url}`);
+          console.log(`  ${r.content.slice(0, 200)}${r.content.length > 200 ? "..." : ""}`);
+        }
       }
-    }
-    closeDatabase();
-  });
+      closeDatabase();
+    },
+  );
 
 // topics
 const topicsCmd = program.command("topics").description("Manage topics");

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -9,6 +9,12 @@ export interface SearchOptions {
   version?: string | undefined;
   minRating?: number | undefined;
   limit?: number | undefined;
+  offset?: number | undefined;
+}
+
+export interface SearchResponse {
+  results: SearchResult[];
+  totalCount: number;
 }
 
 export interface SearchResult {
@@ -30,11 +36,12 @@ export async function searchDocuments(
   db: Database.Database,
   provider: EmbeddingProvider,
   options: SearchOptions,
-): Promise<SearchResult[]> {
+): Promise<SearchResponse> {
   const log = getLogger();
   const limit = options.limit ?? 10;
+  const offset = options.offset ?? 0;
 
-  log.info({ query: options.query, limit }, "Searching documents");
+  log.info({ query: options.query, limit, offset }, "Searching documents");
 
   // Generate query embedding
   const queryEmbedding = await provider.embed(options.query);
@@ -91,8 +98,17 @@ export async function searchDocuments(
       params.push(options.minRating);
     }
 
-    sql += ` ORDER BY candidates.distance LIMIT ?`;
+    sql += ` ORDER BY candidates.distance LIMIT ? OFFSET ?`;
     params.push(limit);
+    params.push(offset);
+
+    // Count total results (without LIMIT/OFFSET)
+    const countSql = sql.replace(/ORDER BY candidates\.distance LIMIT \? OFFSET \?/, "");
+    const countParams = params.slice(0, -2);
+    const countRow = db
+      .prepare(`SELECT COUNT(*) AS cnt FROM (${countSql})`)
+      .get(...countParams) as { cnt: number };
+    const totalCount = countRow.cnt;
 
     const rows = db.prepare(sql).all(...params) as Array<{
       chunk_id: string;
@@ -108,22 +124,25 @@ export async function searchDocuments(
       avg_rating: number | null;
     }>;
 
-    return rows.map((row) => ({
-      documentId: row.document_id,
-      chunkId: row.chunk_id,
-      title: row.title,
-      content: row.chunk_content,
-      sourceType: row.source_type,
-      library: row.library,
-      version: row.version,
-      topicId: row.topic_id,
-      url: row.url,
-      score: 1 - row.distance, // Convert distance to similarity
-      avgRating: row.avg_rating,
-    }));
+    return {
+      totalCount,
+      results: rows.map((row) => ({
+        documentId: row.document_id,
+        chunkId: row.chunk_id,
+        title: row.title,
+        content: row.chunk_content,
+        sourceType: row.source_type,
+        library: row.library,
+        version: row.version,
+        topicId: row.topic_id,
+        url: row.url,
+        score: 1 - row.distance, // Convert distance to similarity
+        avgRating: row.avg_rating,
+      })),
+    };
   } catch (err) {
     log.warn({ err }, "Vector search unavailable, falling back to keyword search");
-    return keywordSearch(db, options, limit);
+    return keywordSearch(db, options, limit, offset);
   }
 }
 
@@ -133,18 +152,19 @@ function keywordSearch(
   db: Database.Database,
   options: SearchOptions,
   limit: number,
-): SearchResult[] {
+  offset: number,
+): SearchResponse {
   const log = getLogger();
 
   // Try FTS5 first
   try {
-    return fts5Search(db, options, limit);
+    return fts5Search(db, options, limit, offset);
   } catch (err) {
     log.debug({ err }, "FTS5 unavailable, falling back to LIKE search");
   }
 
   const words = options.query.split(/\s+/).filter((w) => w.length > 2);
-  if (words.length === 0) return [];
+  if (words.length === 0) return { results: [], totalCount: 0 };
 
   const likeConditions = words.map(() => "c.content LIKE ?").join(" OR ");
   const params: unknown[] = words.map((w) => `%${w}%`);
@@ -188,8 +208,17 @@ function keywordSearch(
     params.push(options.minRating);
   }
 
-  sql += " LIMIT ?";
+  sql += " LIMIT ? OFFSET ?";
   params.push(limit);
+  params.push(offset);
+
+  // Count total results
+  const countSql = sql.replace(/ LIMIT \? OFFSET \?$/, "");
+  const countParams = params.slice(0, -2);
+  const countRow = db.prepare(`SELECT COUNT(*) AS cnt FROM (${countSql})`).get(...countParams) as {
+    cnt: number;
+  };
+  const totalCount = countRow.cnt;
 
   const rows = db.prepare(sql).all(...params) as Array<{
     chunk_id: string;
@@ -204,26 +233,34 @@ function keywordSearch(
     avg_rating: number | null;
   }>;
 
-  return rows.map((row, index) => ({
-    documentId: row.document_id,
-    chunkId: row.chunk_id,
-    title: row.title,
-    content: row.chunk_content,
-    sourceType: row.source_type,
-    library: row.library,
-    version: row.version,
-    topicId: row.topic_id,
-    url: row.url,
-    score: Math.max(0, 1 - index * 0.1), // Simple rank-based score
-    avgRating: row.avg_rating,
-  }));
+  return {
+    totalCount,
+    results: rows.map((row, index) => ({
+      documentId: row.document_id,
+      chunkId: row.chunk_id,
+      title: row.title,
+      content: row.chunk_content,
+      sourceType: row.source_type,
+      library: row.library,
+      version: row.version,
+      topicId: row.topic_id,
+      url: row.url,
+      score: Math.max(0, 1 - index * 0.1), // Simple rank-based score
+      avgRating: row.avg_rating,
+    })),
+  };
 }
 
 /** FTS5-based full-text search with BM25 ranking. */
-function fts5Search(db: Database.Database, options: SearchOptions, limit: number): SearchResult[] {
+function fts5Search(
+  db: Database.Database,
+  options: SearchOptions,
+  limit: number,
+  offset: number,
+): SearchResponse {
   // Escape FTS5 query: wrap each word in quotes for safety
   const words = options.query.split(/\s+/).filter((w) => w.length > 0);
-  if (words.length === 0) return [];
+  if (words.length === 0) return { results: [], totalCount: 0 };
 
   const ftsQuery = words.map((w) => `"${w.replace(/"/g, '""')}"`).join(" OR ");
   const params: unknown[] = [ftsQuery];
@@ -268,8 +305,17 @@ function fts5Search(db: Database.Database, options: SearchOptions, limit: number
     params.push(options.minRating);
   }
 
-  sql += " ORDER BY rank LIMIT ?";
+  sql += " ORDER BY rank LIMIT ? OFFSET ?";
   params.push(limit);
+  params.push(offset);
+
+  // Count total results
+  const countSql = sql.replace(/ ORDER BY rank LIMIT \? OFFSET \?$/, "");
+  const countParams = params.slice(0, -2);
+  const countRow = db.prepare(`SELECT COUNT(*) AS cnt FROM (${countSql})`).get(...countParams) as {
+    cnt: number;
+  };
+  const totalCount = countRow.cnt;
 
   const rows = db.prepare(sql).all(...params) as Array<{
     chunk_id: string;
@@ -285,17 +331,20 @@ function fts5Search(db: Database.Database, options: SearchOptions, limit: number
     avg_rating: number | null;
   }>;
 
-  return rows.map((row) => ({
-    documentId: row.document_id,
-    chunkId: row.chunk_id,
-    title: row.title,
-    content: row.chunk_content,
-    sourceType: row.source_type,
-    library: row.library,
-    version: row.version,
-    topicId: row.topic_id,
-    url: row.url,
-    score: -row.fts_rank, // BM25 rank is negative, lower = better
-    avgRating: row.avg_rating,
-  }));
+  return {
+    totalCount,
+    results: rows.map((row) => ({
+      documentId: row.document_id,
+      chunkId: row.chunk_id,
+      title: row.title,
+      content: row.chunk_content,
+      sourceType: row.source_type,
+      library: row.library,
+      version: row.version,
+      topicId: row.topic_id,
+      url: row.url,
+      score: -row.fts_rank, // BM25 rank is negative, lower = better
+      avgRating: row.avg_rating,
+    })),
+  };
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -108,6 +108,7 @@ async function main(): Promise<void> {
       library: z.string().optional().describe("Filter by library name"),
       version: z.string().optional().describe("Filter by library version"),
       minRating: z.number().min(1).max(5).optional().describe("Minimum average rating filter"),
+      offset: z.number().min(0).optional().describe("Offset for pagination (default: 0)"),
       limit: z
         .number()
         .min(1)
@@ -116,13 +117,14 @@ async function main(): Promise<void> {
         .describe("Maximum results to return (default: 10)"),
     },
     withErrorHandling(async (params) => {
-      const results = await searchDocuments(db, provider, {
+      const { results, totalCount } = await searchDocuments(db, provider, {
         query: params.query,
         topic: params.topic,
         library: params.library,
         version: params.version,
         minRating: params.minRating,
         limit: params.limit,
+        offset: params.offset,
       });
 
       if (results.length === 0) {
@@ -131,16 +133,18 @@ async function main(): Promise<void> {
         };
       }
 
-      const text = results
-        .map(
-          (r, i) =>
-            `## Result ${i + 1}: ${r.title}\n` +
-            (r.library ? `**Library:** ${r.library}${r.version ? ` v${r.version}` : ""}\n` : "") +
-            (r.url ? `**Source:** ${r.url}\n` : "") +
-            (r.avgRating ? `**Rating:** ${r.avgRating.toFixed(1)}/5\n` : "") +
-            `\n${r.content}\n`,
-        )
-        .join("\n---\n\n");
+      const text =
+        `**Total results: ${totalCount}**\n\n` +
+        results
+          .map(
+            (r, i) =>
+              `## Result ${i + 1}: ${r.title}\n` +
+              (r.library ? `**Library:** ${r.library}${r.version ? ` v${r.version}` : ""}\n` : "") +
+              (r.url ? `**Source:** ${r.url}\n` : "") +
+              (r.avgRating ? `**Rating:** ${r.avgRating.toFixed(1)}/5\n` : "") +
+              `\n${r.content}\n`,
+          )
+          .join("\n---\n\n");
 
       return { content: [{ type: "text" as const, text }] };
     }),

--- a/tests/integration/workflow.test.ts
+++ b/tests/integration/workflow.test.ts
@@ -56,7 +56,7 @@ describe("integration: full workflow", () => {
     expect(chunks.length).toBe(indexed.chunkCount);
 
     // 5. Search (falls back to keyword since we don't have vec0)
-    const results = await searchDocuments(db, provider, {
+    const { results } = await searchDocuments(db, provider, {
       query: "JWT tokens authentication",
     });
     expect(results.length).toBeGreaterThan(0);
@@ -169,13 +169,13 @@ describe("integration: full workflow", () => {
     });
 
     // Keyword search should find the right docs
-    const dbResults = await searchDocuments(db, provider, {
+    const { results: dbResults } = await searchDocuments(db, provider, {
       query: "PostgreSQL connection",
     });
     expect(dbResults.length).toBeGreaterThan(0);
     expect(dbResults[0]!.title).toBe("Database Setup");
 
-    const authResults = await searchDocuments(db, provider, {
+    const { results: authResults } = await searchDocuments(db, provider, {
       query: "JWT authentication token",
     });
     expect(authResults.length).toBeGreaterThan(0);

--- a/tests/unit/search.test.ts
+++ b/tests/unit/search.test.ts
@@ -44,9 +44,10 @@ describe("searchDocuments (FTS5 fallback)", () => {
     insertDoc(db, "doc2", "Advanced TypeScript");
     insertChunk(db, "c2", "doc2", "TypeScript generics and advanced type patterns");
 
-    const results = await searchDocuments(db, provider, { query: "TypeScript" });
+    const { results, totalCount } = await searchDocuments(db, provider, { query: "TypeScript" });
 
     expect(results.length).toBe(2);
+    expect(totalCount).toBe(2);
     expect(results[0].content).toContain("TypeScript");
     expect(results[0].score).toBeGreaterThan(0);
   });
@@ -58,7 +59,7 @@ describe("searchDocuments (FTS5 fallback)", () => {
     insertDoc(db, "doc2", "Vue Composition", { library: "vue" });
     insertChunk(db, "c2", "doc2", "Vue composition API for state management");
 
-    const results = await searchDocuments(db, provider, {
+    const { results } = await searchDocuments(db, provider, {
       query: "state",
       library: "react",
     });
@@ -77,7 +78,7 @@ describe("searchDocuments (FTS5 fallback)", () => {
     insertDoc(db, "doc2", "Deploy Guide", { topicId: "deployment" });
     insertChunk(db, "c2", "doc2", "Deployment best practices for production");
 
-    const results = await searchDocuments(db, provider, {
+    const { results } = await searchDocuments(db, provider, {
       query: "best practices",
       topic: "testing",
     });
@@ -90,10 +91,39 @@ describe("searchDocuments (FTS5 fallback)", () => {
     insertDoc(db, "doc1", "Some Doc");
     insertChunk(db, "c1", "doc1", "Content about databases and SQL");
 
-    const results = await searchDocuments(db, provider, {
+    const { results } = await searchDocuments(db, provider, {
       query: "xyznonexistent",
     });
 
     expect(results).toEqual([]);
+  });
+
+  it("should paginate results with offset", async () => {
+    insertDoc(db, "doc1", "First TypeScript Guide");
+    insertChunk(db, "c1", "doc1", "TypeScript basics and fundamentals");
+
+    insertDoc(db, "doc2", "Second TypeScript Guide");
+    insertChunk(db, "c2", "doc2", "TypeScript advanced patterns");
+
+    insertDoc(db, "doc3", "Third TypeScript Guide");
+    insertChunk(db, "c3", "doc3", "TypeScript generics and utilities");
+
+    const page1 = await searchDocuments(db, provider, {
+      query: "TypeScript",
+      limit: 2,
+      offset: 0,
+    });
+
+    expect(page1.totalCount).toBe(3);
+    expect(page1.results.length).toBe(2);
+
+    const page2 = await searchDocuments(db, provider, {
+      query: "TypeScript",
+      limit: 2,
+      offset: 2,
+    });
+
+    expect(page2.totalCount).toBe(3);
+    expect(page2.results.length).toBe(1);
   });
 });


### PR DESCRIPTION
Closes #49

- Add `offset` parameter to `SearchOptions` interface
- Add `SearchResponse` type returning `{ results, totalCount }`
- Update MCP `search-docs` tool with offset parameter
- Update CLI `search` command with `--offset` flag
- Add pagination test