### PR TITLE
feat: add conversational RAG search with LLM answers (closes #119)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,6 +6,7 @@ import { getDatabase, runMigrations, createVectorTable, closeDatabase } from "..
 import { createEmbeddingProvider } from "../providers/index.js";
 import { indexDocument } from "../core/indexing.js";
 import { searchDocuments } from "../core/search.js";
+import { askQuestion, createLlmProvider } from "../core/rag.js";
 import { getDocumentRatings, listRatings } from "../core/ratings.js";
 import { createTopic, listTopics } from "../core/topics.js";
 import { getDocument, listDocuments, deleteDocument } from "../core/documents.js";
@@ -293,6 +294,64 @@ program
             if (r.url) console.log(`  Source: ${r.url}`);
             console.log(`  ${r.content.slice(0, 200)}${r.content.length > 200 ? "..." : ""}`);
           }
+        }
+      } finally {
+        closeDatabase();
+      }
+    },
+  );
+
+// ask (RAG question answering)
+program
+  .command("ask <question>")
+  .description("Ask a question and get an LLM-synthesized answer using RAG")
+  .option("--top-k <n>", "Number of chunks to retrieve", "5")
+  .option("--topic <topic>", "Filter by topic")
+  .option("--library <lib>", "Filter by library")
+  .option("--model <model>", "Override LLM model")
+  .action(
+    async (
+      question: string,
+      opts: { topK: string; topic?: string; library?: string; model?: string },
+    ) => {
+      const { config, db, provider } = initializeAppWithEmbedding();
+      try {
+        let llmProvider;
+        try {
+          if (opts.model) {
+            config.llm = { ...config.llm, model: opts.model };
+          }
+          llmProvider = createLlmProvider(config);
+        } catch (err) {
+          console.error(
+            `\u2717 ${err instanceof Error ? err.message : String(err)}\n\n` +
+              `To configure an LLM provider, run:\n` +
+              `  libscope config set llm.provider openai   # or ollama\n` +
+              `  export LIBSCOPE_LLM_PROVIDER=openai\n`,
+          );
+          process.exit(1);
+        }
+
+        const result = await askQuestion(db, provider, llmProvider, {
+          question,
+          topK: parseInt(opts.topK, 10),
+          topic: opts.topic,
+          library: opts.library,
+        });
+
+        console.log(`\n${result.answer}\n`);
+
+        if (result.sources.length > 0) {
+          console.log("\u2500\u2500 Sources \u2500\u2500");
+          for (const src of result.sources) {
+            console.log(
+              `  \u2022 ${src.title} (score: ${src.score.toFixed(2)}) [${src.documentId}]`,
+            );
+          }
+        }
+
+        if (result.tokensUsed != null) {
+          console.log(`\n  Model: ${result.model} | Tokens: ${result.tokensUsed}`);
         }
       } finally {
         closeDatabase();

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,12 @@ export interface LibScopeConfig {
     openaiApiKey?: string;
     openaiModel?: string;
   };
+  llm?: {
+    provider?: "openai" | "ollama";
+    model?: string;
+    ollamaUrl?: string;
+    openaiApiKey?: string;
+  };
   database: {
     path: string;
   };
@@ -80,6 +86,16 @@ function getEnvOverrides(): Partial<LibScopeConfig> {
   if (ollamaUrl) {
     overrides.embedding = { ...(overrides.embedding ?? DEFAULT_CONFIG.embedding), ollamaUrl };
   }
+
+  const llmProvider = process.env["LIBSCOPE_LLM_PROVIDER"];
+  const llmModel = process.env["LIBSCOPE_LLM_MODEL"];
+  if (llmProvider === "openai" || llmProvider === "ollama" || llmModel) {
+    overrides.llm = {
+      ...(llmProvider === "openai" || llmProvider === "ollama" ? { provider: llmProvider } : {}),
+      ...(llmModel ? { model: llmModel } : {}),
+    };
+  }
+
   return overrides;
 }
 
@@ -95,6 +111,11 @@ export function loadConfig(): LibScopeConfig {
       ...userConfig.embedding,
       ...projectConfig.embedding,
       ...envOverrides.embedding,
+    },
+    llm: {
+      ...userConfig.llm,
+      ...projectConfig.llm,
+      ...envOverrides.llm,
     },
     database: {
       ...DEFAULT_CONFIG.database,
@@ -126,6 +147,10 @@ export function saveUserConfig(config: Partial<LibScopeConfig>): void {
       ...DEFAULT_CONFIG.embedding,
       ...existing.embedding,
       ...config.embedding,
+    },
+    llm: {
+      ...existing.llm,
+      ...config.llm,
     },
     database: {
       ...DEFAULT_CONFIG.database,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -51,6 +51,9 @@ export type { Tag, TagWithCount, GetDocumentsByTagOptions } from "./tags.js";
 export { FileWatcher, DEFAULT_WATCH_EXTENSIONS } from "./watcher.js";
 export type { WatchOptions } from "./watcher.js";
 
+export { askQuestion, createLlmProvider, buildContextPrompt, extractSources } from "./rag.js";
+export type { RagOptions, RagResult, RagSource, LlmProvider } from "./rag.js";
+
 export { registerProvider, createEmbeddingProvider } from "../providers/index.js";
 export type { EmbeddingProvider } from "../providers/embedding.js";
 export type { ProviderFactory } from "../providers/index.js";

--- a/src/core/rag.ts
+++ b/src/core/rag.ts
@@ -1,0 +1,216 @@
+import type Database from "better-sqlite3";
+import type { EmbeddingProvider } from "../providers/embedding.js";
+import type { LibScopeConfig } from "../config.js";
+import { searchDocuments, type SearchResult } from "./search.js";
+
+export const DEFAULT_SYSTEM_PROMPT =
+  "You are a helpful assistant. Answer based on the provided context. " +
+  "Cite sources by title. If the context doesn't contain enough information, say so.";
+
+export interface RagOptions {
+  question: string;
+  topK?: number | undefined;
+  topic?: string | undefined;
+  library?: string | undefined;
+  systemPrompt?: string | undefined;
+}
+
+export interface RagSource {
+  documentId: string;
+  title: string;
+  chunk: string;
+  score: number;
+}
+
+export interface RagResult {
+  answer: string;
+  sources: RagSource[];
+  model: string;
+  tokensUsed?: number | undefined;
+}
+
+export interface LlmProvider {
+  readonly model: string;
+  complete(
+    prompt: string,
+    systemPrompt?: string,
+  ): Promise<{ text: string; tokensUsed?: number | undefined }>;
+}
+
+/** Build the context prompt from retrieved search results. */
+export function buildContextPrompt(question: string, results: SearchResult[]): string {
+  if (results.length === 0) {
+    return `Question: ${question}\n\nNo relevant documents were found. Please let the user know.`;
+  }
+
+  const contextBlocks = results
+    .map((r, i) => `[Source ${i + 1}: "${r.title}"]\n${r.content}`)
+    .join("\n\n");
+
+  return (
+    "Use the following context to answer the question. Cite sources by their title.\n\n" +
+    `${contextBlocks}\n\n` +
+    `Question: ${question}`
+  );
+}
+
+/** Extract source citations from search results. */
+export function extractSources(results: SearchResult[]): RagSource[] {
+  return results.map((r) => ({
+    documentId: r.documentId,
+    title: r.title,
+    chunk: r.content,
+    score: r.score,
+  }));
+}
+
+interface LlmConfig {
+  provider?: "openai" | "ollama";
+  model?: string;
+  ollamaUrl?: string;
+  openaiApiKey?: string;
+}
+
+/** Create an LLM provider from config. */
+export function createLlmProvider(config: LibScopeConfig): LlmProvider {
+  const llmConfig: LlmConfig | undefined = config.llm;
+  const providerType = llmConfig?.provider;
+
+  if (providerType === "openai") {
+    return createOpenAiProvider(config.embedding, llmConfig);
+  }
+  if (providerType === "ollama") {
+    return createOllamaProvider(config.embedding, llmConfig);
+  }
+
+  throw new Error(
+    "No LLM provider configured. Set llm.provider to 'openai' or 'ollama' in your config, " +
+      "or set LIBSCOPE_LLM_PROVIDER environment variable.",
+  );
+}
+
+function createOpenAiProvider(
+  embedding: LibScopeConfig["embedding"],
+  llmConfig: LlmConfig | undefined,
+): LlmProvider {
+  const apiKey = llmConfig?.openaiApiKey ?? embedding.openaiApiKey;
+  if (!apiKey) {
+    throw new Error(
+      "OpenAI API key is required. Set llm.openaiApiKey or embedding.openaiApiKey in config.",
+    );
+  }
+
+  const model = llmConfig?.model ?? "gpt-4o-mini";
+
+  return {
+    model,
+    async complete(
+      prompt: string,
+      systemPrompt?: string,
+    ): Promise<{ text: string; tokensUsed?: number | undefined }> {
+      const messages: Array<{ role: string; content: string }> = [];
+      if (systemPrompt) {
+        messages.push({ role: "system", content: systemPrompt });
+      }
+      messages.push({ role: "user", content: prompt });
+
+      const res = await fetch("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({ model, messages }),
+      });
+
+      if (!res.ok) {
+        const body = await res.text();
+        throw new Error(`OpenAI API error (${res.status}): ${body}`);
+      }
+
+      const data = (await res.json()) as {
+        choices: Array<{ message: { content: string } }>;
+        usage?: { total_tokens: number };
+      };
+
+      return {
+        text: data.choices[0]?.message.content ?? "",
+        tokensUsed: data.usage?.total_tokens,
+      };
+    },
+  };
+}
+
+function createOllamaProvider(
+  embedding: LibScopeConfig["embedding"],
+  llmConfig: LlmConfig | undefined,
+): LlmProvider {
+  const baseUrl = llmConfig?.ollamaUrl ?? embedding.ollamaUrl ?? "http://localhost:11434";
+  const model = llmConfig?.model ?? "llama3.2";
+
+  return {
+    model,
+    async complete(
+      prompt: string,
+      systemPrompt?: string,
+    ): Promise<{ text: string; tokensUsed?: number | undefined }> {
+      const res = await fetch(`${baseUrl}/api/generate`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model,
+          prompt,
+          system: systemPrompt,
+          stream: false,
+        }),
+      });
+
+      if (!res.ok) {
+        const body = await res.text();
+        throw new Error(`Ollama API error (${res.status}): ${body}`);
+      }
+
+      const data = (await res.json()) as {
+        response: string;
+        eval_count?: number;
+        prompt_eval_count?: number;
+      };
+
+      const tokensUsed =
+        data.eval_count != null && data.prompt_eval_count != null
+          ? data.eval_count + data.prompt_eval_count
+          : undefined;
+
+      return { text: data.response, tokensUsed };
+    },
+  };
+}
+
+/** Perform RAG: retrieve relevant chunks, then generate an LLM answer. */
+export async function askQuestion(
+  db: Database.Database,
+  embeddingProvider: EmbeddingProvider,
+  llmProvider: LlmProvider,
+  options: RagOptions,
+): Promise<RagResult> {
+  const topK = options.topK ?? 5;
+
+  const { results } = await searchDocuments(db, embeddingProvider, {
+    query: options.question,
+    topic: options.topic,
+    library: options.library,
+    limit: topK,
+  });
+
+  const contextPrompt = buildContextPrompt(options.question, results);
+  const systemPrompt = options.systemPrompt ?? DEFAULT_SYSTEM_PROMPT;
+
+  const { text, tokensUsed } = await llmProvider.complete(contextPrompt, systemPrompt);
+
+  return {
+    answer: text,
+    sources: extractSources(results),
+    model: llmProvider.model,
+    tokensUsed,
+  };
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -5,6 +5,7 @@ import { loadConfig } from "../config.js";
 import { getDatabase, runMigrations, createVectorTable } from "../db/index.js";
 import { createEmbeddingProvider } from "../providers/index.js";
 import { searchDocuments } from "../core/search.js";
+import { askQuestion, createLlmProvider, type LlmProvider } from "../core/rag.js";
 import { getDocument, listDocuments, deleteDocument } from "../core/documents.js";
 import { rateDocument, getDocumentRatings } from "../core/ratings.js";
 import { indexDocument } from "../core/indexing.js";
@@ -72,6 +73,7 @@ async function main(): Promise<void> {
   }
 
   let provider;
+  let llmProvider: LlmProvider | undefined;
   try {
     provider = createEmbeddingProvider(config);
     createVectorTable(db, provider.dimensions);
@@ -82,6 +84,12 @@ async function main(): Promise<void> {
     );
     db.close();
     process.exit(1);
+  }
+
+  try {
+    llmProvider = createLlmProvider(config);
+  } catch {
+    // LLM provider is optional; ask-question tool will report the error
   }
 
   process.on("SIGINT", () => {
@@ -423,6 +431,54 @@ async function main(): Promise<void> {
 
       return {
         content: [{ type: "text" as const, text: `## Documents (${docs.length})\n\n${text}` }],
+      };
+    }),
+  );
+
+  // Tool: ask-question (RAG)
+  server.tool(
+    "ask-question",
+    "Ask a question and get an LLM-synthesized answer based on indexed documentation (RAG)",
+    {
+      question: z.string().describe("The question to answer"),
+      topK: z
+        .number()
+        .min(1)
+        .max(20)
+        .optional()
+        .describe("Number of chunks to retrieve for context (default: 5)"),
+      topic: z.string().optional().describe("Filter by topic ID"),
+      library: z.string().optional().describe("Filter by library name"),
+    },
+    withErrorHandling(async (params) => {
+      if (!llmProvider) {
+        throw new Error(
+          "No LLM provider configured. Set llm.provider to 'openai' or 'ollama' in your config.",
+        );
+      }
+
+      const result = await askQuestion(db, provider, llmProvider, {
+        question: params.question,
+        topK: params.topK,
+        topic: params.topic,
+        library: params.library,
+      });
+
+      const sourcesText =
+        result.sources.length > 0
+          ? "\n\n**Sources:**\n" +
+            result.sources
+              .map((s) => `- ${s.title} (score: ${s.score.toFixed(2)}) [${s.documentId}]`)
+              .join("\n")
+          : "";
+
+      const metaText =
+        result.tokensUsed != null
+          ? `\n\n_Model: ${result.model} | Tokens: ${result.tokensUsed}_`
+          : "";
+
+      return {
+        content: [{ type: "text" as const, text: result.answer + sourcesText + metaText }],
       };
     }),
   );

--- a/tests/unit/rag.test.ts
+++ b/tests/unit/rag.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  buildContextPrompt,
+  extractSources,
+  createLlmProvider,
+  DEFAULT_SYSTEM_PROMPT,
+  type LlmProvider,
+} from "../../src/core/rag.js";
+import type { SearchResult, SearchMethod } from "../../src/core/search.js";
+import type { LibScopeConfig } from "../../src/config.js";
+
+function makeSearchResult(overrides: Partial<SearchResult> = {}): SearchResult {
+  return {
+    documentId: "doc-1",
+    chunkId: "chunk-1",
+    title: "Test Doc",
+    content: "Some content about testing.",
+    sourceType: "manual",
+    library: null,
+    version: null,
+    topicId: null,
+    url: null,
+    score: 0.95,
+    avgRating: null,
+    scoreExplanation: {
+      method: "vector" as SearchMethod,
+      rawScore: 0.05,
+      boostFactors: [],
+      details: "test",
+    },
+    ...overrides,
+  };
+}
+
+function createMockLlmProvider(response = "Test answer"): LlmProvider {
+  return {
+    model: "mock-model",
+    complete: vi.fn().mockResolvedValue({ text: response, tokensUsed: 42 }),
+  };
+}
+
+describe("buildContextPrompt", () => {
+  it("includes question and source titles in prompt", () => {
+    const results = [
+      makeSearchResult({ title: "React Hooks Guide", content: "useEffect runs after render." }),
+      makeSearchResult({ title: "Vue Composition API", content: "setup() runs before mount." }),
+    ];
+
+    const prompt = buildContextPrompt("How do hooks work?", results);
+
+    expect(prompt).toContain("How do hooks work?");
+    expect(prompt).toContain('[Source 1: "React Hooks Guide"]');
+    expect(prompt).toContain('[Source 2: "Vue Composition API"]');
+    expect(prompt).toContain("useEffect runs after render.");
+    expect(prompt).toContain("setup() runs before mount.");
+  });
+
+  it("handles empty results with informative message", () => {
+    const prompt = buildContextPrompt("What is X?", []);
+
+    expect(prompt).toContain("What is X?");
+    expect(prompt).toContain("No relevant documents were found");
+  });
+});
+
+describe("extractSources", () => {
+  it("maps search results to RagSource format", () => {
+    const results = [
+      makeSearchResult({ documentId: "d1", title: "Doc 1", content: "chunk text", score: 0.9 }),
+      makeSearchResult({ documentId: "d2", title: "Doc 2", content: "other text", score: 0.7 }),
+    ];
+
+    const sources = extractSources(results);
+
+    expect(sources).toHaveLength(2);
+    expect(sources[0]).toEqual({
+      documentId: "d1",
+      title: "Doc 1",
+      chunk: "chunk text",
+      score: 0.9,
+    });
+    expect(sources[1]).toEqual({
+      documentId: "d2",
+      title: "Doc 2",
+      chunk: "other text",
+      score: 0.7,
+    });
+  });
+});
+
+describe("askQuestion", () => {
+  it("retrieves context and calls LLM provider", async () => {
+    const mockLlm = createMockLlmProvider("The answer is 42.");
+    const mockEmbedding = {
+      name: "mock",
+      dimensions: 4,
+      embed: vi.fn().mockResolvedValue([0.1, 0.2, 0.3, 0.4]),
+      embedBatch: vi.fn().mockResolvedValue([[0.1, 0.2, 0.3, 0.4]]),
+    };
+
+    const searchMock = vi.fn().mockResolvedValue({
+      results: [makeSearchResult({ title: "Relevant Doc" })],
+      totalCount: 1,
+    });
+
+    const { askQuestion: askFn } = await import("../../src/core/rag.js");
+    const searchModule = await import("../../src/core/search.js");
+    vi.spyOn(searchModule, "searchDocuments").mockImplementation(searchMock);
+
+    const mockDb = {} as Parameters<typeof askFn>[0];
+
+    try {
+      const result = await askFn(mockDb, mockEmbedding, mockLlm, {
+        question: "What is the meaning of life?",
+        topK: 3,
+      });
+
+      expect(result.answer).toBe("The answer is 42.");
+      expect(result.model).toBe("mock-model");
+      expect(result.tokensUsed).toBe(42);
+      expect(result.sources).toHaveLength(1);
+      expect(result.sources[0]!.title).toBe("Relevant Doc");
+
+      expect(searchMock).toHaveBeenCalledWith(mockDb, mockEmbedding, {
+        query: "What is the meaning of life?",
+        topic: undefined,
+        library: undefined,
+        limit: 3,
+      });
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLlm.complete).toHaveBeenCalledWith(
+        expect.stringContaining("What is the meaning of life?"),
+        DEFAULT_SYSTEM_PROMPT,
+      );
+    } finally {
+      vi.mocked(searchModule.searchDocuments).mockRestore();
+    }
+  });
+
+  it("uses custom system prompt when provided", async () => {
+    const mockLlm = createMockLlmProvider("Custom answer");
+    const mockEmbedding = {
+      name: "mock",
+      dimensions: 4,
+      embed: vi.fn().mockResolvedValue([0.1, 0.2, 0.3, 0.4]),
+      embedBatch: vi.fn().mockResolvedValue([[0.1, 0.2, 0.3, 0.4]]),
+    };
+
+    const searchModule = await import("../../src/core/search.js");
+    vi.spyOn(searchModule, "searchDocuments").mockResolvedValue({
+      results: [],
+      totalCount: 0,
+    });
+
+    const { askQuestion: askFn } = await import("../../src/core/rag.js");
+    const mockDb = {} as Parameters<typeof askFn>[0];
+
+    try {
+      await askFn(mockDb, mockEmbedding, mockLlm, {
+        question: "test",
+        systemPrompt: "You are a pirate.",
+      });
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockLlm.complete).toHaveBeenCalledWith(expect.any(String), "You are a pirate.");
+    } finally {
+      vi.mocked(searchModule.searchDocuments).mockRestore();
+    }
+  });
+
+  it("defaults topK to 5", async () => {
+    const mockLlm = createMockLlmProvider();
+    const mockEmbedding = {
+      name: "mock",
+      dimensions: 4,
+      embed: vi.fn().mockResolvedValue([0.1, 0.2, 0.3, 0.4]),
+      embedBatch: vi.fn().mockResolvedValue([[0.1, 0.2, 0.3, 0.4]]),
+    };
+
+    const searchModule = await import("../../src/core/search.js");
+    const searchMock = vi.spyOn(searchModule, "searchDocuments").mockResolvedValue({
+      results: [],
+      totalCount: 0,
+    });
+
+    const { askQuestion: askFn } = await import("../../src/core/rag.js");
+    const mockDb = {} as Parameters<typeof askFn>[0];
+
+    try {
+      await askFn(mockDb, mockEmbedding, mockLlm, { question: "test" });
+
+      expect(searchMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ limit: 5 }),
+      );
+    } finally {
+      searchMock.mockRestore();
+    }
+  });
+});
+
+describe("createLlmProvider", () => {
+  it("throws when no LLM provider is configured", () => {
+    const config: LibScopeConfig = {
+      embedding: { provider: "local" },
+      database: { path: ":memory:" },
+      indexing: { maxDocumentSize: 1024 },
+      logging: { level: "silent" },
+    };
+
+    expect(() => createLlmProvider(config)).toThrow("No LLM provider configured");
+  });
+
+  it("creates an OpenAI provider when configured", () => {
+    const config: LibScopeConfig = {
+      embedding: { provider: "local" },
+      llm: { provider: "openai", openaiApiKey: "sk-test", model: "gpt-4o" },
+      database: { path: ":memory:" },
+      indexing: { maxDocumentSize: 1024 },
+      logging: { level: "silent" },
+    };
+
+    const provider = createLlmProvider(config);
+    expect(provider.model).toBe("gpt-4o");
+  });
+
+  it("creates an Ollama provider when configured", () => {
+    const config: LibScopeConfig = {
+      embedding: { provider: "local" },
+      llm: { provider: "ollama", model: "mistral" },
+      database: { path: ":memory:" },
+      indexing: { maxDocumentSize: 1024 },
+      logging: { level: "silent" },
+    };
+
+    const provider = createLlmProvider(config);
+    expect(provider.model).toBe("mistral");
+  });
+
+  it("throws when OpenAI provider has no API key", () => {
+    const config: LibScopeConfig = {
+      embedding: { provider: "local" },
+      llm: { provider: "openai" },
+      database: { path: ":memory:" },
+      indexing: { maxDocumentSize: 1024 },
+      logging: { level: "silent" },
+    };
+
+    expect(() => createLlmProvider(config)).toThrow("OpenAI API key is required");
+  });
+});


