### PR TITLE
feat: add similarity-based deduplication on ingest (closes #116)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,6 +15,7 @@ import { join, extname, basename } from "node:path";
 import { fetchAndConvert } from "../core/url-fetcher.js";
 import { exportKnowledgeBase, importFromBackup } from "../core/export.js";
 import { batchImport } from "../core/batch.js";
+import { findDuplicates } from "../core/dedup.js";
 import { startRepl } from "./repl.js";
 
 // Graceful shutdown
@@ -64,10 +65,11 @@ program
   .option("--library <name>", "Mark as library documentation")
   .option("--version <version>", "Library version")
   .option("--title <title>", "Override document title")
+  .option("--dedup <mode>", "Dedup mode: skip, warn, or force")
   .action(
     async (
       fileOrUrl: string,
-      opts: { topic?: string; library?: string; version?: string; title?: string },
+      opts: { topic?: string; library?: string; version?: string; title?: string; dedup?: string },
     ) => {
       const { db, provider } = initializeAppWithEmbedding();
       try {
@@ -94,6 +96,7 @@ program
           version: opts.version,
           topicId: opts.topic,
           url,
+          dedup: opts.dedup as "skip" | "warn" | "force" | undefined,
         });
 
         console.log(`✓ Indexed "${title}" (${result.chunkCount} chunks)`);
@@ -112,10 +115,17 @@ program
   .option("--library <name>", "Mark all as library documentation")
   .option("--version <version>", "Library version")
   .option("--extensions <exts>", "Comma-separated file extensions to include", ".md,.mdx,.txt")
+  .option("--dedup <mode>", "Dedup mode: skip, warn, or force")
   .action(
     async (
       directory: string,
-      opts: { topic?: string; library?: string; version?: string; extensions: string },
+      opts: {
+        topic?: string;
+        library?: string;
+        version?: string;
+        extensions: string;
+        dedup?: string;
+      },
     ) => {
       const { db, provider } = initializeAppWithEmbedding();
       try {
@@ -144,6 +154,7 @@ program
               library: opts.library,
               version: opts.version,
               topicId: opts.topic,
+              dedup: opts.dedup as "skip" | "warn" | "force" | undefined,
             });
 
             indexed++;
@@ -552,6 +563,59 @@ program
     const { db, provider } = initializeAppWithEmbedding();
     try {
       await startRepl({ db, provider, limit: parseInt(opts.limit, 10) });
+    } finally {
+      closeDatabase();
+    }
+  });
+
+// dedupe — scan and report duplicates
+program
+  .command("dedupe")
+  .description("Scan the knowledge base for duplicate documents")
+  .option("--threshold <n>", "Similarity threshold (0-1)", "0.95")
+  .option("--strategy <type>", "Detection strategy: exact, semantic, or both", "both")
+  .action(async (opts: { threshold: string; strategy: string }) => {
+    const { db, provider } = initializeAppWithEmbedding();
+    try {
+      console.log("Scanning for duplicates...\n");
+      const groups = await findDuplicates(db, provider, {
+        threshold: parseFloat(opts.threshold),
+        strategy: opts.strategy as "exact" | "semantic" | "both",
+      });
+
+      if (groups.length === 0) {
+        console.log("No duplicates found.");
+        return;
+      }
+
+      console.log(`Found ${groups.length} duplicate group(s):\n`);
+
+      const groupCol = 7;
+      const typeCol = 10;
+      const idCol = 38;
+      const titleCol = 40;
+
+      const header =
+        "Group".padEnd(groupCol) + "Type".padEnd(typeCol) + "Document ID".padEnd(idCol) + "Title";
+      console.log(header);
+      console.log("\u2500".repeat(header.length + titleCol));
+
+      for (let i = 0; i < groups.length; i++) {
+        const group = groups[i]!;
+        for (let j = 0; j < group.documentIds.length; j++) {
+          const gLabel = j === 0 ? String(i + 1) : "";
+          const tLabel = j === 0 ? group.matchType : "";
+          const docId = group.documentIds[j] ?? "";
+          const title = group.titles[j] ?? "";
+          console.log(
+            gLabel.padEnd(groupCol) +
+              tLabel.padEnd(typeCol) +
+              docId.padEnd(idCol) +
+              title.slice(0, titleCol),
+          );
+        }
+        console.log();
+      }
     } finally {
       closeDatabase();
     }

--- a/src/core/dedup.ts
+++ b/src/core/dedup.ts
@@ -1,0 +1,222 @@
+import type Database from "better-sqlite3";
+import { createHash } from "node:crypto";
+import type { EmbeddingProvider } from "../providers/embedding.js";
+import { getLogger } from "../logger.js";
+
+export interface DedupResult {
+  isDuplicate: boolean;
+  matchType?: "exact" | "similar";
+  existingDocId?: string;
+  similarity?: number;
+}
+
+export interface DedupOptions {
+  /** Cosine similarity threshold for near-duplicate detection (default: 0.95). */
+  threshold?: number;
+  /** Strategy: exact hash only, semantic embedding, or both (default: 'both'). */
+  strategy?: "exact" | "semantic" | "both";
+}
+
+export interface DuplicateGroup {
+  /** Content hash shared by the group (null for semantic-only groups). */
+  contentHash: string | null;
+  /** Type of duplication detected. */
+  matchType: "exact" | "similar";
+  /** Document IDs in the group. */
+  documentIds: string[];
+  /** Titles of the documents in the group. */
+  titles: string[];
+}
+
+const DEFAULT_THRESHOLD = 0.95;
+const DEFAULT_STRATEGY = "both";
+/** Maximum characters to sample for semantic comparison. */
+const SAMPLE_SIZE = 1000;
+
+function computeHash(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function cosineSimilarity(a: number[], b: number[]): number {
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    const ai = a[i] ?? 0;
+    const bi = b[i] ?? 0;
+    dot += ai * bi;
+    normA += ai * ai;
+    normB += bi * bi;
+  }
+  const denom = Math.sqrt(normA) * Math.sqrt(normB);
+  return denom === 0 ? 0 : dot / denom;
+}
+
+/**
+ * Check whether the given content is a duplicate of an existing document.
+ *
+ * Fast path: SHA-256 hash match against the content_hash column.
+ * Slow path: embed a sample of the content and vector-search for similar docs.
+ */
+export async function checkDuplicate(
+  db: Database.Database,
+  provider: EmbeddingProvider,
+  content: string,
+  options?: DedupOptions,
+): Promise<DedupResult> {
+  const threshold = options?.threshold ?? DEFAULT_THRESHOLD;
+  const strategy = options?.strategy ?? DEFAULT_STRATEGY;
+  const log = getLogger();
+
+  // --- Fast path: exact hash match ---
+  if (strategy === "exact" || strategy === "both") {
+    const hash = computeHash(content);
+    const row = db.prepare("SELECT id FROM documents WHERE content_hash = ?").get(hash) as
+      | { id: string }
+      | undefined;
+
+    if (row) {
+      log.debug({ existingDocId: row.id }, "Exact duplicate detected via content hash");
+      return { isDuplicate: true, matchType: "exact", existingDocId: row.id, similarity: 1.0 };
+    }
+  }
+
+  // --- Slow path: semantic similarity ---
+  if (strategy === "semantic" || strategy === "both") {
+    try {
+      const sample = content.slice(0, SAMPLE_SIZE);
+      const queryEmbedding = await provider.embed(sample);
+      const vecBuffer = Buffer.from(new Float32Array(queryEmbedding).buffer);
+
+      const rows = db
+        .prepare(
+          `SELECT ce.chunk_id, ce.distance, c.document_id
+           FROM chunk_embeddings ce
+           JOIN chunks c ON c.id = ce.chunk_id
+           WHERE ce.embedding MATCH ?
+           ORDER BY ce.distance
+           LIMIT 1`,
+        )
+        .all(vecBuffer) as Array<{
+        chunk_id: string;
+        distance: number;
+        document_id: string;
+      }>;
+
+      if (rows.length > 0) {
+        const best = rows[0]!;
+        const similarity = 1 - best.distance;
+        if (similarity >= threshold) {
+          log.debug(
+            { existingDocId: best.document_id, similarity },
+            "Near-duplicate detected via semantic similarity",
+          );
+          return {
+            isDuplicate: true,
+            matchType: "similar",
+            existingDocId: best.document_id,
+            similarity,
+          };
+        }
+      }
+    } catch {
+      log.debug("Semantic dedup skipped (vector table may not be available)");
+    }
+  }
+
+  return { isDuplicate: false };
+}
+
+/**
+ * Scan all documents and return groups of duplicates.
+ *
+ * Phase 1: group by content_hash (exact duplicates).
+ * Phase 2: sample-check remaining docs for near-duplicates via embeddings.
+ */
+export async function findDuplicates(
+  db: Database.Database,
+  provider: EmbeddingProvider,
+  options?: DedupOptions,
+): Promise<DuplicateGroup[]> {
+  const threshold = options?.threshold ?? DEFAULT_THRESHOLD;
+  const strategy = options?.strategy ?? DEFAULT_STRATEGY;
+  const log = getLogger();
+  const groups: DuplicateGroup[] = [];
+
+  // --- Phase 1: exact hash groups ---
+  if (strategy === "exact" || strategy === "both") {
+    const hashGroups = db
+      .prepare(
+        `SELECT content_hash, GROUP_CONCAT(id) AS ids, GROUP_CONCAT(title, '|||') AS titles
+         FROM documents
+         WHERE content_hash IS NOT NULL
+         GROUP BY content_hash
+         HAVING COUNT(*) > 1`,
+      )
+      .all() as Array<{ content_hash: string; ids: string; titles: string }>;
+
+    for (const row of hashGroups) {
+      groups.push({
+        contentHash: row.content_hash,
+        matchType: "exact",
+        documentIds: row.ids.split(","),
+        titles: row.titles.split("|||"),
+      });
+    }
+
+    log.info({ exactGroups: hashGroups.length }, "Exact duplicate scan complete");
+  }
+
+  // --- Phase 2: semantic near-duplicate detection ---
+  if (strategy === "semantic" || strategy === "both") {
+    const exactDocIds = new Set(groups.flatMap((g) => g.documentIds));
+
+    const docs = db.prepare("SELECT id, title, content FROM documents").all() as Array<{
+      id: string;
+      title: string;
+      content: string;
+    }>;
+
+    const remaining = docs.filter((d) => !exactDocIds.has(d.id));
+
+    if (remaining.length > 1) {
+      try {
+        const samples = remaining.map((d) => d.content.slice(0, SAMPLE_SIZE));
+        const embeddings = await provider.embedBatch(samples);
+        const matched = new Set<string>();
+
+        for (let i = 0; i < remaining.length; i++) {
+          if (matched.has(remaining[i]!.id)) continue;
+          const group: string[] = [remaining[i]!.id];
+          const groupTitles: string[] = [remaining[i]!.title];
+
+          for (let j = i + 1; j < remaining.length; j++) {
+            if (matched.has(remaining[j]!.id)) continue;
+            const sim = cosineSimilarity(embeddings[i]!, embeddings[j]!);
+            if (sim >= threshold) {
+              group.push(remaining[j]!.id);
+              groupTitles.push(remaining[j]!.title);
+              matched.add(remaining[j]!.id);
+            }
+          }
+
+          if (group.length > 1) {
+            matched.add(remaining[i]!.id);
+            groups.push({
+              contentHash: null,
+              matchType: "similar",
+              documentIds: group,
+              titles: groupTitles,
+            });
+          }
+        }
+
+        log.info({ semanticGroups: groups.length }, "Semantic near-duplicate scan complete");
+      } catch {
+        log.debug("Semantic duplicate scan skipped (vector operations unavailable)");
+      }
+    }
+  }
+
+  return groups;
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,6 +1,9 @@
 export { indexDocument, chunkContent } from "./indexing.js";
 export type { IndexDocumentInput, IndexedDocument } from "./indexing.js";
 
+export { checkDuplicate, findDuplicates } from "./dedup.js";
+export type { DedupResult, DedupOptions, DuplicateGroup } from "./dedup.js";
+
 export { searchDocuments } from "./search.js";
 export type { SearchOptions, SearchResult, SearchMethod, ScoreExplanation } from "./search.js";
 

--- a/src/core/indexing.ts
+++ b/src/core/indexing.ts
@@ -4,6 +4,8 @@ import type { Readable } from "node:stream";
 import type { EmbeddingProvider } from "../providers/embedding.js";
 import { ValidationError } from "../errors.js";
 import { getLogger } from "../logger.js";
+import { checkDuplicate } from "./dedup.js";
+import type { DedupOptions } from "./dedup.js";
 
 export interface IndexDocumentInput {
   title: string;
@@ -14,6 +16,10 @@ export interface IndexDocumentInput {
   topicId?: string | undefined;
   url?: string | undefined;
   submittedBy?: "manual" | "model" | "crawler" | undefined;
+  /** Dedup behaviour: 'skip' returns existing doc, 'warn' logs but indexes, 'force' bypasses check. */
+  dedup?: "skip" | "warn" | "force" | undefined;
+  /** Options for duplicate detection (threshold, strategy). */
+  dedupOptions?: DedupOptions | undefined;
 }
 
 export interface IndexedDocument {
@@ -177,6 +183,30 @@ export async function indexDocument(
   }
   if (!input.content.trim()) {
     throw new ValidationError("Document content is required");
+  }
+
+  // Dedup check (unless mode is 'force' or unset — backwards compatible)
+  if (input.dedup && input.dedup !== "force") {
+    const dedupResult = await checkDuplicate(db, provider, input.content, input.dedupOptions);
+    if (dedupResult.isDuplicate) {
+      if (input.dedup === "skip") {
+        log.info(
+          { existingDocId: dedupResult.existingDocId, matchType: dedupResult.matchType },
+          "Duplicate detected, skipping",
+        );
+        return { id: dedupResult.existingDocId!, chunkCount: 0 };
+      }
+      if (input.dedup === "warn") {
+        log.warn(
+          {
+            existingDocId: dedupResult.existingDocId,
+            matchType: dedupResult.matchType,
+            similarity: dedupResult.similarity,
+          },
+          "Duplicate detected, indexing anyway",
+        );
+      }
+    }
   }
 
   // Compute content hash for versioning

--- a/tests/unit/dedup.test.ts
+++ b/tests/unit/dedup.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createHash, randomUUID } from "node:crypto";
+import { createTestDb, createTestDbWithVec } from "../fixtures/test-db.js";
+import { MockEmbeddingProvider } from "../fixtures/mock-provider.js";
+import { checkDuplicate, findDuplicates } from "../../src/core/dedup.js";
+import { indexDocument } from "../../src/core/indexing.js";
+import { initLogger } from "../../src/logger.js";
+import type Database from "better-sqlite3";
+
+function insertDocument(
+  db: Database.Database,
+  overrides: Partial<{
+    id: string;
+    title: string;
+    content: string;
+    contentHash: string;
+    sourceType: string;
+  }> = {},
+): string {
+  const id = overrides.id ?? randomUUID();
+  const content = overrides.content ?? "some content";
+  const hash = overrides.contentHash ?? createHash("sha256").update(content).digest("hex");
+  db.prepare(
+    `INSERT INTO documents (id, source_type, title, content, content_hash)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run(id, overrides.sourceType ?? "manual", overrides.title ?? "Test Doc", content, hash);
+  return id;
+}
+
+describe("dedup", () => {
+  beforeEach(() => {
+    initLogger("silent");
+  });
+
+  describe("checkDuplicate", () => {
+    it("should detect an exact hash match", async () => {
+      const db = createTestDb();
+      const provider = new MockEmbeddingProvider();
+      const content = "Hello, duplicate world!";
+      insertDocument(db, { content });
+
+      const result = await checkDuplicate(db, provider, content, { strategy: "exact" });
+
+      expect(result.isDuplicate).toBe(true);
+      expect(result.matchType).toBe("exact");
+      expect(result.similarity).toBe(1.0);
+      expect(result.existingDocId).toBeDefined();
+    });
+
+    it("should return not duplicate when no match exists", async () => {
+      const db = createTestDb();
+      const provider = new MockEmbeddingProvider();
+      insertDocument(db, { content: "existing content" });
+
+      const result = await checkDuplicate(db, provider, "completely different", {
+        strategy: "exact",
+      });
+
+      expect(result.isDuplicate).toBe(false);
+    });
+
+    it("should skip semantic check when strategy is exact", async () => {
+      const db = createTestDb();
+      const provider = new MockEmbeddingProvider();
+      const embedSpy = vi.spyOn(provider, "embed");
+
+      await checkDuplicate(db, provider, "anything", { strategy: "exact" });
+
+      expect(embedSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("indexDocument with dedup", () => {
+    it("should return existing doc id when dedup is skip", async () => {
+      const db = createTestDbWithVec();
+      const provider = new MockEmbeddingProvider();
+      const content = "# Dedup Skip Test\n\nThis content exists already.";
+      const existingId = insertDocument(db, { content, title: "Existing" });
+
+      const result = await indexDocument(db, provider, {
+        title: "New Title",
+        content,
+        sourceType: "manual",
+        dedup: "skip",
+        dedupOptions: { strategy: "exact" },
+      });
+
+      expect(result.id).toBe(existingId);
+      expect(result.chunkCount).toBe(0);
+    });
+
+    it("should log warning but still index when dedup is warn", async () => {
+      const db = createTestDbWithVec();
+      const provider = new MockEmbeddingProvider();
+      const content = "# Dedup Warn Test\n\nWarn about this content.";
+      insertDocument(db, { content, title: "Original" });
+
+      const result = await indexDocument(db, provider, {
+        title: "Copy",
+        content,
+        sourceType: "manual",
+        dedup: "warn",
+        dedupOptions: { strategy: "exact" },
+      });
+
+      expect(result.chunkCount).toBeGreaterThan(0);
+
+      const count = db.prepare("SELECT COUNT(*) AS cnt FROM documents").get() as { cnt: number };
+      expect(count.cnt).toBe(2);
+    });
+
+    it("should bypass dedup check entirely when mode is force", async () => {
+      const db = createTestDbWithVec();
+      const provider = new MockEmbeddingProvider();
+      const content = "# Force Test\n\nForce this content through.";
+      insertDocument(db, { content, title: "Original Force" });
+
+      const result = await indexDocument(db, provider, {
+        title: "Force Copy",
+        content,
+        sourceType: "manual",
+        dedup: "force",
+        dedupOptions: { strategy: "exact" },
+      });
+
+      expect(result.chunkCount).toBeGreaterThan(0);
+
+      const count = db.prepare("SELECT COUNT(*) AS cnt FROM documents").get() as { cnt: number };
+      expect(count.cnt).toBe(2);
+    });
+  });
+
+  describe("findDuplicates", () => {
+    it("should find exact duplicate groups by content hash", async () => {
+      const db = createTestDb();
+      const provider = new MockEmbeddingProvider();
+      const content = "Identical content for grouping test";
+
+      insertDocument(db, { content, title: "Doc A" });
+      insertDocument(db, { content, title: "Doc B" });
+      insertDocument(db, { content: "unique content", title: "Doc C" });
+
+      const groups = await findDuplicates(db, provider, { strategy: "exact" });
+
+      expect(groups.length).toBe(1);
+      expect(groups[0]!.matchType).toBe("exact");
+      expect(groups[0]!.documentIds.length).toBe(2);
+      expect(groups[0]!.titles).toContain("Doc A");
+      expect(groups[0]!.titles).toContain("Doc B");
+    });
+
+    it("should return empty array when no duplicates exist", async () => {
+      const db = createTestDb();
+      const provider = new MockEmbeddingProvider();
+
+      insertDocument(db, { content: "unique A", title: "A" });
+      insertDocument(db, { content: "unique B", title: "B" });
+
+      const groups = await findDuplicates(db, provider, { strategy: "exact" });
+
+      expect(groups.length).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements similarity-based deduplication on ingest (#116).

### Changes

- **`src/core/dedup.ts`** — New module with:
  - `checkDuplicate()`: Fast path (SHA-256 hash match) + slow path (semantic vector similarity)
  - `findDuplicates()`: Scans all documents, groups exact and near-duplicates
  - Configurable threshold (default 0.95) and strategy (exact/semantic/both)

- **`src/core/indexing.ts`** — Added optional `dedup` field to `IndexDocumentInput`:
  - `skip`: silently return existing doc if duplicate found
  - `warn`: log warning but still index
  - `force`: bypass dedup check entirely
  - Default: no dedup check (backwards compatible)

- **`src/cli/index.ts`** — CLI integration:
  - `--dedup <skip|warn|force>` option on `add` and `import` commands
  - New `libscope dedupe` command for scanning and reporting duplicate groups

- **`src/core/index.ts`** — Barrel exports for dedup types and functions

- **`tests/unit/dedup.test.ts`** — 8 tests covering exact match, skip/warn/force modes, and findDuplicates

### Testing

All 210 tests pass. No lint errors.