### PR TITLE
fix: use atomic INSERT ON CONFLICT for topic creation

### DIFF
--- a/src/core/topics.ts
+++ b/src/core/topics.ts
@@ -42,30 +42,51 @@ export function createTopic(db: Database.Database, input: CreateTopicInput): Top
     }
   }
 
-  // Check for duplicate
-  const existing = db.prepare("SELECT id FROM topics WHERE id = ?").get(id) as
-    | { id: string }
-    | undefined;
-  if (existing) {
-    throw new ValidationError(`Topic '${id}' already exists`);
-  }
-
-  db.prepare(
-    `
+  // Atomic insert: ON CONFLICT avoids check-then-insert race condition
+  const result = db
+    .prepare(
+      `
     INSERT INTO topics (id, name, description, parent_id)
     VALUES (?, ?, ?, ?)
+    ON CONFLICT(name) DO NOTHING
   `,
-  ).run(id, input.name, input.description ?? null, input.parentId ?? null);
+    )
+    .run(id, input.name, input.description ?? null, input.parentId ?? null);
 
-  log.info({ topicId: id, name: input.name }, "Topic created");
+  if (result.changes > 0) {
+    log.info({ topicId: id, name: input.name }, "Topic created");
+    return {
+      id,
+      name: input.name,
+      description: input.description ?? null,
+      parentId: input.parentId ?? null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+  }
+
+  // Topic already existed — fetch and return it
+  log.info({ name: input.name }, "Topic already exists, returning existing");
+  const row = db
+    .prepare(
+      "SELECT id, name, description, parent_id, created_at, updated_at FROM topics WHERE name = ?",
+    )
+    .get(input.name) as {
+    id: string;
+    name: string;
+    description: string | null;
+    parent_id: string | null;
+    created_at: string;
+    updated_at: string;
+  };
 
   return {
-    id,
-    name: input.name,
-    description: input.description ?? null,
-    parentId: input.parentId ?? null,
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    parentId: row.parent_id,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
   };
 }
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -2,7 +2,7 @@ import type Database from "better-sqlite3";
 import { DatabaseError } from "../errors.js";
 import { getLogger } from "../logger.js";
 
-const SCHEMA_VERSION = 3;
+const SCHEMA_VERSION = 4;
 
 const MIGRATIONS: Record<number, string> = {
   1: `
@@ -93,6 +93,11 @@ const MIGRATIONS: Record<number, string> = {
     CREATE INDEX IF NOT EXISTS idx_documents_url ON documents(url);
 
     INSERT INTO schema_version (version) VALUES (3);
+  `,
+  4: `
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_topics_name ON topics(name);
+
+    INSERT INTO schema_version (version) VALUES (4);
   `,
 };
 

--- a/tests/unit/schema.test.ts
+++ b/tests/unit/schema.test.ts
@@ -35,7 +35,7 @@ describe("database schema", () => {
       const version = db.prepare("SELECT MAX(version) as v FROM schema_version").get() as {
         v: number;
       };
-      expect(version.v).toBe(3);
+      expect(version.v).toBe(4);
     });
 
     it("should create expected indexes", () => {

--- a/tests/unit/topics.test.ts
+++ b/tests/unit/topics.test.ts
@@ -37,9 +37,11 @@ describe("topics", () => {
       expect(() => createTopic(db, { name: "   " })).toThrow("Topic name is required");
     });
 
-    it("should reject duplicate topic", () => {
-      createTopic(db, { name: "Testing" });
-      expect(() => createTopic(db, { name: "Testing" })).toThrow("already exists");
+    it("should return existing topic on duplicate name", () => {
+      const first = createTopic(db, { name: "Testing" });
+      const second = createTopic(db, { name: "Testing" });
+      expect(second.id).toBe(first.id);
+      expect(second.name).toBe("Testing");
     });
 
     it("should support parent topics", () => {


### PR DESCRIPTION
Closes #77

## Changes
- Added migration 4: UNIQUE index on `topics.name` column
- Refactored `createTopic()` to use `INSERT ... ON CONFLICT(name) DO NOTHING` instead of separate SELECT-then-INSERT
- On duplicate name, returns the existing topic instead of throwing
- Updated schema version test and topics duplicate test