### PR DESCRIPTION
## Summary

Adds conversational RAG (Retrieval-Augmented Generation) search with LLM-synthesized answers.

### Changes

- **`src/core/rag.ts`** — Core RAG module with:
  - `LlmProvider` interface with OpenAI and Ollama implementations
  - `askQuestion()` — retrieves relevant chunks via `searchDocuments`, builds context prompt, calls LLM
  - `buildContextPrompt()` and `extractSources()` utilities
  - `createLlmProvider()` factory supporting OpenAI (`/v1/chat/completions`) and Ollama (`/api/generate`)
  - Default system prompt with source citation instructions

- **`src/config.ts`** — Added optional `llm` config section (`provider`, `model`, `ollamaUrl`, `openaiApiKey`) with env var overrides (`LIBSCOPE_LLM_PROVIDER`, `LIBSCOPE_LLM_MODEL`)

- **`src/cli/index.ts`** — New `ask <question>` command with `--top-k`, `--topic`, `--library`, `--model` options and formatted source citations

- **`src/mcp/server.ts`** — New `ask-question` MCP tool with question, topK, topic, library params

- **`src/core/index.ts`** — Exports RAG types and functions

- **`tests/unit/rag.test.ts`** — 10 unit tests covering prompt building, source extraction, askQuestion integration, provider creation, and error cases

### Testing

All 220 tests pass including 10 new RAG tests.

Closes #119