### PR TITLE
feat: add multi-label tag system for document organization

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,6 +16,12 @@ import { fetchAndConvert } from "../core/url-fetcher.js";
 import { exportKnowledgeBase, importFromBackup } from "../core/export.js";
 import { batchImport } from "../core/batch.js";
 import { startRepl } from "./repl.js";
+import {
+  addTagsToDocument,
+  removeTagFromDocument,
+  listTags,
+  getDocumentTags,
+} from "../core/tags.js";
 
 // Graceful shutdown
 process.on("SIGINT", () => {
@@ -406,6 +412,10 @@ docsCmd
       console.log(`Submitted by: ${doc.submittedBy}`);
       console.log(`Created: ${doc.createdAt}`);
       console.log(`Updated: ${doc.updatedAt}`);
+      const tags = getDocumentTags(db, documentId);
+      if (tags.length > 0) {
+        console.log(`Tags: ${tags.map((t) => t.name).join(", ")}`);
+      }
       console.log(`\n---\n`);
       console.log(doc.content);
     } finally {
@@ -422,6 +432,67 @@ docsCmd
       const doc = getDocument(db, documentId);
       deleteDocument(db, documentId);
       console.log(`✓ Deleted "${doc.title}" (${documentId})`);
+    } finally {
+      closeDatabase();
+    }
+  });
+
+// tag
+const tagCmd = program.command("tag").description("Manage document tags");
+
+tagCmd
+  .command("add <docId> <tags...>")
+  .description("Add tags to a document (comma or space separated)")
+  .action((docId: string, tags: string[]) => {
+    const { db } = initializeApp();
+    try {
+      const tagNames = tags
+        .flatMap((t) => t.split(","))
+        .map((t) => t.trim())
+        .filter(Boolean);
+      const created = addTagsToDocument(db, docId, tagNames);
+      console.log(`✓ Added ${created.length} tag(s) to document ${docId}`);
+      for (const t of created) {
+        console.log(`  • ${t.name}`);
+      }
+    } finally {
+      closeDatabase();
+    }
+  });
+
+tagCmd
+  .command("remove <docId> <tag>")
+  .description("Remove a tag from a document")
+  .action((docId: string, tagName: string) => {
+    const { db } = initializeApp();
+    try {
+      const docTags = getDocumentTags(db, docId);
+      const tag = docTags.find((t) => t.name === tagName.trim().toLowerCase());
+      if (!tag) {
+        console.log(`Tag "${tagName}" not found on document ${docId}`);
+        return;
+      }
+      removeTagFromDocument(db, docId, tag.id);
+      console.log(`✓ Removed tag "${tag.name}" from document ${docId}`);
+    } finally {
+      closeDatabase();
+    }
+  });
+
+tagCmd
+  .command("list")
+  .description("List all tags with document counts")
+  .action(() => {
+    const { db } = initializeApp();
+    try {
+      const allTags = listTags(db);
+      if (allTags.length === 0) {
+        console.log("No tags found. Add tags with: libscope tag add <docId> <tags...>");
+      } else {
+        for (const t of allTags) {
+          console.log(`  ${t.name} (${t.documentCount} doc${t.documentCount !== 1 ? "s" : ""})`);
+        }
+      }
     } finally {
       closeDatabase();
     }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -34,6 +34,17 @@ export type {
   BatchFileResult,
 } from "./batch.js";
 
+export {
+  createTag,
+  deleteTag,
+  listTags,
+  addTagsToDocument,
+  removeTagFromDocument,
+  getDocumentTags,
+  getDocumentsByTag,
+} from "./tags.js";
+export type { Tag, TagWithCount, GetDocumentsByTagOptions } from "./tags.js";
+
 export { registerProvider, createEmbeddingProvider } from "../providers/index.js";
 export type { EmbeddingProvider } from "../providers/embedding.js";
 export type { ProviderFactory } from "../providers/index.js";

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -3,6 +3,24 @@ import type { EmbeddingProvider } from "../providers/embedding.js";
 import { withCorrelationId, createChildLogger } from "../logger.js";
 import { validateCountRow } from "../utils/db-validation.js";
 
+/** Build SQL clause and params for AND-logic tag filtering on a document alias. */
+function buildTagFilter(
+  tags: string[] | undefined,
+  docAlias: string,
+): { clause: string; params: unknown[] } {
+  if (!tags || tags.length === 0) return { clause: "", params: [] };
+  const normalized = tags.map((t) => t.trim().toLowerCase());
+  const placeholders = normalized.map(() => "?").join(", ");
+  const clause = ` AND ${docAlias}.id IN (
+    SELECT dt_f.document_id FROM document_tags dt_f
+    JOIN tags t_f ON t_f.id = dt_f.tag_id
+    WHERE t_f.name IN (${placeholders})
+    GROUP BY dt_f.document_id
+    HAVING COUNT(DISTINCT t_f.name) = ?
+  )`;
+  return { clause, params: [...normalized, normalized.length] };
+}
+
 /** Errors that indicate the vector table is missing or unusable – safe to fall back from. */
 const VECTOR_TABLE_MISSING_PATTERNS = [
   "no such table: chunk_embeddings",
@@ -33,6 +51,7 @@ export interface SearchOptions {
   dateFrom?: string | undefined;
   dateTo?: string | undefined;
   source?: string | undefined;
+  tags?: string[] | undefined;
   limit?: number | undefined;
   offset?: number | undefined;
 }
@@ -144,6 +163,10 @@ export async function searchDocuments(
       sql += " AND d.source_type = ?";
       params.push(options.source);
     }
+
+    const tagFilterVec = buildTagFilter(options.tags, "d");
+    sql += tagFilterVec.clause;
+    params.push(...tagFilterVec.params);
 
     // Build count query from base SQL (before adding ORDER BY/LIMIT/OFFSET)
     const baseSql = sql;
@@ -279,6 +302,10 @@ function keywordSearch(
     params.push(options.source);
   }
 
+  const tagFilterKw = buildTagFilter(options.tags, "d");
+  sql += tagFilterKw.clause;
+  params.push(...tagFilterKw.params);
+
   // Build count query from base SQL (before adding LIMIT/OFFSET)
   const baseSql = sql;
   const baseParams = [...params];
@@ -396,6 +423,10 @@ function fts5Search(
     sql += " AND d.source_type = ?";
     params.push(options.source);
   }
+
+  const tagFilterFts = buildTagFilter(options.tags, "d");
+  sql += tagFilterFts.clause;
+  params.push(...tagFilterFts.params);
 
   // Build count query from base SQL (before adding ORDER BY/LIMIT/OFFSET)
   const baseSql = sql;

--- a/src/core/tags.ts
+++ b/src/core/tags.ts
@@ -1,0 +1,210 @@
+import type Database from "better-sqlite3";
+import { randomUUID } from "node:crypto";
+import { ValidationError } from "../errors.js";
+import { createChildLogger } from "../logger.js";
+import type { Document } from "./documents.js";
+
+export interface Tag {
+  id: string;
+  name: string;
+  createdAt: string;
+}
+
+export interface TagWithCount extends Tag {
+  documentCount: number;
+}
+
+/** Create a tag or return the existing one if the name already exists. */
+export function createTag(db: Database.Database, name: string): Tag {
+  const log = createChildLogger({ operation: "createTag" });
+  const trimmed = name.trim().toLowerCase();
+  if (!trimmed) {
+    throw new ValidationError("Tag name is required");
+  }
+
+  const id = randomUUID();
+  const result = db
+    .prepare(
+      `INSERT INTO tags (id, name) VALUES (?, ?)
+       ON CONFLICT(name) DO NOTHING`,
+    )
+    .run(id, trimmed);
+
+  if (result.changes > 0) {
+    log.info({ tagId: id, name: trimmed }, "Tag created");
+    return { id, name: trimmed, createdAt: new Date().toISOString() };
+  }
+
+  const existing = db
+    .prepare("SELECT id, name, created_at FROM tags WHERE name = ?")
+    .get(trimmed) as {
+    id: string;
+    name: string;
+    created_at: string;
+  };
+
+  log.info({ name: trimmed }, "Tag already exists, returning existing");
+  return { id: existing.id, name: existing.name, createdAt: existing.created_at };
+}
+
+/** Delete a tag and all its document associations. */
+export function deleteTag(db: Database.Database, tagId: string): void {
+  const log = createChildLogger({ operation: "deleteTag" });
+  db.prepare("DELETE FROM tags WHERE id = ?").run(tagId);
+  log.info({ tagId }, "Tag deleted");
+}
+
+/** List all tags with their document counts. */
+export function listTags(db: Database.Database): TagWithCount[] {
+  const rows = db
+    .prepare(
+      `SELECT t.id, t.name, t.created_at, COUNT(dt.document_id) AS document_count
+       FROM tags t
+       LEFT JOIN document_tags dt ON dt.tag_id = t.id
+       GROUP BY t.id
+       ORDER BY t.name`,
+    )
+    .all() as Array<{
+    id: string;
+    name: string;
+    created_at: string;
+    document_count: number;
+  }>;
+
+  return rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    createdAt: row.created_at,
+    documentCount: row.document_count,
+  }));
+}
+
+/** Add multiple tags to a document, creating tags if they don't exist. */
+export function addTagsToDocument(
+  db: Database.Database,
+  documentId: string,
+  tagNames: string[],
+): Tag[] {
+  const log = createChildLogger({ operation: "addTagsToDocument" });
+
+  const run = db.transaction(() => {
+    const tags: Tag[] = [];
+    for (const name of tagNames) {
+      const tag = createTag(db, name);
+      db.prepare(
+        `INSERT INTO document_tags (document_id, tag_id) VALUES (?, ?)
+         ON CONFLICT DO NOTHING`,
+      ).run(documentId, tag.id);
+      tags.push(tag);
+    }
+    return tags;
+  });
+
+  const tags = run();
+  log.info({ documentId, tagCount: tags.length }, "Tags added to document");
+  return tags;
+}
+
+/** Remove a specific tag from a document. */
+export function removeTagFromDocument(
+  db: Database.Database,
+  documentId: string,
+  tagId: string,
+): void {
+  const log = createChildLogger({ operation: "removeTagFromDocument" });
+  db.prepare("DELETE FROM document_tags WHERE document_id = ? AND tag_id = ?").run(
+    documentId,
+    tagId,
+  );
+  log.info({ documentId, tagId }, "Tag removed from document");
+}
+
+/** Get all tags for a specific document. */
+export function getDocumentTags(db: Database.Database, documentId: string): Tag[] {
+  const rows = db
+    .prepare(
+      `SELECT t.id, t.name, t.created_at
+       FROM tags t
+       JOIN document_tags dt ON dt.tag_id = t.id
+       WHERE dt.document_id = ?
+       ORDER BY t.name`,
+    )
+    .all(documentId) as Array<{
+    id: string;
+    name: string;
+    created_at: string;
+  }>;
+
+  return rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    createdAt: row.created_at,
+  }));
+}
+
+export interface GetDocumentsByTagOptions {
+  limit?: number;
+  offset?: number;
+}
+
+/** Get documents matching ALL specified tags (AND logic). */
+export function getDocumentsByTag(
+  db: Database.Database,
+  tagNames: string[],
+  options?: GetDocumentsByTagOptions,
+): Document[] {
+  const log = createChildLogger({ operation: "getDocumentsByTag" });
+  if (tagNames.length === 0) return [];
+
+  const limit = options?.limit ?? 50;
+  const offset = options?.offset ?? 0;
+  const normalized = tagNames.map((t) => t.trim().toLowerCase());
+
+  const placeholders = normalized.map(() => "?").join(", ");
+  const sql = `
+    SELECT d.id, d.source_type, d.library, d.version, d.topic_id,
+           d.title, d.content, d.url, d.content_hash, d.submitted_by,
+           d.created_at, d.updated_at
+    FROM documents d
+    JOIN document_tags dt ON dt.document_id = d.id
+    JOIN tags t ON t.id = dt.tag_id
+    WHERE t.name IN (${placeholders})
+    GROUP BY d.id
+    HAVING COUNT(DISTINCT t.name) = ?
+    ORDER BY d.created_at DESC
+    LIMIT ? OFFSET ?
+  `;
+
+  const params = [...normalized, normalized.length, limit, offset];
+  const rows = db.prepare(sql).all(...params) as Array<{
+    id: string;
+    source_type: string;
+    library: string | null;
+    version: string | null;
+    topic_id: string | null;
+    title: string;
+    content: string;
+    url: string | null;
+    content_hash: string | null;
+    submitted_by: string;
+    created_at: string;
+    updated_at: string;
+  }>;
+
+  log.info({ tagNames: normalized, resultCount: rows.length }, "Documents retrieved by tags");
+
+  return rows.map((row) => ({
+    id: row.id,
+    sourceType: row.source_type,
+    library: row.library,
+    version: row.version,
+    topicId: row.topic_id,
+    title: row.title,
+    content: row.content,
+    url: row.url,
+    contentHash: row.content_hash,
+    submittedBy: row.submitted_by,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }));
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -2,7 +2,7 @@ import type Database from "better-sqlite3";
 import { DatabaseError } from "../errors.js";
 import { getLogger } from "../logger.js";
 
-const SCHEMA_VERSION = 4;
+const SCHEMA_VERSION = 5;
 
 const MIGRATIONS: Record<number, string> = {
   1: `
@@ -98,6 +98,26 @@ const MIGRATIONS: Record<number, string> = {
     CREATE UNIQUE INDEX IF NOT EXISTS idx_topics_name ON topics(name);
 
     INSERT INTO schema_version (version) VALUES (4);
+  `,
+  5: `
+    CREATE TABLE IF NOT EXISTS tags (
+      id TEXT PRIMARY KEY,
+      name TEXT UNIQUE NOT NULL,
+      created_at TEXT DEFAULT (datetime('now'))
+    );
+
+    CREATE TABLE IF NOT EXISTS document_tags (
+      document_id TEXT NOT NULL,
+      tag_id TEXT NOT NULL,
+      PRIMARY KEY (document_id, tag_id),
+      FOREIGN KEY (document_id) REFERENCES documents(id) ON DELETE CASCADE,
+      FOREIGN KEY (tag_id) REFERENCES tags(id) ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_document_tags_doc ON document_tags(document_id);
+    CREATE INDEX IF NOT EXISTS idx_document_tags_tag ON document_tags(tag_id);
+
+    INSERT INTO schema_version (version) VALUES (5);
   `,
 };
 

--- a/tests/unit/schema.test.ts
+++ b/tests/unit/schema.test.ts
@@ -35,7 +35,7 @@ describe("database schema", () => {
       const version = db.prepare("SELECT MAX(version) as v FROM schema_version").get() as {
         v: number;
       };
-      expect(version.v).toBe(4);
+      expect(version.v).toBe(5);
     });
 
     it("should create expected indexes", () => {

--- a/tests/unit/tags.test.ts
+++ b/tests/unit/tags.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createTestDb } from "../fixtures/test-db.js";
+import {
+  createTag,
+  deleteTag,
+  listTags,
+  addTagsToDocument,
+  removeTagFromDocument,
+  getDocumentTags,
+  getDocumentsByTag,
+} from "../../src/core/tags.js";
+import { ValidationError } from "../../src/errors.js";
+import type Database from "better-sqlite3";
+
+function insertDocument(db: Database.Database, id: string, title: string): void {
+  db.prepare(
+    `INSERT INTO documents (id, source_type, title, content, submitted_by)
+     VALUES (?, 'manual', ?, 'content', 'manual')`,
+  ).run(id, title);
+}
+
+describe("tags", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  describe("createTag", () => {
+    it("should create a new tag", () => {
+      const tag = createTag(db, "JavaScript");
+      expect(tag.name).toBe("javascript");
+      expect(tag.id).toBeDefined();
+      expect(tag.createdAt).toBeDefined();
+    });
+
+    it("should return existing tag on duplicate name", () => {
+      const first = createTag(db, "React");
+      const second = createTag(db, "react");
+      expect(second.id).toBe(first.id);
+      expect(second.name).toBe("react");
+    });
+
+    it("should reject empty name", () => {
+      expect(() => createTag(db, "")).toThrow(ValidationError);
+      expect(() => createTag(db, "   ")).toThrow(ValidationError);
+    });
+  });
+
+  describe("deleteTag", () => {
+    it("should delete tag and cascade associations", () => {
+      insertDocument(db, "doc-1", "Test Doc");
+      const tags = addTagsToDocument(db, "doc-1", ["important"]);
+      deleteTag(db, tags[0].id);
+
+      const docTags = getDocumentTags(db, "doc-1");
+      expect(docTags).toHaveLength(0);
+
+      const allTags = listTags(db);
+      expect(allTags).toHaveLength(0);
+    });
+  });
+
+  describe("listTags", () => {
+    it("should return tags with document counts", () => {
+      insertDocument(db, "doc-1", "Doc 1");
+      insertDocument(db, "doc-2", "Doc 2");
+      addTagsToDocument(db, "doc-1", ["api", "guide"]);
+      addTagsToDocument(db, "doc-2", ["api"]);
+
+      const tags = listTags(db);
+      const apiTag = tags.find((t) => t.name === "api");
+      const guideTag = tags.find((t) => t.name === "guide");
+
+      expect(apiTag?.documentCount).toBe(2);
+      expect(guideTag?.documentCount).toBe(1);
+    });
+  });
+
+  describe("addTagsToDocument", () => {
+    it("should add multiple tags in a single call", () => {
+      insertDocument(db, "doc-1", "Test Doc");
+      const tags = addTagsToDocument(db, "doc-1", ["tag-a", "tag-b", "tag-c"]);
+      expect(tags).toHaveLength(3);
+
+      const docTags = getDocumentTags(db, "doc-1");
+      expect(docTags).toHaveLength(3);
+    });
+
+    it("should not duplicate tags on repeated calls", () => {
+      insertDocument(db, "doc-1", "Test Doc");
+      addTagsToDocument(db, "doc-1", ["repeated"]);
+      addTagsToDocument(db, "doc-1", ["repeated"]);
+
+      const docTags = getDocumentTags(db, "doc-1");
+      expect(docTags).toHaveLength(1);
+    });
+  });
+
+  describe("removeTagFromDocument", () => {
+    it("should remove only the specified tag", () => {
+      insertDocument(db, "doc-1", "Test Doc");
+      const tags = addTagsToDocument(db, "doc-1", ["keep", "remove"]);
+      const removeId = tags.find((t) => t.name === "remove")!.id;
+
+      removeTagFromDocument(db, "doc-1", removeId);
+
+      const docTags = getDocumentTags(db, "doc-1");
+      expect(docTags).toHaveLength(1);
+      expect(docTags[0].name).toBe("keep");
+    });
+  });
+
+  describe("getDocumentsByTag", () => {
+    it("should return documents matching all specified tags (AND logic)", () => {
+      insertDocument(db, "doc-1", "Both Tags");
+      insertDocument(db, "doc-2", "One Tag");
+      insertDocument(db, "doc-3", "No Tags");
+
+      addTagsToDocument(db, "doc-1", ["alpha", "beta"]);
+      addTagsToDocument(db, "doc-2", ["alpha"]);
+
+      const bothTags = getDocumentsByTag(db, ["alpha", "beta"]);
+      expect(bothTags).toHaveLength(1);
+      expect(bothTags[0].id).toBe("doc-1");
+
+      const singleTag = getDocumentsByTag(db, ["alpha"]);
+      expect(singleTag).toHaveLength(2);
+    });
+
+    it("should support pagination", () => {
+      for (let i = 0; i < 5; i++) {
+        insertDocument(db, `doc-${i}`, `Doc ${i}`);
+        addTagsToDocument(db, `doc-${i}`, ["paginated"]);
+      }
+
+      const page1 = getDocumentsByTag(db, ["paginated"], { limit: 2, offset: 0 });
+      const page2 = getDocumentsByTag(db, ["paginated"], { limit: 2, offset: 2 });
+      expect(page1).toHaveLength(2);
+      expect(page2).toHaveLength(2);
+      expect(page1[0].id).not.toBe(page2[0].id);
+    });
+
+    it("should return empty array for no matching tags", () => {
+      const result = getDocumentsByTag(db, ["nonexistent"]);
+      expect(result).toHaveLength(0);
+    });
+
+    it("should return empty array for empty tag list", () => {
+      const result = getDocumentsByTag(db, []);
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe("cascading deletes", () => {
+    it("should remove tag associations when a document is deleted", () => {
+      insertDocument(db, "doc-del", "To Delete");
+      addTagsToDocument(db, "doc-del", ["orphan-tag"]);
+
+      db.prepare("DELETE FROM documents WHERE id = ?").run("doc-del");
+
+      const tags = listTags(db);
+      const orphan = tags.find((t) => t.name === "orphan-tag");
+      expect(orphan?.documentCount).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Implements a multi-label tag system for flexible document organization (closes #121).

## Changes
- **Schema**: Migration v5 adds `tags` and `document_tags` tables with proper indexes and cascading deletes
- **Core module** (`src/core/tags.ts`): Full CRUD — `createTag`, `deleteTag`, `listTags`, `addTagsToDocument`, `removeTagFromDocument`, `getDocumentTags`, `getDocumentsByTag` (AND-logic filtering with pagination)
- **Search integration**: Optional `tags` filter in `SearchOptions` applied to all 3 search paths (vector, FTS5, keyword)
- **CLI commands**: `tag add`, `tag remove`, `tag list`; `docs show` now displays tags
- **Exports**: All tag types and functions exported from `src/core/index.ts`
- **Tests**: 13 unit tests covering CRUD, associations, AND-logic, cascading deletes, pagination

All 215 tests pass. Typecheck clean.