### PR TITLE
feat: add Notion page and database connector (closes #152)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -57,6 +57,8 @@ import {
   disconnectOneNote,
 } from "../connectors/onenote.js";
 import { loadConnectorConfig, saveConnectorConfig } from "../connectors/index.js";
+import { syncNotion, disconnectNotion } from "../connectors/notion.js";
+import type { NotionConfig } from "../connectors/notion.js";
 
 // Graceful shutdown
 process.on("SIGINT", () => {
@@ -1467,6 +1469,56 @@ disconnectCmd
 
     const removed = disconnectVault(db, resolvedPath);
     console.log(`✓ Disconnected vault. Removed ${removed} documents.`);
+
+    connectCmd
+      .command("notion")
+      .description("Connect and sync Notion pages and databases")
+      .option("--token <token>", "Notion integration token (secret_...)")
+      .option("--sync", "Sync pages using a previously stored token")
+      .option("--exclude <ids...>", "Page/database IDs to exclude")
+      .action(async (opts: { token?: string; sync?: boolean; exclude?: string[] }) => {
+        const { db, provider } = initializeAppWithEmbedding();
+        let token = opts.token;
+
+        if (opts.sync && !token) {
+          token = process.env["NOTION_TOKEN"];
+          if (!token) {
+            console.error("Error: --token is required, or set NOTION_TOKEN environment variable.");
+            process.exitCode = 1;
+            return;
+          }
+        }
+
+        if (!token) {
+          console.error("Error: --token <token> is required.");
+          process.exitCode = 1;
+          return;
+        }
+
+        const config: NotionConfig = { token };
+        if (opts.exclude) {
+          config.excludePages = opts.exclude;
+        }
+
+        console.log("Syncing Notion...");
+        const result = await syncNotion(db, provider, config);
+        console.log(
+          `✓ Synced: ${result.pagesIndexed} pages, ${result.databasesIndexed} databases` +
+            (result.errors.length > 0 ? `, ${result.errors.length} errors` : ""),
+        );
+        for (const err of result.errors) {
+          console.log(`  ⚠ ${err.page}: ${err.error}`);
+        }
+      });
+
+    disconnectCmd
+      .command("notion")
+      .description("Remove all Notion documents")
+      .action(async () => {
+        const { db } = initializeApp();
+        const removed = await disconnectNotion(db);
+        console.log(`✓ Removed ${removed} Notion documents.`);
+      });
   });
 
 program.parse();

--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -2,6 +2,8 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { ConfigError } from "../errors.js";
+import type Database from "better-sqlite3";
+import { getLogger } from "../logger.js";
 
 export interface ConnectorConfig {
   type: string;
@@ -37,3 +39,35 @@ export function saveConnectorConfig(config: Record<string, unknown>): void {
     throw new ConfigError("Failed to save connector config", err);
   }
 }
+
+/** Save connector config to the database. */
+export function saveDbConnectorConfig(db: Database.Database, config: ConnectorConfig): void {
+  const log = getLogger();
+  db.prepare(
+    `INSERT INTO connector_configs (type, config_json, updated_at)
+     VALUES (?, ?, datetime('now'))
+     ON CONFLICT(type) DO UPDATE SET config_json = excluded.config_json, updated_at = datetime('now')`,
+  ).run(config.type, JSON.stringify(config));
+  log.debug({ type: config.type }, "Saved connector config");
+}
+
+/** Load connector config from the database. Returns undefined if not found. */
+export function loadDbConnectorConfig(
+  db: Database.Database,
+  type: string,
+): ConnectorConfig | undefined {
+  const row = db.prepare("SELECT config_json FROM connector_configs WHERE type = ?").get(type) as
+    | { config_json: string }
+    | undefined;
+  if (!row) return undefined;
+  return JSON.parse(row.config_json) as ConnectorConfig;
+}
+
+/** Delete connector config from the database. */
+export function deleteDbConnectorConfig(db: Database.Database, type: string): boolean {
+  const result = db.prepare("DELETE FROM connector_configs WHERE type = ?").run(type);
+  return result.changes > 0;
+}
+
+export { syncNotion, convertNotionBlocks, disconnectNotion } from "./notion.js";
+export type { NotionConfig, NotionSyncResult, NotionBlock } from "./notion.js";

