### PR TITLE
feat: add search result scoring explanation

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -2,7 +2,7 @@ export { indexDocument, chunkContent } from "./indexing.js";
 export type { IndexDocumentInput, IndexedDocument } from "./indexing.js";
 
 export { searchDocuments } from "./search.js";
-export type { SearchOptions, SearchResult } from "./search.js";
+export type { SearchOptions, SearchResult, SearchMethod, ScoreExplanation } from "./search.js";
 
 export { rateDocument, getDocumentRatings, listRatings } from "./ratings.js";
 export type { RateDocumentInput, Rating, RatingSummary } from "./ratings.js";

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -39,6 +39,15 @@ export interface SearchResponse {
   totalCount: number;
 }
 
+export type SearchMethod = "vector" | "fts5" | "keyword";
+
+export interface ScoreExplanation {
+  method: SearchMethod;
+  rawScore: number;
+  boostFactors: string[];
+  details: string;
+}
+
 export interface SearchResult {
   documentId: string;
   chunkId: string;
@@ -51,6 +60,7 @@ export interface SearchResult {
   url: string | null;
   score: number;
   avgRating: number | null;
+  scoreExplanation: ScoreExplanation;
 }
 
 /** Perform semantic search across indexed documents. */
@@ -148,19 +158,28 @@ export async function searchDocuments(
 
     return {
       totalCount,
-      results: rows.map((row) => ({
-        documentId: row.document_id,
-        chunkId: row.chunk_id,
-        title: row.title,
-        content: row.chunk_content,
-        sourceType: row.source_type,
-        library: row.library,
-        version: row.version,
-        topicId: row.topic_id,
-        url: row.url,
-        score: 1 - row.distance, // Convert distance to similarity
-        avgRating: row.avg_rating,
-      })),
+      results: rows.map((row) => {
+        const similarity = 1 - row.distance;
+        return {
+          documentId: row.document_id,
+          chunkId: row.chunk_id,
+          title: row.title,
+          content: row.chunk_content,
+          sourceType: row.source_type,
+          library: row.library,
+          version: row.version,
+          topicId: row.topic_id,
+          url: row.url,
+          score: similarity,
+          avgRating: row.avg_rating,
+          scoreExplanation: {
+            method: "vector" as SearchMethod,
+            rawScore: row.distance,
+            boostFactors: [],
+            details: `Vector similarity: distance=${row.distance.toFixed(4)}, similarity=${similarity.toFixed(4)}`,
+          },
+        };
+      }),
     };
   } catch (err) {
     if (!isVectorTableError(err)) {
@@ -260,19 +279,28 @@ function keywordSearch(
 
   return {
     totalCount,
-    results: rows.map((row, index) => ({
-      documentId: row.document_id,
-      chunkId: row.chunk_id,
-      title: row.title,
-      content: row.chunk_content,
-      sourceType: row.source_type,
-      library: row.library,
-      version: row.version,
-      topicId: row.topic_id,
-      url: row.url,
-      score: Math.max(0, 1 - index * 0.1), // Simple rank-based score
-      avgRating: row.avg_rating,
-    })),
+    results: rows.map((row, index) => {
+      const rankScore = Math.max(0, 1 - index * 0.1);
+      return {
+        documentId: row.document_id,
+        chunkId: row.chunk_id,
+        title: row.title,
+        content: row.chunk_content,
+        sourceType: row.source_type,
+        library: row.library,
+        version: row.version,
+        topicId: row.topic_id,
+        url: row.url,
+        score: rankScore,
+        avgRating: row.avg_rating,
+        scoreExplanation: {
+          method: "keyword" as SearchMethod,
+          rawScore: rankScore,
+          boostFactors: [],
+          details: `Keyword LIKE match: rank=${index + 1}, score=${rankScore.toFixed(4)}`,
+        },
+      };
+    }),
   };
 }
 
@@ -358,18 +386,27 @@ function fts5Search(
 
   return {
     totalCount,
-    results: rows.map((row) => ({
-      documentId: row.document_id,
-      chunkId: row.chunk_id,
-      title: row.title,
-      content: row.chunk_content,
-      sourceType: row.source_type,
-      library: row.library,
-      version: row.version,
-      topicId: row.topic_id,
-      url: row.url,
-      score: -row.fts_rank, // BM25 rank is negative, lower = better
-      avgRating: row.avg_rating,
-    })),
+    results: rows.map((row) => {
+      const bm25Score = -row.fts_rank;
+      return {
+        documentId: row.document_id,
+        chunkId: row.chunk_id,
+        title: row.title,
+        content: row.chunk_content,
+        sourceType: row.source_type,
+        library: row.library,
+        version: row.version,
+        topicId: row.topic_id,
+        url: row.url,
+        score: bm25Score,
+        avgRating: row.avg_rating,
+        scoreExplanation: {
+          method: "fts5" as SearchMethod,
+          rawScore: row.fts_rank,
+          boostFactors: [],
+          details: `FTS5 BM25 ranking: raw_rank=${row.fts_rank.toFixed(4)}, score=${bm25Score.toFixed(4)}`,
+        },
+      };
+    }),
   };
 }

--- a/tests/unit/search.test.ts
+++ b/tests/unit/search.test.ts
@@ -4,6 +4,7 @@ import { createTestDb } from "../fixtures/test-db.js";
 import { MockEmbeddingProvider } from "../fixtures/mock-provider.js";
 import { insertDoc, insertChunk } from "../fixtures/helpers.js";
 import { searchDocuments, escapeLikePattern } from "../../src/core/search.js";
+import type { ScoreExplanation } from "../../src/core/search.js";
 
 describe("searchDocuments (FTS5 fallback)", () => {
   let db: Database.Database;
@@ -201,5 +202,61 @@ describe("LIKE wildcard escaping in keyword search (issue #79)", () => {
     const { results } = await searchDocuments(db, provider, { query: "user_name" });
     expect(results.length).toBe(1);
     expect(results[0]!.content).toContain("user_name");
+  });
+});
+
+describe("search result scoring explanation (issue #89)", () => {
+  let db: Database.Database;
+  let provider: MockEmbeddingProvider;
+
+  beforeEach(() => {
+    db = createTestDb();
+    provider = new MockEmbeddingProvider();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("should include scoreExplanation with FTS5 method", async () => {
+    insertDoc(db, "doc1", "TypeScript Guide");
+    insertChunk(db, "c1", "doc1", "TypeScript basics and fundamentals");
+
+    const { results } = await searchDocuments(db, provider, { query: "TypeScript" });
+
+    expect(results.length).toBeGreaterThan(0);
+    const explanation: ScoreExplanation = results[0]!.scoreExplanation;
+    expect(explanation).toBeDefined();
+    expect(explanation.method).toBe("fts5");
+    expect(typeof explanation.rawScore).toBe("number");
+    expect(Array.isArray(explanation.boostFactors)).toBe(true);
+    expect(explanation.details).toContain("FTS5 BM25");
+  });
+
+  it("should include scoreExplanation with keyword method for LIKE fallback", async () => {
+    insertDoc(db, "doc1", "Keyword Doc");
+    insertChunk(db, "c1", "doc1", "testing keyword search fallback");
+
+    // Drop FTS table after inserting to force LIKE fallback
+    db.exec("DROP TABLE IF EXISTS chunks_fts");
+
+    const { results } = await searchDocuments(db, provider, { query: "keyword" });
+
+    expect(results.length).toBeGreaterThan(0);
+    const explanation = results[0]!.scoreExplanation;
+    expect(explanation.method).toBe("keyword");
+    expect(explanation.details).toContain("Keyword LIKE match");
+  });
+
+  it("should have consistent score and rawScore values for FTS5", async () => {
+    insertDoc(db, "doc1", "Score Test");
+    insertChunk(db, "c1", "doc1", "consistency check for scoring");
+
+    const { results } = await searchDocuments(db, provider, { query: "consistency" });
+
+    expect(results.length).toBe(1);
+    const result = results[0]!;
+    // FTS5: score = -rawScore (BM25 rank is negative)
+    expect(result.score).toBe(-result.scoreExplanation.rawScore);
   });
 });


### PR DESCRIPTION
Closes #89

Adds a `scoreExplanation` field to `SearchResult` that includes:
- **method**: Which search method was used (vector, fts5, keyword)
- **rawScore**: The raw similarity/relevance score before transformation
- **boostFactors**: Array of any boost factors applied
- **details**: Human-readable explanation of how the score was computed

Also exports `SearchMethod` and `ScoreExplanation` types.