### PR TITLE
feat: add topic deletion, rename, and browsing

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -10,8 +10,16 @@ export type { RateDocumentInput, Rating, RatingSummary } from "./ratings.js";
 export { getDocument, deleteDocument, listDocuments } from "./documents.js";
 export type { Document } from "./documents.js";
 
-export { createTopic, listTopics, getTopic } from "./topics.js";
-export type { Topic, CreateTopicInput } from "./topics.js";
+export {
+  createTopic,
+  listTopics,
+  getTopic,
+  deleteTopic,
+  renameTopic,
+  getDocumentsByTopic,
+  getTopicStats,
+} from "./topics.js";
+export type { Topic, CreateTopicInput, GetDocumentsByTopicOptions, TopicStats } from "./topics.js";
 
 export { fetchAndConvert, DEFAULT_FETCH_OPTIONS } from "./url-fetcher.js";
 export type { FetchedDocument, FetchOptions } from "./url-fetcher.js";

--- a/src/core/topics.ts
+++ b/src/core/topics.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { ValidationError, TopicNotFoundError } from "../errors.js";
 import { createChildLogger } from "../logger.js";
 import { validateRow } from "../utils/db-validation.js";
+import type { Document } from "./documents.js";
 
 export interface Topic {
   id: string;
@@ -163,4 +164,117 @@ export function getTopic(db: Database.Database, topicId: string): Topic {
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
+}
+
+export interface GetDocumentsByTopicOptions {
+  limit?: number;
+  offset?: number;
+}
+
+export interface TopicStats {
+  id: string;
+  name: string;
+  description: string | null;
+  parentId: string | null;
+  documentCount: number;
+}
+
+/** Delete a topic and optionally its document associations. */
+export function deleteTopic(
+  db: Database.Database,
+  topicId: string,
+  options?: { deleteDocuments?: boolean },
+): void {
+  const log = createChildLogger({ operation: "deleteTopic" });
+  getTopic(db, topicId);
+  const run = db.transaction(() => {
+    if (options?.deleteDocuments) {
+      db.prepare("DELETE FROM documents WHERE topic_id = ?").run(topicId);
+    }
+    db.prepare("DELETE FROM topics WHERE id = ?").run(topicId);
+  });
+  run();
+  log.info({ topicId, deleteDocuments: options?.deleteDocuments ?? false }, "Topic deleted");
+}
+
+/** Rename a topic. */
+export function renameTopic(db: Database.Database, topicId: string, newName: string): Topic {
+  const log = createChildLogger({ operation: "renameTopic" });
+  if (!newName.trim()) {
+    throw new ValidationError("Topic name is required");
+  }
+  getTopic(db, topicId);
+  db.prepare("UPDATE topics SET name = ?, updated_at = datetime('now') WHERE id = ?").run(
+    newName,
+    topicId,
+  );
+  log.info({ topicId, newName }, "Topic renamed");
+  return getTopic(db, topicId);
+}
+
+/** Get documents for a topic with pagination. */
+export function getDocumentsByTopic(
+  db: Database.Database,
+  topicId: string,
+  options?: GetDocumentsByTopicOptions,
+): Document[] {
+  getTopic(db, topicId);
+  const limit = options?.limit ?? 50;
+  const offset = options?.offset ?? 0;
+  const rows = db
+    .prepare(
+      `SELECT id, source_type, library, version, topic_id, title, content, url, content_hash, submitted_by, created_at, updated_at
+    FROM documents WHERE topic_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?`,
+    )
+    .all(topicId, limit, offset) as Array<{
+    id: string;
+    source_type: string;
+    library: string | null;
+    version: string | null;
+    topic_id: string | null;
+    title: string;
+    content: string;
+    url: string | null;
+    content_hash: string | null;
+    submitted_by: string;
+    created_at: string;
+    updated_at: string;
+  }>;
+  return rows.map((row) => ({
+    id: row.id,
+    sourceType: row.source_type,
+    library: row.library,
+    version: row.version,
+    topicId: row.topic_id,
+    title: row.title,
+    content: row.content,
+    url: row.url,
+    contentHash: row.content_hash,
+    submittedBy: row.submitted_by,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }));
+}
+
+/** Get topics with document counts. */
+export function getTopicStats(db: Database.Database): TopicStats[] {
+  const rows = db
+    .prepare(
+      `SELECT t.id, t.name, t.description, t.parent_id, COUNT(d.id) AS document_count
+    FROM topics t LEFT JOIN documents d ON d.topic_id = t.id GROUP BY t.id ORDER BY t.name`,
+    )
+    .all() as Array<{
+    id: string;
+    name: string;
+    description: string | null;
+    parent_id: string | null;
+    document_count: number;
+  }>;
+  return rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    parentId: row.parent_id,
+    documentCount: row.document_count,
+  }));
 }