--- a/src/connectors/notion.ts
+++ b/src/connectors/notion.ts
@@ -1,0 +1,513 @@
+import type Database from "better-sqlite3";
+import type { EmbeddingProvider } from "../providers/embedding.js";
+import { getLogger } from "../logger.js";
+import { ValidationError, FetchError } from "../errors.js";
+import { indexDocument } from "../core/indexing.js";
+import { deleteDocument } from "../core/documents.js";
+
+const NOTION_API_BASE = "https://api.notion.com";
+const NOTION_VERSION = "2022-06-28";
+
+export interface NotionConfig {
+  token: string;
+  lastSync?: string | undefined;
+  excludePages?: string[] | undefined;
+}
+
+export interface NotionSyncResult {
+  pagesIndexed: number;
+  databasesIndexed: number;
+  errors: Array<{ page: string; error: string }>;
+}
+
+export interface NotionBlock {
+  id: string;
+  type: string;
+  has_children?: boolean | undefined;
+  [key: string]: unknown;
+}
+
+interface NotionRichText {
+  plain_text: string;
+  href?: string | null;
+}
+
+interface NotionSearchResult {
+  object: string;
+  id: string;
+  last_edited_time: string;
+  properties?: Record<string, NotionProperty>;
+  parent?: { type: string; database_id?: string };
+  url?: string;
+  title?: Array<{ plain_text: string }>;
+}
+
+interface NotionProperty {
+  type: string;
+  title?: Array<{ plain_text: string }>;
+  rich_text?: Array<{ plain_text: string }>;
+  select?: { name: string } | null;
+  multi_select?: Array<{ name: string }>;
+  date?: { start: string; end?: string | null } | null;
+  number?: number | null;
+  checkbox?: boolean;
+  url?: string | null;
+  [key: string]: unknown;
+}
+
+interface NotionSearchResponse {
+  results: NotionSearchResult[];
+  has_more: boolean;
+  next_cursor: string | null;
+}
+
+interface NotionBlocksResponse {
+  results: NotionBlock[];
+  has_more: boolean;
+  next_cursor: string | null;
+}
+
+interface NotionDatabaseQueryResponse {
+  results: NotionSearchResult[];
+  has_more: boolean;
+  next_cursor: string | null;
+}
+
+async function notionFetch<T>(
+  endpoint: string,
+  token: string,
+  options: { method?: string; body?: unknown } = {},
+): Promise<T> {
+  const url = `${NOTION_API_BASE}${endpoint}`;
+  const method = options.method ?? "GET";
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    "Notion-Version": NOTION_VERSION,
+    "Content-Type": "application/json",
+  };
+
+  const fetchOptions: RequestInit = { method, headers };
+  if (options.body) {
+    fetchOptions.body = JSON.stringify(options.body);
+  }
+
+  const response = await fetch(url, fetchOptions);
+
+  if (response.status === 401) {
+    throw new ValidationError("Invalid Notion token or insufficient permissions");
+  }
+  if (response.status === 429) {
+    throw new FetchError("Notion API rate limit exceeded. Try again later.");
+  }
+  if (!response.ok) {
+    const text = await response.text().catch(() => "unknown error");
+    throw new FetchError(`Notion API error (${response.status}): ${text}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+async function searchNotion(token: string, lastSync?: string): Promise<NotionSearchResult[]> {
+  const allResults: NotionSearchResult[] = [];
+  let cursor: string | null = null;
+  let hasMore = true;
+
+  while (hasMore) {
+    const body: Record<string, unknown> = { page_size: 100 };
+    if (cursor) body["start_cursor"] = cursor;
+    if (lastSync) {
+      body["filter"] = { timestamp: "last_edited_time", last_edited_time: { after: lastSync } };
+    }
+
+    const response = await notionFetch<NotionSearchResponse>("/v1/search", token, {
+      method: "POST",
+      body,
+    });
+
+    allResults.push(...response.results);
+    hasMore = response.has_more;
+    cursor = response.next_cursor;
+  }
+
+  return allResults;
+}
+
+async function fetchBlockChildren(token: string, blockId: string): Promise<NotionBlock[]> {
+  const allBlocks: NotionBlock[] = [];
+  let cursor: string | null = null;
+  let hasMore = true;
+
+  while (hasMore) {
+    const endpoint: string = `/v1/blocks/${blockId}/children${cursor ? `?start_cursor=${cursor}` : ""}`;
+    const response: NotionBlocksResponse = await notionFetch<NotionBlocksResponse>(endpoint, token);
+    allBlocks.push(...response.results);
+    hasMore = response.has_more;
+    cursor = response.next_cursor;
+  }
+
+  // Recursively fetch children
+  for (const block of allBlocks) {
+    if (block.has_children) {
+      const children = await fetchBlockChildren(token, block.id);
+      (block as Record<string, unknown>)["children"] = children;
+    }
+  }
+
+  return allBlocks;
+}
+
+async function queryDatabase(token: string, databaseId: string): Promise<NotionSearchResult[]> {
+  const allRows: NotionSearchResult[] = [];
+  let cursor: string | null = null;
+  let hasMore = true;
+
+  while (hasMore) {
+    const body: Record<string, unknown> = { page_size: 100 };
+    if (cursor) body["start_cursor"] = cursor;
+
+    const response = await notionFetch<NotionDatabaseQueryResponse>(
+      `/v1/databases/${databaseId}/query`,
+      token,
+      { method: "POST", body },
+    );
+
+    allRows.push(...response.results);
+    hasMore = response.has_more;
+    cursor = response.next_cursor;
+  }
+
+  return allRows;
+}
+
+function extractRichText(richText: NotionRichText[] | undefined): string {
+  if (!richText) return "";
+  return richText.map((t) => t.plain_text).join("");
+}
+
+function getBlockText(block: NotionBlock): string {
+  const data = block[block.type] as Record<string, unknown> | undefined;
+  if (!data) return "";
+  const richText = data["rich_text"] as NotionRichText[] | undefined;
+  return extractRichText(richText);
+}
+
+/** Convert an array of Notion blocks to markdown. */
+export function convertNotionBlocks(blocks: NotionBlock[]): string {
+  const lines: string[] = [];
+
+  for (const block of blocks) {
+    const text = getBlockText(block);
+    const children = (block as Record<string, unknown>)["children"] as NotionBlock[] | undefined;
+
+    switch (block.type) {
+      case "paragraph":
+        lines.push(text);
+        break;
+
+      case "heading_1":
+        lines.push(`# ${text}`);
+        break;
+
+      case "heading_2":
+        lines.push(`## ${text}`);
+        break;
+
+      case "heading_3":
+        lines.push(`### ${text}`);
+        break;
+
+      case "bulleted_list_item":
+        lines.push(`- ${text}`);
+        break;
+
+      case "numbered_list_item":
+        lines.push(`1. ${text}`);
+        break;
+
+      case "to_do": {
+        const data = block["to_do"] as { checked?: boolean } | undefined;
+        const checked = data?.checked ? "x" : " ";
+        lines.push(`- [${checked}] ${text}`);
+        break;
+      }
+
+      case "toggle":
+        lines.push(text);
+        break;
+
+      case "code": {
+        const data = block["code"] as { language?: string } | undefined;
+        const lang = data?.language ?? "";
+        lines.push(`\`\`\`${lang}\n${text}\n\`\`\``);
+        break;
+      }
+
+      case "quote":
+        lines.push(`> ${text}`);
+        break;
+
+      case "callout": {
+        const data = block["callout"] as { icon?: { emoji?: string } } | undefined;
+        const emoji = data?.icon?.emoji ?? "";
+        lines.push(`> ${emoji} ${text}`.trim());
+        break;
+      }
+
+      case "divider":
+        lines.push("---");
+        break;
+
+      case "table": {
+        if (children) {
+          for (const row of children) {
+            const rowData = row["table_row"] as { cells?: NotionRichText[][] } | undefined;
+            if (rowData?.cells) {
+              const cells = rowData.cells.map((cell) => extractRichText(cell));
+              lines.push(`| ${cells.join(" | ")} |`);
+            }
+          }
+        }
+        break;
+      }
+
+      case "table_row":
+        // Handled by table
+        break;
+
+      case "image": {
+        const data = block["image"] as
+          | {
+              type?: string;
+              file?: { url?: string };
+              external?: { url?: string };
+              caption?: NotionRichText[];
+            }
+          | undefined;
+        const url = data?.type === "external" ? data?.external?.url : data?.file?.url;
+        const caption = extractRichText(data?.caption);
+        if (url) {
+          lines.push(`![${caption}](${url})`);
+        } else {
+          lines.push("[image]");
+        }
+        break;
+      }
+
+      case "bookmark": {
+        const data = block["bookmark"] as { url?: string; caption?: NotionRichText[] } | undefined;
+        const caption = extractRichText(data?.caption);
+        const url = data?.url ?? "";
+        lines.push(`[${caption || url}](${url})`);
+        break;
+      }
+
+      case "child_page": {
+        const data = block["child_page"] as { title?: string } | undefined;
+        lines.push(`[${data?.title ?? "Untitled"}](notion://page/${block.id})`);
+        break;
+      }
+
+      default:
+        if (text) lines.push(text);
+        break;
+    }
+
+    // Render nested children (except table children which are handled inline)
+    if (children && block.type !== "table") {
+      const childContent = convertNotionBlocks(children);
+      if (childContent) {
+        const indented = childContent
+          .split("\n")
+          .map((l) => `  ${l}`)
+          .join("\n");
+        lines.push(indented);
+      }
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function extractTitle(result: NotionSearchResult): string {
+  // Direct title field (databases)
+  if (result.title) {
+    return extractRichText(result.title);
+  }
+  // Search through properties for title type
+  if (result.properties) {
+    for (const prop of Object.values(result.properties)) {
+      if (prop.type === "title" && prop.title) {
+        return extractRichText(prop.title as unknown as NotionRichText[]);
+      }
+    }
+  }
+  return "Untitled";
+}
+
+function extractPropertyMetadata(properties: Record<string, NotionProperty>): string[] {
+  const tags: string[] = [];
+  for (const [key, prop] of Object.entries(properties)) {
+    if (prop.type === "title") continue; // Skip title, it's used as the document title
+    switch (prop.type) {
+      case "select":
+        if (prop.select) tags.push(`${key}:${prop.select.name}`);
+        break;
+      case "multi_select":
+        if (prop.multi_select) {
+          for (const s of prop.multi_select) {
+            tags.push(`${key}:${s.name}`);
+          }
+        }
+        break;
+      case "date":
+        if (prop.date) tags.push(`${key}:${prop.date.start}`);
+        break;
+      case "rich_text":
+        if (prop.rich_text) {
+          const text = extractRichText(prop.rich_text as unknown as NotionRichText[]);
+          if (text) tags.push(`${key}:${text}`);
+        }
+        break;
+      default:
+        break;
+    }
+  }
+  return tags;
+}
+
+/** Sync pages and databases from Notion into the knowledge base. */
+export async function syncNotion(
+  db: Database.Database,
+  provider: EmbeddingProvider,
+  config: NotionConfig,
+): Promise<NotionSyncResult> {
+  const log = getLogger();
+
+  if (!config.token.startsWith("secret_") && !config.token.startsWith("ntn_")) {
+    throw new ValidationError("Notion token must start with 'secret_' or 'ntn_'");
+  }
+
+  const result: NotionSyncResult = {
+    pagesIndexed: 0,
+    databasesIndexed: 0,
+    errors: [],
+  };
+
+  const excludeSet = new Set(config.excludePages ?? []);
+
+  log.info({ lastSync: config.lastSync }, "Starting Notion sync");
+  const searchResults = await searchNotion(config.token, config.lastSync);
+  log.info({ count: searchResults.length }, "Found Notion objects");
+
+  for (const item of searchResults) {
+    if (excludeSet.has(item.id)) {
+      log.debug({ id: item.id }, "Skipping excluded page");
+      continue;
+    }
+
+    try {
+      if (item.object === "page") {
+        // Check if this page is a database row (has a database parent)
+        // Database rows are indexed when their parent database is processed
+        if (item.parent?.type === "database_id") {
+          continue;
+        }
+
+        const title = extractTitle(item);
+        const blocks = await fetchBlockChildren(config.token, item.id);
+        const content = convertNotionBlocks(blocks);
+
+        if (!content.trim()) {
+          log.debug({ id: item.id, title }, "Skipping empty page");
+          continue;
+        }
+
+        // Delete existing document for this Notion page before re-indexing
+        const existingDocs = db
+          .prepare("SELECT id FROM documents WHERE url = ?")
+          .all(`notion://page/${item.id}`) as Array<{ id: string }>;
+        for (const doc of existingDocs) {
+          deleteDocument(db, doc.id);
+        }
+
+        await indexDocument(db, provider, {
+          title,
+          content,
+          sourceType: "manual",
+          url: `notion://page/${item.id}`,
+          submittedBy: "crawler",
+        });
+
+        result.pagesIndexed++;
+        log.debug({ id: item.id, title }, "Indexed Notion page");
+      } else if (item.object === "database") {
+        const dbTitle = extractTitle(item);
+        const rows = await queryDatabase(config.token, item.id);
+
+        for (const row of rows) {
+          if (excludeSet.has(row.id)) continue;
+
+          const rowTitle = extractTitle(row);
+          const tags = row.properties ? extractPropertyMetadata(row.properties) : [];
+          const metadataSection = tags.length > 0 ? `\n\nMetadata: ${tags.join(", ")}` : "";
+
+          // Fetch row page content
+          const blocks = await fetchBlockChildren(config.token, row.id);
+          const content = convertNotionBlocks(blocks);
+          const fullContent = `# ${rowTitle}${metadataSection}\n\n${content}`;
+
+          const existingDocs = db
+            .prepare("SELECT id FROM documents WHERE url = ?")
+            .all(`notion://page/${row.id}`) as Array<{ id: string }>;
+          for (const doc of existingDocs) {
+            deleteDocument(db, doc.id);
+          }
+
+          await indexDocument(db, provider, {
+            title: `${dbTitle} — ${rowTitle}`,
+            content: fullContent,
+            sourceType: "manual",
+            url: `notion://page/${row.id}`,
+            submittedBy: "crawler",
+          });
+        }
+
+        result.databasesIndexed++;
+        log.debug({ id: item.id, title: dbTitle, rows: rows.length }, "Indexed Notion database");
+      }
+    } catch (err) {
+      const title = extractTitle(item);
+      const message = err instanceof Error ? err.message : String(err);
+      result.errors.push({ page: title, error: message });
+      log.warn({ id: item.id, err }, "Failed to index Notion item");
+    }
+  }
+
+  log.info(
+    {
+      pagesIndexed: result.pagesIndexed,
+      databasesIndexed: result.databasesIndexed,
+      errors: result.errors.length,
+    },
+    "Notion sync complete",
+  );
+
+  return result;
+}
+
+/** Remove all Notion-sourced documents from the knowledge base. */
+export function disconnectNotion(db: Database.Database): Promise<number> {
+  const log = getLogger();
+  const docs = db.prepare("SELECT id FROM documents WHERE url LIKE 'notion://%'").all() as Array<{
+    id: string;
+  }>;
+  let removed = 0;
+
+  for (const doc of docs) {
+    deleteDocument(db, doc.id);
+    removed++;
+  }
+
+  log.info({ removed }, "Disconnected Notion");
+  return Promise.resolve(removed);
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -119,9 +119,6 @@ export {
 } from "../connectors/obsidian.js";
 export type { ObsidianConfig, SyncResult } from "../connectors/obsidian.js";
 
-export { loadConnectorConfig, saveConnectorConfig } from "../connectors/index.js";
-export type { ConnectorConfig } from "../connectors/index.js";
-
 export { registerProvider, createEmbeddingProvider } from "../providers/index.js";
 export type { EmbeddingProvider } from "../providers/embedding.js";
 export type { ProviderFactory } from "../providers/index.js";
@@ -143,3 +140,14 @@ export type { KnowledgeGraph, GraphNode, GraphEdge, GraphOptions } from "./graph
 
 export { startApiServer } from "../api/server.js";
 export type { ApiServerOptions } from "../api/server.js";
+
+export { syncNotion, convertNotionBlocks, disconnectNotion } from "../connectors/notion.js";
+export type { NotionConfig, NotionSyncResult, NotionBlock } from "../connectors/notion.js";
+export {
+  saveDbConnectorConfig,
+  loadDbConnectorConfig,
+  deleteDbConnectorConfig,
+  loadConnectorConfig,
+  saveConnectorConfig,
+} from "../connectors/index.js";
+export type { ConnectorConfig } from "../connectors/index.js";

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -2,7 +2,7 @@ import type Database from "better-sqlite3";
 import { DatabaseError } from "../errors.js";
 import { getLogger } from "../logger.js";
 
-const SCHEMA_VERSION = 8;
+const SCHEMA_VERSION = 9;
 
 const MIGRATIONS: Record<number, string> = {
   1: `
@@ -171,6 +171,15 @@ const MIGRATIONS: Record<number, string> = {
     CREATE INDEX IF NOT EXISTS idx_documents_pack ON documents(pack_name);
 
     INSERT INTO schema_version (version) VALUES (8);
+  `,
+  9: `
+    CREATE TABLE IF NOT EXISTS connector_configs (
+      type TEXT PRIMARY KEY,
+      config_json TEXT NOT NULL,
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    INSERT INTO schema_version (version) VALUES (9);
   `,
 };
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -638,6 +638,41 @@ async function main(): Promise<void> {
     }),
   );
 
+  // Tool: sync-notion
+  server.tool(
+    "sync-notion",
+    "Sync pages and databases from a connected Notion workspace into the knowledge base",
+    {
+      token: z.string().describe("Notion integration token (secret_... or ntn_...)"),
+      lastSync: z
+        .string()
+        .optional()
+        .describe("ISO-8601 timestamp — only sync pages edited after this time"),
+      excludePages: z
+        .array(z.string())
+        .optional()
+        .describe("List of Notion page/database IDs to exclude from sync"),
+    },
+    withErrorHandling(async (params) => {
+      const { syncNotion } = await import("../connectors/notion.js");
+      const result = await syncNotion(db, provider, {
+        token: params.token,
+        lastSync: params.lastSync,
+        excludePages: params.excludePages,
+      });
+
+      const text =
+        `Notion sync complete.\n` +
+        `Pages indexed: ${result.pagesIndexed}\n` +
+        `Databases indexed: ${result.databasesIndexed}` +
+        (result.errors.length > 0
+          ? `\nErrors: ${result.errors.map((e) => `${e.page}: ${e.error}`).join("; ")}`
+          : "");
+
+      return { content: [{ type: "text" as const, text }] };
+    }),
+  );
+
   // Tool: sync-obsidian-vault
   server.tool(
     "sync-obsidian-vault",

--- a/tests/unit/notion.test.ts
+++ b/tests/unit/notion.test.ts
@@ -1,0 +1,555 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ValidationError, FetchError } from "../../src/errors.js";
+import { createTestDbWithVec } from "../fixtures/test-db.js";
+import { MockEmbeddingProvider } from "../fixtures/mock-provider.js";
+import type Database from "better-sqlite3";
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const { syncNotion, convertNotionBlocks, disconnectNotion } =
+  await import("../../src/connectors/notion.js");
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
+  } as Response;
+}
+
+describe("convertNotionBlocks", () => {
+  it("should convert paragraph blocks", () => {
+    const blocks = [
+      { id: "1", type: "paragraph", paragraph: { rich_text: [{ plain_text: "Hello world" }] } },
+    ];
+    expect(convertNotionBlocks(blocks)).toBe("Hello world");
+  });
+
+  it("should convert heading blocks", () => {
+    const blocks = [
+      { id: "1", type: "heading_1", heading_1: { rich_text: [{ plain_text: "Title" }] } },
+      { id: "2", type: "heading_2", heading_2: { rich_text: [{ plain_text: "Subtitle" }] } },
+      { id: "3", type: "heading_3", heading_3: { rich_text: [{ plain_text: "Section" }] } },
+    ];
+    expect(convertNotionBlocks(blocks)).toBe("# Title\n## Subtitle\n### Section");
+  });
+
+  it("should convert bulleted and numbered list items", () => {
+    const blocks = [
+      {
+        id: "1",
+        type: "bulleted_list_item",
+        bulleted_list_item: { rich_text: [{ plain_text: "Bullet" }] },
+      },
+      {
+        id: "2",
+        type: "numbered_list_item",
+        numbered_list_item: { rich_text: [{ plain_text: "Number" }] },
+      },
+    ];
+    expect(convertNotionBlocks(blocks)).toBe("- Bullet\n1. Number");
+  });
+
+  it("should convert to_do blocks with checked and unchecked states", () => {
+    const blocks = [
+      {
+        id: "1",
+        type: "to_do",
+        to_do: { rich_text: [{ plain_text: "Done" }], checked: true },
+      },
+      {
+        id: "2",
+        type: "to_do",
+        to_do: { rich_text: [{ plain_text: "Pending" }], checked: false },
+      },
+    ];
+    expect(convertNotionBlocks(blocks)).toBe("- [x] Done\n- [ ] Pending");
+  });
+
+  it("should convert code blocks with language", () => {
+    const blocks = [
+      {
+        id: "1",
+        type: "code",
+        code: { rich_text: [{ plain_text: "const x = 1;" }], language: "typescript" },
+      },
+    ];
+    expect(convertNotionBlocks(blocks)).toBe("```typescript\nconst x = 1;\n```");
+  });
+
+  it("should convert quote blocks", () => {
+    const blocks = [
+      { id: "1", type: "quote", quote: { rich_text: [{ plain_text: "A wise quote" }] } },
+    ];
+    expect(convertNotionBlocks(blocks)).toBe("> A wise quote");
+  });
+
+  it("should convert callout blocks with emoji", () => {
+    const blocks = [
+      {
+        id: "1",
+        type: "callout",
+        callout: { rich_text: [{ plain_text: "Important note" }], icon: { emoji: "⚠️" } },
+      },
+    ];
+    expect(convertNotionBlocks(blocks)).toBe("> ⚠️ Important note");
+  });
+
+  it("should convert divider blocks", () => {
+    const blocks = [{ id: "1", type: "divider" }];
+    expect(convertNotionBlocks(blocks)).toBe("---");
+  });
+
+  it("should convert image blocks", () => {
+    const blocks = [
+      {
+        id: "1",
+        type: "image",
+        image: {
+          type: "external",
+          external: { url: "https://example.com/img.png" },
+          caption: [{ plain_text: "My image" }],
+        },
+      },
+    ];
+    expect(convertNotionBlocks(blocks)).toBe("![My image](https://example.com/img.png)");
+  });
+
+  it("should convert image blocks without URL", () => {
+    const blocks = [
+      {
+        id: "1",
+        type: "image",
+        image: { type: "file", file: {} },
+      },
+    ];
+    expect(convertNotionBlocks(blocks)).toBe("[image]");
+  });
+
+  it("should convert bookmark blocks", () => {
+    const blocks = [
+      {
+        id: "1",
+        type: "bookmark",
+        bookmark: { url: "https://example.com", caption: [{ plain_text: "Example" }] },
+      },
+    ];
+    expect(convertNotionBlocks(blocks)).toBe("[Example](https://example.com)");
+  });
+
+  it("should convert child_page blocks", () => {
+    const blocks = [{ id: "abc-123", type: "child_page", child_page: { title: "Sub Page" } }];
+    expect(convertNotionBlocks(blocks)).toBe("[Sub Page](notion://page/abc-123)");
+  });
+
+  it("should convert toggle blocks", () => {
+    const blocks = [
+      { id: "1", type: "toggle", toggle: { rich_text: [{ plain_text: "Toggle content" }] } },
+    ];
+    expect(convertNotionBlocks(blocks)).toBe("Toggle content");
+  });
+
+  it("should convert table blocks with rows", () => {
+    const blocks = [
+      {
+        id: "1",
+        type: "table",
+        children: [
+          {
+            id: "r1",
+            type: "table_row",
+            table_row: { cells: [[{ plain_text: "A" }], [{ plain_text: "B" }]] },
+          },
+          {
+            id: "r2",
+            type: "table_row",
+            table_row: { cells: [[{ plain_text: "1" }], [{ plain_text: "2" }]] },
+          },
+        ],
+      },
+    ];
+    expect(convertNotionBlocks(blocks)).toBe("| A | B |\n| 1 | 2 |");
+  });
+
+  it("should handle nested blocks (children)", () => {
+    const blocks = [
+      {
+        id: "1",
+        type: "bulleted_list_item",
+        bulleted_list_item: { rich_text: [{ plain_text: "Parent" }] },
+        children: [
+          {
+            id: "2",
+            type: "bulleted_list_item",
+            bulleted_list_item: { rich_text: [{ plain_text: "Child" }] },
+          },
+        ],
+      },
+    ];
+    const result = convertNotionBlocks(blocks);
+    expect(result).toContain("- Parent");
+    expect(result).toContain("  - Child");
+  });
+
+  it("should handle blocks with no rich_text gracefully", () => {
+    const blocks = [{ id: "1", type: "paragraph", paragraph: {} }];
+    expect(convertNotionBlocks(blocks)).toBe("");
+  });
+
+  it("should handle unknown block types with text", () => {
+    const blocks = [
+      {
+        id: "1",
+        type: "embed",
+        embed: { rich_text: [{ plain_text: "embedded content" }] },
+      },
+    ];
+    expect(convertNotionBlocks(blocks)).toBe("embedded content");
+  });
+});
+
+describe("syncNotion", () => {
+  let db: Database.Database;
+  let provider: MockEmbeddingProvider;
+
+  beforeEach(() => {
+    db = createTestDbWithVec();
+    provider = new MockEmbeddingProvider();
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("should reject invalid tokens", async () => {
+    await expect(syncNotion(db, provider, { token: "bad-token" })).rejects.toThrow(ValidationError);
+  });
+
+  it("should index pages from search results", async () => {
+    // Search returns one page
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        results: [
+          {
+            object: "page",
+            id: "page-1",
+            last_edited_time: "2024-01-01T00:00:00Z",
+            properties: {
+              title: { type: "title", title: [{ plain_text: "Test Page" }] },
+            },
+          },
+        ],
+        has_more: false,
+        next_cursor: null,
+      }),
+    );
+    // Fetch blocks for the page
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        results: [
+          {
+            id: "b1",
+            type: "paragraph",
+            paragraph: { rich_text: [{ plain_text: "Page content here" }] },
+            has_children: false,
+          },
+        ],
+        has_more: false,
+        next_cursor: null,
+      }),
+    );
+
+    const result = await syncNotion(db, provider, { token: "secret_test123" });
+
+    expect(result.pagesIndexed).toBe(1);
+    expect(result.databasesIndexed).toBe(0);
+    expect(result.errors).toHaveLength(0);
+
+    // Verify the document was indexed
+    const docs = db.prepare("SELECT * FROM documents WHERE url = ?").all("notion://page/page-1");
+    expect(docs).toHaveLength(1);
+  });
+
+  it("should index database entries", async () => {
+    // Search returns one database
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        results: [
+          {
+            object: "database",
+            id: "db-1",
+            last_edited_time: "2024-01-01T00:00:00Z",
+            title: [{ plain_text: "My Database" }],
+          },
+        ],
+        has_more: false,
+        next_cursor: null,
+      }),
+    );
+    // Query database returns rows
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        results: [
+          {
+            object: "page",
+            id: "row-1",
+            last_edited_time: "2024-01-01T00:00:00Z",
+            properties: {
+              Name: { type: "title", title: [{ plain_text: "Row 1" }] },
+              Status: { type: "select", select: { name: "Active" } },
+              Tags: { type: "multi_select", multi_select: [{ name: "tag1" }, { name: "tag2" }] },
+            },
+          },
+        ],
+        has_more: false,
+        next_cursor: null,
+      }),
+    );
+    // Fetch blocks for the row
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        results: [
+          {
+            id: "rb1",
+            type: "paragraph",
+            paragraph: { rich_text: [{ plain_text: "Row content" }] },
+            has_children: false,
+          },
+        ],
+        has_more: false,
+        next_cursor: null,
+      }),
+    );
+
+    const result = await syncNotion(db, provider, { token: "secret_test123" });
+
+    expect(result.databasesIndexed).toBe(1);
+    expect(result.errors).toHaveLength(0);
+
+    const docs = db.prepare("SELECT * FROM documents WHERE url = ?").all("notion://page/row-1");
+    expect(docs).toHaveLength(1);
+  });
+
+  it("should skip excluded pages", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        results: [
+          {
+            object: "page",
+            id: "excluded-page",
+            last_edited_time: "2024-01-01T00:00:00Z",
+            properties: {
+              title: { type: "title", title: [{ plain_text: "Excluded" }] },
+            },
+          },
+        ],
+        has_more: false,
+        next_cursor: null,
+      }),
+    );
+
+    const result = await syncNotion(db, provider, {
+      token: "secret_test123",
+      excludePages: ["excluded-page"],
+    });
+
+    expect(result.pagesIndexed).toBe(0);
+    expect(mockFetch).toHaveBeenCalledTimes(1); // Only the search call
+  });
+
+  it("should use lastSync for incremental sync", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ results: [], has_more: false, next_cursor: null }),
+    );
+
+    await syncNotion(db, provider, {
+      token: "secret_test123",
+      lastSync: "2024-01-01T00:00:00Z",
+    });
+
+    const callArgs = mockFetch.mock.calls[0] as [string, RequestInit] | undefined;
+    const callBody = JSON.parse(callArgs?.[1]?.body as string) as Record<string, unknown>;
+    expect(callBody).toHaveProperty("filter");
+    const filter = callBody["filter"] as Record<string, unknown>;
+    expect(filter).toHaveProperty("timestamp", "last_edited_time");
+  });
+
+  it("should handle auth failure (401)", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ message: "Unauthorized" }, 401));
+
+    await expect(syncNotion(db, provider, { token: "secret_bad" })).rejects.toThrow(
+      ValidationError,
+    );
+  });
+
+  it("should handle rate limiting (429)", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ message: "Rate limited" }, 429));
+
+    await expect(syncNotion(db, provider, { token: "secret_test123" })).rejects.toThrow(FetchError);
+  });
+
+  it("should collect errors for individual pages", async () => {
+    // Search returns one page
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        results: [
+          {
+            object: "page",
+            id: "err-page",
+            last_edited_time: "2024-01-01T00:00:00Z",
+            properties: {
+              title: { type: "title", title: [{ plain_text: "Error Page" }] },
+            },
+          },
+        ],
+        has_more: false,
+        next_cursor: null,
+      }),
+    );
+    // Fetching blocks fails
+    mockFetch.mockResolvedValueOnce(jsonResponse({ message: "Not found" }, 404));
+
+    const result = await syncNotion(db, provider, { token: "secret_test123" });
+
+    expect(result.pagesIndexed).toBe(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]!.page).toBe("Error Page");
+  });
+
+  it("should skip empty pages", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        results: [
+          {
+            object: "page",
+            id: "empty-page",
+            last_edited_time: "2024-01-01T00:00:00Z",
+            properties: {
+              title: { type: "title", title: [{ plain_text: "Empty" }] },
+            },
+          },
+        ],
+        has_more: false,
+        next_cursor: null,
+      }),
+    );
+    // Blocks returns empty
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ results: [], has_more: false, next_cursor: null }),
+    );
+
+    const result = await syncNotion(db, provider, { token: "secret_test123" });
+    expect(result.pagesIndexed).toBe(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("should skip database row pages", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        results: [
+          {
+            object: "page",
+            id: "db-row-page",
+            last_edited_time: "2024-01-01T00:00:00Z",
+            parent: { type: "database_id", database_id: "parent-db" },
+            properties: {
+              title: { type: "title", title: [{ plain_text: "DB Row" }] },
+            },
+          },
+        ],
+        has_more: false,
+        next_cursor: null,
+      }),
+    );
+
+    const result = await syncNotion(db, provider, { token: "secret_test123" });
+    expect(result.pagesIndexed).toBe(0);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("should handle pagination in search results", async () => {
+    // First page
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        results: [
+          {
+            object: "page",
+            id: "page-a",
+            last_edited_time: "2024-01-01T00:00:00Z",
+            properties: { title: { type: "title", title: [{ plain_text: "Page A" }] } },
+          },
+        ],
+        has_more: true,
+        next_cursor: "cursor-1",
+      }),
+    );
+    // Second page of search
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ results: [], has_more: false, next_cursor: null }),
+    );
+    // Blocks for page-a
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        results: [
+          {
+            id: "b1",
+            type: "paragraph",
+            paragraph: { rich_text: [{ plain_text: "Content" }] },
+            has_children: false,
+          },
+        ],
+        has_more: false,
+        next_cursor: null,
+      }),
+    );
+
+    const result = await syncNotion(db, provider, { token: "secret_test123" });
+    expect(result.pagesIndexed).toBe(1);
+    // Two search calls + one blocks call
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("disconnectNotion", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDbWithVec();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("should remove Notion documents", async () => {
+    // Insert some Notion documents
+    db.prepare(
+      `INSERT INTO documents (id, source_type, title, content, url, content_hash, submitted_by)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run("d1", "manual", "Notion Page", "content", "notion://page/p1", "hash1", "crawler");
+    db.prepare(
+      `INSERT INTO documents (id, source_type, title, content, url, content_hash, submitted_by)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run("d2", "manual", "Regular Doc", "content", "https://example.com", "hash2", "manual");
+    db.prepare(
+      `INSERT INTO documents (id, source_type, title, content, url, content_hash, submitted_by)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run("d3", "manual", "Another Notion", "content", "notion://page/p2", "hash3", "crawler");
+
+    const removed = await disconnectNotion(db);
+    expect(removed).toBe(2);
+
+    // Regular doc should remain
+    const remaining = db.prepare("SELECT * FROM documents").all();
+    expect(remaining).toHaveLength(1);
+  });
+
+  it("should return 0 when no Notion documents exist", async () => {
+    const removed = await disconnectNotion(db);
+    expect(removed).toBe(0);
+  });
+});

--- a/tests/unit/schema.test.ts
+++ b/tests/unit/schema.test.ts
@@ -35,7 +35,7 @@ describe("database schema", () => {
       const version = db.prepare("SELECT MAX(version) as v FROM schema_version").get() as {
         v: number;
       };
-      expect(version.v).toBe(8);
+      expect(version.v).toBe(9);
     });
 
     it("should create expected indexes", () => {


### PR DESCRIPTION
## Summary

Adds a Notion connector that indexes pages and databases into the LibScope knowledge base.

### New files
- **`src/connectors/notion.ts`** — Core connector: `syncNotion`, `convertNotionBlocks`, `disconnectNotion`
- **`src/connectors/index.ts`** — Shared connector config helpers (`saveConnectorConfig`, `loadConnectorConfig`, `deleteConnectorConfig`)
- **`tests/unit/notion.test.ts`** — 30 unit tests covering block conversion, page/database sync, incremental sync, error handling, pagination, and disconnect

### Modified files
- **`src/db/schema.ts`** — Migration v9: `connector_configs` table
- **`src/core/index.ts`** — Re-exports connector types
- **`src/cli/index.ts`** — CLI commands: `connect notion --token`, `disconnect notion`
- **`src/mcp/server.ts`** — MCP tool: `sync-notion`
- **`tests/unit/schema.test.ts`** — Updated schema version assertion

### Features
- Notion API v2022-06-28 via native fetch (no dependencies added)
- Block → Markdown conversion for all major block types (headings, lists, code, tables, images, etc.)
- Database row indexing with property metadata extraction (select, multi_select, date → tags)
- Incremental sync via `last_edited_time` filter
- Page exclusion support
- Nested block recursion
- Error collection per page (sync continues on individual failures)

### Testing
- 30 new tests, 400 total — all passing
- Typecheck, lint, format all clean

Closes #152