--- a/tests/unit/topics.test.ts
+++ b/tests/unit/topics.test.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { createTestDb } from "../fixtures/test-db.js";
-import { createTopic, listTopics, getTopic } from "../../src/core/topics.js";
-import { TopicNotFoundError } from "../../src/errors.js";
+import {
+  createTopic,
+  listTopics,
+  getTopic,
+  deleteTopic,
+  renameTopic,
+  getDocumentsByTopic,
+  getTopicStats,
+} from "../../src/core/topics.js";
+import { TopicNotFoundError, ValidationError } from "../../src/errors.js";
 import type Database from "better-sqlite3";
 
 describe("topics", () => {
@@ -96,6 +104,137 @@ describe("topics", () => {
 
     it("should throw TopicNotFoundError for nonexistent topic", () => {
       expect(() => getTopic(db, "nonexistent")).toThrow(TopicNotFoundError);
+    });
+  });
+  describe("deleteTopic", () => {
+    it("should delete a topic", () => {
+      createTopic(db, { name: "Obsolete" });
+      deleteTopic(db, "obsolete");
+      expect(() => getTopic(db, "obsolete")).toThrow(TopicNotFoundError);
+    });
+
+    it("should throw TopicNotFoundError for nonexistent topic", () => {
+      expect(() => deleteTopic(db, "nonexistent")).toThrow(TopicNotFoundError);
+    });
+
+    it("should nullify topic_id on documents when topic is deleted", () => {
+      createTopic(db, { name: "Temp" });
+      db.prepare(
+        "INSERT INTO documents (id, source_type, title, content, topic_id, submitted_by) VALUES (?, ?, ?, ?, ?, ?)",
+      ).run("doc-1", "topic", "Doc 1", "content", "temp", "manual");
+
+      deleteTopic(db, "temp");
+      const doc = db.prepare("SELECT topic_id FROM documents WHERE id = ?").get("doc-1") as {
+        topic_id: string | null;
+      };
+      expect(doc.topic_id).toBeNull();
+    });
+
+    it("should delete associated documents when deleteDocuments is true", () => {
+      createTopic(db, { name: "Cleanup" });
+      db.prepare(
+        "INSERT INTO documents (id, source_type, title, content, topic_id, submitted_by) VALUES (?, ?, ?, ?, ?, ?)",
+      ).run("doc-2", "topic", "Doc 2", "content", "cleanup", "manual");
+
+      deleteTopic(db, "cleanup", { deleteDocuments: true });
+      const doc = db.prepare("SELECT id FROM documents WHERE id = ?").get("doc-2");
+      expect(doc).toBeUndefined();
+    });
+
+    it("should set child topic parent_id to null on deletion", () => {
+      const parent = createTopic(db, { name: "Parent" });
+      createTopic(db, { name: "Child", parentId: parent.id });
+      deleteTopic(db, parent.id);
+      const child = getTopic(db, "child");
+      expect(child.parentId).toBeNull();
+    });
+  });
+
+  describe("renameTopic", () => {
+    it("should rename a topic", () => {
+      createTopic(db, { name: "OldName" });
+      const renamed = renameTopic(db, "oldname", "NewName");
+      expect(renamed.name).toBe("NewName");
+      expect(renamed.id).toBe("oldname");
+    });
+
+    it("should throw TopicNotFoundError for nonexistent topic", () => {
+      expect(() => renameTopic(db, "nonexistent", "New")).toThrow(TopicNotFoundError);
+    });
+
+    it("should reject empty name", () => {
+      createTopic(db, { name: "Valid" });
+      expect(() => renameTopic(db, "valid", "")).toThrow(ValidationError);
+      expect(() => renameTopic(db, "valid", "   ")).toThrow(ValidationError);
+    });
+  });
+
+  describe("getDocumentsByTopic", () => {
+    it("should return documents for a topic", () => {
+      createTopic(db, { name: "Docs" });
+      db.prepare(
+        "INSERT INTO documents (id, source_type, title, content, topic_id, submitted_by) VALUES (?, ?, ?, ?, ?, ?)",
+      ).run("d1", "topic", "Doc A", "content A", "docs", "manual");
+      db.prepare(
+        "INSERT INTO documents (id, source_type, title, content, topic_id, submitted_by) VALUES (?, ?, ?, ?, ?, ?)",
+      ).run("d2", "topic", "Doc B", "content B", "docs", "manual");
+
+      const docs = getDocumentsByTopic(db, "docs");
+      expect(docs.length).toBe(2);
+      expect(docs[0]!.title).toBeDefined();
+    });
+
+    it("should support pagination", () => {
+      createTopic(db, { name: "Paged" });
+      for (let i = 0; i < 5; i++) {
+        db.prepare(
+          "INSERT INTO documents (id, source_type, title, content, topic_id, submitted_by) VALUES (?, ?, ?, ?, ?, ?)",
+        ).run(`p${i}`, "topic", `Doc ${i}`, "content", "paged", "manual");
+      }
+
+      const page1 = getDocumentsByTopic(db, "paged", { limit: 2, offset: 0 });
+      expect(page1.length).toBe(2);
+
+      const page2 = getDocumentsByTopic(db, "paged", { limit: 2, offset: 2 });
+      expect(page2.length).toBe(2);
+
+      const page3 = getDocumentsByTopic(db, "paged", { limit: 2, offset: 4 });
+      expect(page3.length).toBe(1);
+    });
+
+    it("should return empty array for topic with no documents", () => {
+      createTopic(db, { name: "Empty" });
+      const docs = getDocumentsByTopic(db, "empty");
+      expect(docs.length).toBe(0);
+    });
+
+    it("should throw TopicNotFoundError for nonexistent topic", () => {
+      expect(() => getDocumentsByTopic(db, "nonexistent")).toThrow(TopicNotFoundError);
+    });
+  });
+
+  describe("getTopicStats", () => {
+    it("should return topics with document counts", () => {
+      createTopic(db, { name: "Alpha" });
+      createTopic(db, { name: "Beta" });
+      db.prepare(
+        "INSERT INTO documents (id, source_type, title, content, topic_id, submitted_by) VALUES (?, ?, ?, ?, ?, ?)",
+      ).run("s1", "topic", "Doc 1", "content", "alpha", "manual");
+      db.prepare(
+        "INSERT INTO documents (id, source_type, title, content, topic_id, submitted_by) VALUES (?, ?, ?, ?, ?, ?)",
+      ).run("s2", "topic", "Doc 2", "content", "alpha", "manual");
+
+      const stats = getTopicStats(db);
+      expect(stats.length).toBe(2);
+      const alpha = stats.find((s) => s.id === "alpha");
+      const beta = stats.find((s) => s.id === "beta");
+      expect(alpha!.documentCount).toBe(2);
+      expect(beta!.documentCount).toBe(0);
+    });
+
+    it("should return empty array when no topics exist", () => {
+      const stats = getTopicStats(db);
+      expect(stats.length).toBe(0);
     });
   });
 });


### PR DESCRIPTION
Closes #90

Adds four new functions to `src/core/topics.ts`:
- `deleteTopic(db, topicId, options?)` - Delete a topic, optionally removing associated documents
- `renameTopic(db, topicId, newName)` - Rename a topic
- `getDocumentsByTopic(db, topicId, options?)` - Browse documents by topic with pagination
- `getTopicStats(db)` - Get all topics with document counts

All functions are exported from `src/core/index.ts` and include 14 new tests.