### PR TITLE
feat: add REST API server with OpenAPI spec (closes #150)

### DIFF
--- a/src/api/middleware.ts
+++ b/src/api/middleware.ts
@@ -1,0 +1,69 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+/** Set CORS headers and handle OPTIONS preflight. Returns true if request was handled (preflight). */
+export function corsMiddleware(
+  req: IncomingMessage,
+  res: ServerResponse,
+  origins: string[],
+): boolean {
+  const origin = req.headers["origin"] ?? "*";
+  const allowedOrigin = origins.includes("*") ? "*" : origins.includes(origin) ? origin : "";
+
+  if (allowedOrigin) {
+    res.setHeader("Access-Control-Allow-Origin", allowedOrigin);
+  }
+  res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+  res.setHeader("Access-Control-Max-Age", "86400");
+
+  if (req.method === "OPTIONS") {
+    res.writeHead(204);
+    res.end();
+    return true;
+  }
+  return false;
+}
+
+/** Parse the request body as JSON. Returns the parsed object or null on failure. */
+export async function parseJsonBody(req: IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      const raw = Buffer.concat(chunks).toString("utf-8");
+      if (!raw) {
+        resolve(null);
+        return;
+      }
+      try {
+        resolve(JSON.parse(raw));
+      } catch {
+        reject(new Error("Invalid JSON body"));
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+/** Send a JSON success response with consistent envelope. */
+export function sendJson(res: ServerResponse, status: number, data: unknown, took?: number): void {
+  const body: Record<string, unknown> = { data };
+  if (took !== undefined) {
+    body["meta"] = { took };
+  }
+  const json = JSON.stringify(body);
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(json);
+}
+
+/** Send a JSON error response with consistent envelope. */
+export function sendError(
+  res: ServerResponse,
+  status: number,
+  code: string,
+  message: string,
+): void {
+  const json = JSON.stringify({ error: { code, message } });
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(json);
+}

--- a/src/api/openapi.ts
+++ b/src/api/openapi.ts
@@ -1,0 +1,411 @@
+export const OPENAPI_SPEC = {
+  openapi: "3.0.3",
+  info: {
+    title: "LibScope REST API",
+    version: "1.0.0",
+    description: "AI-powered knowledge base with semantic search, document indexing, and RAG Q&A.",
+  },
+  servers: [{ url: "http://localhost:3378", description: "Local development" }],
+  paths: {
+    "/api/v1/search": {
+      get: {
+        summary: "Semantic search",
+        operationId: "searchDocuments",
+        parameters: [
+          {
+            name: "q",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+            description: "Search query",
+          },
+          {
+            name: "topic",
+            in: "query",
+            schema: { type: "string" },
+            description: "Filter by topic",
+          },
+          { name: "tag", in: "query", schema: { type: "string" }, description: "Filter by tag" },
+          {
+            name: "limit",
+            in: "query",
+            schema: { type: "integer", default: 10 },
+            description: "Max results",
+          },
+        ],
+        responses: {
+          "200": {
+            description: "Search results",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/SearchResponse" },
+                example: {
+                  data: {
+                    results: [
+                      {
+                        documentId: "abc123",
+                        title: "Getting Started",
+                        content: "...",
+                        score: 0.95,
+                      },
+                    ],
+                    totalCount: 1,
+                  },
+                  meta: { took: 42 },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/v1/documents": {
+      get: {
+        summary: "List documents with filters",
+        operationId: "listDocuments",
+        parameters: [
+          { name: "topic", in: "query", schema: { type: "string" } },
+          { name: "tag", in: "query", schema: { type: "string" } },
+          { name: "limit", in: "query", schema: { type: "integer", default: 50 } },
+          { name: "offset", in: "query", schema: { type: "integer", default: 0 } },
+        ],
+        responses: {
+          "200": {
+            description: "List of documents",
+            content: {
+              "application/json": { schema: { $ref: "#/components/schemas/DocumentListResponse" } },
+            },
+          },
+        },
+      },
+      post: {
+        summary: "Index a new document",
+        operationId: "indexDocument",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/IndexDocumentRequest" },
+              example: { content: "# Guide\nHow to...", title: "My Guide", topic: "tutorials" },
+            },
+          },
+        },
+        responses: {
+          "201": {
+            description: "Document indexed",
+            content: {
+              "application/json": { schema: { $ref: "#/components/schemas/DocumentResponse" } },
+            },
+          },
+        },
+      },
+    },
+    "/api/v1/documents/{id}": {
+      get: {
+        summary: "Get a single document",
+        operationId: "getDocument",
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+        responses: {
+          "200": {
+            description: "Document found",
+            content: {
+              "application/json": { schema: { $ref: "#/components/schemas/DocumentResponse" } },
+            },
+          },
+          "404": { description: "Document not found" },
+        },
+      },
+      delete: {
+        summary: "Delete a document",
+        operationId: "deleteDocument",
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+        responses: {
+          "200": { description: "Document deleted" },
+          "404": { description: "Document not found" },
+        },
+      },
+    },
+    "/api/v1/documents/url": {
+      post: {
+        summary: "Index document from URL",
+        operationId: "indexFromUrl",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/IndexFromUrlRequest" },
+              example: { url: "https://example.com/docs", topic: "guides" },
+            },
+          },
+        },
+        responses: {
+          "201": {
+            description: "Document indexed from URL",
+            content: {
+              "application/json": { schema: { $ref: "#/components/schemas/DocumentResponse" } },
+            },
+          },
+        },
+      },
+    },
+    "/api/v1/ask": {
+      post: {
+        summary: "RAG Q&A — ask a question",
+        operationId: "askQuestion",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/AskRequest" },
+              example: { question: "How do I configure authentication?", topic: "security" },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "Answer with sources",
+            content: {
+              "application/json": { schema: { $ref: "#/components/schemas/AskResponse" } },
+            },
+          },
+        },
+      },
+    },
+    "/api/v1/topics": {
+      get: {
+        summary: "List all topics",
+        operationId: "listTopics",
+        responses: {
+          "200": {
+            description: "List of topics",
+            content: {
+              "application/json": { schema: { $ref: "#/components/schemas/TopicListResponse" } },
+            },
+          },
+        },
+      },
+      post: {
+        summary: "Create a topic",
+        operationId: "createTopic",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/CreateTopicRequest" },
+              example: { name: "tutorials", parentId: null },
+            },
+          },
+        },
+        responses: {
+          "201": {
+            description: "Topic created",
+            content: {
+              "application/json": { schema: { $ref: "#/components/schemas/TopicResponse" } },
+            },
+          },
+        },
+      },
+    },
+    "/api/v1/tags": {
+      get: {
+        summary: "List all tags",
+        operationId: "listTags",
+        responses: {
+          "200": {
+            description: "List of tags",
+            content: {
+              "application/json": { schema: { $ref: "#/components/schemas/TagListResponse" } },
+            },
+          },
+        },
+      },
+    },
+    "/api/v1/documents/{id}/tags": {
+      post: {
+        summary: "Add tags to a document",
+        operationId: "addTagsToDocument",
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/AddTagsRequest" },
+              example: { tags: ["typescript", "api"] },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "Tags added" },
+        },
+      },
+    },
+    "/api/v1/stats": {
+      get: {
+        summary: "Usage statistics",
+        operationId: "getStats",
+        responses: {
+          "200": {
+            description: "Statistics",
+            content: {
+              "application/json": { schema: { $ref: "#/components/schemas/StatsResponse" } },
+            },
+          },
+        },
+      },
+    },
+    "/api/v1/health": {
+      get: {
+        summary: "Health check",
+        operationId: "healthCheck",
+        responses: {
+          "200": {
+            description: "Service health",
+            content: {
+              "application/json": {
+                example: { data: { status: "ok", docCount: 42, dbSize: 1048576 } },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/openapi.json": {
+      get: {
+        summary: "OpenAPI 3.0 specification",
+        operationId: "getOpenApiSpec",
+        responses: {
+          "200": { description: "OpenAPI spec JSON" },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      SearchResponse: {
+        type: "object",
+        properties: {
+          data: {
+            type: "object",
+            properties: {
+              results: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    documentId: { type: "string" },
+                    title: { type: "string" },
+                    content: { type: "string" },
+                    score: { type: "number" },
+                  },
+                },
+              },
+              totalCount: { type: "integer" },
+            },
+          },
+          meta: { type: "object", properties: { took: { type: "number" } } },
+        },
+      },
+      DocumentListResponse: {
+        type: "object",
+        properties: { data: { type: "array", items: { $ref: "#/components/schemas/Document" } } },
+      },
+      DocumentResponse: {
+        type: "object",
+        properties: { data: { $ref: "#/components/schemas/Document" } },
+      },
+      Document: {
+        type: "object",
+        properties: {
+          id: { type: "string" },
+          title: { type: "string" },
+          content: { type: "string" },
+          sourceType: { type: "string" },
+          library: { type: "string", nullable: true },
+          topicId: { type: "string", nullable: true },
+          createdAt: { type: "string", format: "date-time" },
+          updatedAt: { type: "string", format: "date-time" },
+        },
+      },
+      IndexDocumentRequest: {
+        type: "object",
+        required: ["content", "title"],
+        properties: {
+          content: { type: "string" },
+          title: { type: "string" },
+          topic: { type: "string" },
+          tags: { type: "array", items: { type: "string" } },
+          source: { type: "string" },
+        },
+      },
+      IndexFromUrlRequest: {
+        type: "object",
+        required: ["url"],
+        properties: {
+          url: { type: "string", format: "uri" },
+          topic: { type: "string" },
+        },
+      },
+      AskRequest: {
+        type: "object",
+        required: ["question"],
+        properties: {
+          question: { type: "string" },
+          topic: { type: "string" },
+        },
+      },
+      AskResponse: {
+        type: "object",
+        properties: {
+          data: {
+            type: "object",
+            properties: {
+              answer: { type: "string" },
+              sources: { type: "array", items: { type: "object" } },
+              model: { type: "string" },
+            },
+          },
+        },
+      },
+      CreateTopicRequest: {
+        type: "object",
+        required: ["name"],
+        properties: {
+          name: { type: "string" },
+          parentId: { type: "string", nullable: true },
+        },
+      },
+      TopicResponse: {
+        type: "object",
+        properties: { data: { type: "object" } },
+      },
+      TopicListResponse: {
+        type: "object",
+        properties: { data: { type: "array", items: { type: "object" } } },
+      },
+      TagListResponse: {
+        type: "object",
+        properties: { data: { type: "array", items: { type: "object" } } },
+      },
+      AddTagsRequest: {
+        type: "object",
+        required: ["tags"],
+        properties: { tags: { type: "array", items: { type: "string" } } },
+      },
+      StatsResponse: {
+        type: "object",
+        properties: { data: { $ref: "#/components/schemas/Stats" } },
+      },
+      Stats: {
+        type: "object",
+        properties: {
+          totalDocuments: { type: "integer" },
+          totalChunks: { type: "integer" },
+          totalTopics: { type: "integer" },
+          databaseSizeBytes: { type: "integer" },
+          totalSearches: { type: "integer" },
+          avgLatencyMs: { type: "number" },
+        },
+      },
+    },
+  },
+} as const;

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1,0 +1,326 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { URL } from "node:url";
+import type Database from "better-sqlite3";
+import { performance } from "node:perf_hooks";
+import type { EmbeddingProvider } from "../providers/embedding.js";
+import {
+  searchDocuments,
+  listDocuments,
+  getDocument,
+  indexDocument,
+  deleteDocument,
+  listTopics,
+  createTopic,
+  listTags,
+  addTagsToDocument,
+  getStats,
+  fetchAndConvert,
+  askQuestion,
+  createLlmProvider,
+} from "../core/index.js";
+import { loadConfig } from "../config.js";
+import { DocumentNotFoundError, LibScopeError } from "../errors.js";
+import { getLogger } from "../logger.js";
+import { parseJsonBody, sendJson, sendError } from "./middleware.js";
+import { OPENAPI_SPEC } from "./openapi.js";
+
+function parseUrl(req: IncomingMessage): URL {
+  return new URL(req.url ?? "/", `http://${req.headers["host"] ?? "localhost"}`);
+}
+
+function extractPathSegments(pathname: string): string[] {
+  return pathname.split("/").filter(Boolean);
+}
+
+/** Match a path like /api/v1/documents/:id and return the id, or null. */
+function matchDocumentId(segments: string[]): string | null {
+  // ["api", "v1", "documents", "<id>"]
+  if (
+    segments.length === 4 &&
+    segments[0] === "api" &&
+    segments[1] === "v1" &&
+    segments[2] === "documents"
+  ) {
+    const id = segments[3];
+    // Exclude sub-paths that are named routes
+    if (id === "url") return null;
+    return id ?? null;
+  }
+  return null;
+}
+
+/** Match /api/v1/documents/:id/tags */
+function matchDocumentTags(segments: string[]): string | null {
+  if (
+    segments.length === 5 &&
+    segments[0] === "api" &&
+    segments[1] === "v1" &&
+    segments[2] === "documents" &&
+    segments[4] === "tags"
+  ) {
+    return segments[3] ?? null;
+  }
+  return null;
+}
+
+export async function handleRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  db: Database.Database,
+  provider: EmbeddingProvider,
+): Promise<void> {
+  const log = getLogger();
+  const start = performance.now();
+  const url = parseUrl(req);
+  const pathname = url.pathname;
+  const method = req.method ?? "GET";
+  const segments = extractPathSegments(pathname);
+
+  try {
+    // OpenAPI spec
+    if (pathname === "/openapi.json" && method === "GET") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(OPENAPI_SPEC));
+      return;
+    }
+
+    // Health check
+    if (pathname === "/api/v1/health" && method === "GET") {
+      const stats = getStats(db);
+      const took = Math.round(performance.now() - start);
+      sendJson(
+        res,
+        200,
+        { status: "ok", docCount: stats.totalDocuments, dbSize: stats.databaseSizeBytes },
+        took,
+      );
+      return;
+    }
+
+    // Search
+    if (pathname === "/api/v1/search" && method === "GET") {
+      const q = url.searchParams.get("q") ?? "";
+      if (!q) {
+        sendError(res, 400, "VALIDATION_ERROR", "Query parameter 'q' is required");
+        return;
+      }
+      const topic = url.searchParams.get("topic") ?? undefined;
+      const tag = url.searchParams.get("tag") ?? undefined;
+      const limit = url.searchParams.has("limit")
+        ? parseInt(url.searchParams.get("limit")!, 10)
+        : undefined;
+      const tags = tag ? [tag] : undefined;
+
+      const result = await searchDocuments(db, provider, { query: q, topic, tags, limit });
+      const took = Math.round(performance.now() - start);
+      sendJson(res, 200, result, took);
+      return;
+    }
+
+    // List documents
+    if (pathname === "/api/v1/documents" && method === "GET") {
+      const topicId = url.searchParams.get("topic") ?? undefined;
+      const limit = url.searchParams.has("limit")
+        ? parseInt(url.searchParams.get("limit")!, 10)
+        : undefined;
+      const docs = listDocuments(db, { topicId, limit });
+      const took = Math.round(performance.now() - start);
+      sendJson(res, 200, docs, took);
+      return;
+    }
+
+    // Index new document
+    if (pathname === "/api/v1/documents" && method === "POST") {
+      const body = await parseJsonBody(req);
+      if (!body || typeof body !== "object") {
+        sendError(res, 400, "VALIDATION_ERROR", "Request body must be a JSON object");
+        return;
+      }
+      const b = body as Record<string, unknown>;
+      if (typeof b["content"] !== "string" || typeof b["title"] !== "string") {
+        sendError(
+          res,
+          400,
+          "VALIDATION_ERROR",
+          "Fields 'content' and 'title' are required strings",
+        );
+        return;
+      }
+
+      const topicId = typeof b["topic"] === "string" ? b["topic"] : undefined;
+      const source = typeof b["source"] === "string" ? b["source"] : undefined;
+      const sourceType =
+        source === "library" ||
+        source === "topic" ||
+        source === "manual" ||
+        source === "model-generated"
+          ? source
+          : "manual";
+
+      const doc = await indexDocument(db, provider, {
+        content: b["content"],
+        title: b["title"],
+        sourceType,
+        topicId,
+      });
+
+      // Add tags if provided
+      if (Array.isArray(b["tags"])) {
+        const tagNames = (b["tags"] as unknown[]).filter((t): t is string => typeof t === "string");
+        if (tagNames.length > 0) {
+          addTagsToDocument(db, doc.id, tagNames);
+        }
+      }
+
+      const took = Math.round(performance.now() - start);
+      sendJson(res, 201, doc, took);
+      return;
+    }
+
+    // Index from URL
+    if (pathname === "/api/v1/documents/url" && method === "POST") {
+      const body = await parseJsonBody(req);
+      if (!body || typeof body !== "object") {
+        sendError(res, 400, "VALIDATION_ERROR", "Request body must be a JSON object");
+        return;
+      }
+      const b = body as Record<string, unknown>;
+      if (typeof b["url"] !== "string") {
+        sendError(res, 400, "VALIDATION_ERROR", "Field 'url' is required");
+        return;
+      }
+      const fetched = await fetchAndConvert(b["url"]);
+      const topicId = typeof b["topic"] === "string" ? b["topic"] : undefined;
+      const doc = await indexDocument(db, provider, {
+        content: fetched.content,
+        title: fetched.title,
+        sourceType: "manual",
+        url: b["url"],
+        topicId,
+      });
+      const took = Math.round(performance.now() - start);
+      sendJson(res, 201, doc, took);
+      return;
+    }
+
+    // Ask question (RAG)
+    if (pathname === "/api/v1/ask" && method === "POST") {
+      const body = await parseJsonBody(req);
+      if (!body || typeof body !== "object") {
+        sendError(res, 400, "VALIDATION_ERROR", "Request body must be a JSON object");
+        return;
+      }
+      const b = body as Record<string, unknown>;
+      if (typeof b["question"] !== "string") {
+        sendError(res, 400, "VALIDATION_ERROR", "Field 'question' is required");
+        return;
+      }
+      const config = loadConfig();
+      const llm = createLlmProvider(config);
+      const topic = typeof b["topic"] === "string" ? b["topic"] : undefined;
+      const result = await askQuestion(db, provider, llm, { question: b["question"], topic });
+      const took = Math.round(performance.now() - start);
+      sendJson(res, 200, result, took);
+      return;
+    }
+
+    // Topics
+    if (pathname === "/api/v1/topics" && method === "GET") {
+      const topics = listTopics(db);
+      const took = Math.round(performance.now() - start);
+      sendJson(res, 200, topics, took);
+      return;
+    }
+
+    if (pathname === "/api/v1/topics" && method === "POST") {
+      const body = await parseJsonBody(req);
+      if (!body || typeof body !== "object") {
+        sendError(res, 400, "VALIDATION_ERROR", "Request body must be a JSON object");
+        return;
+      }
+      const b = body as Record<string, unknown>;
+      if (typeof b["name"] !== "string") {
+        sendError(res, 400, "VALIDATION_ERROR", "Field 'name' is required");
+        return;
+      }
+      const parentId = typeof b["parentId"] === "string" ? b["parentId"] : undefined;
+      const topic = createTopic(db, { name: b["name"], parentId });
+      const took = Math.round(performance.now() - start);
+      sendJson(res, 201, topic, took);
+      return;
+    }
+
+    // Tags
+    if (pathname === "/api/v1/tags" && method === "GET") {
+      const tags = listTags(db);
+      const took = Math.round(performance.now() - start);
+      sendJson(res, 200, tags, took);
+      return;
+    }
+
+    // Add tags to document
+    const tagDocId = matchDocumentTags(segments);
+    if (tagDocId && method === "POST") {
+      const body = await parseJsonBody(req);
+      if (!body || typeof body !== "object") {
+        sendError(res, 400, "VALIDATION_ERROR", "Request body must be a JSON object");
+        return;
+      }
+      const b = body as Record<string, unknown>;
+      if (!Array.isArray(b["tags"])) {
+        sendError(res, 400, "VALIDATION_ERROR", "Field 'tags' must be an array of strings");
+        return;
+      }
+      const tagNames = (b["tags"] as unknown[]).filter((t): t is string => typeof t === "string");
+      const tags = addTagsToDocument(db, tagDocId, tagNames);
+      const took = Math.round(performance.now() - start);
+      sendJson(res, 200, tags, took);
+      return;
+    }
+
+    // Stats
+    if (pathname === "/api/v1/stats" && method === "GET") {
+      const stats = getStats(db);
+      const took = Math.round(performance.now() - start);
+      sendJson(res, 200, stats, took);
+      return;
+    }
+
+    // Single document GET / DELETE
+    const docId = matchDocumentId(segments);
+    if (docId && method === "GET") {
+      const doc = getDocument(db, docId);
+      const took = Math.round(performance.now() - start);
+      sendJson(res, 200, doc, took);
+      return;
+    }
+
+    if (docId && method === "DELETE") {
+      deleteDocument(db, docId);
+      const took = Math.round(performance.now() - start);
+      sendJson(res, 200, { deleted: true }, took);
+      return;
+    }
+
+    // Unknown route
+    sendError(res, 404, "NOT_FOUND", `Route not found: ${method} ${pathname}`);
+  } catch (err: unknown) {
+    log.error({ err, method, pathname }, "API request error");
+
+    if (err instanceof DocumentNotFoundError) {
+      sendError(res, 404, "NOT_FOUND", err.message);
+      return;
+    }
+    if (err instanceof LibScopeError && err.code === "VALIDATION_ERROR") {
+      sendError(res, 400, "VALIDATION_ERROR", err.message);
+      return;
+    }
+    if (err instanceof Error && err.message === "Invalid JSON body") {
+      sendError(res, 400, "INVALID_JSON", "Request body contains invalid JSON");
+      return;
+    }
+
+    const message = err instanceof Error ? err.message : "Internal server error";
+    sendError(res, 500, "INTERNAL_ERROR", message);
+  }
+}

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1,0 +1,47 @@
+import { createServer } from "node:http";
+import type Database from "better-sqlite3";
+import type { EmbeddingProvider } from "../providers/embedding.js";
+import { getLogger } from "../logger.js";
+import { corsMiddleware } from "./middleware.js";
+import { handleRequest } from "./routes.js";
+
+export interface ApiServerOptions {
+  port?: number | undefined;
+  host?: string | undefined;
+  corsOrigins?: string[] | undefined;
+}
+
+export async function startApiServer(
+  db: Database.Database,
+  provider: EmbeddingProvider,
+  options?: ApiServerOptions,
+): Promise<{ close: () => void; port: number }> {
+  const log = getLogger();
+  const port = options?.port ?? 3378;
+  const host = options?.host ?? "localhost";
+  const corsOrigins = options?.corsOrigins ?? ["*"];
+
+  const server = createServer((req, res) => {
+    if (corsMiddleware(req, res, corsOrigins)) return;
+    handleRequest(req, res, db, provider).catch((err: unknown) => {
+      log.error({ err }, "Unhandled error in request handler");
+      if (!res.headersSent) {
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({ error: { code: "INTERNAL_ERROR", message: "Internal server error" } }),
+        );
+      }
+    });
+  });
+
+  return new Promise((resolve, reject) => {
+    server.on("error", reject);
+    server.listen(port, host, () => {
+      log.info({ port, host }, "API server started");
+      resolve({
+        close: () => server.close(),
+        port,
+      });
+    });
+  });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -666,10 +666,23 @@ program
 // serve
 program
   .command("serve")
-  .description("Start the MCP server")
-  .action(async () => {
-    // Import and run the MCP server
-    await import("../mcp/server.js");
+  .description("Start the MCP server (or REST API with --api)")
+  .option("--api", "Start the REST API server instead of MCP")
+  .option("--port <port>", "API server port", "3378")
+  .option("--host <host>", "API server host", "localhost")
+  .action(async (opts: { api?: boolean; port: string; host: string }) => {
+    if (opts.api) {
+      const { db, provider } = initializeAppWithEmbedding();
+      const { startApiServer } = await import("../api/server.js");
+      const { port } = await startApiServer(db, provider, {
+        port: parseInt(opts.port, 10),
+        host: opts.host,
+      });
+      console.log(`LibScope API server listening on http://${opts.host}:${port}`);
+      console.log("Press Ctrl+C to stop");
+    } else {
+      await import("../mcp/server.js");
+    }
   });
 
 // config

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -140,3 +140,6 @@ export type { Workspace } from "./workspace.js";
 
 export { buildKnowledgeGraph, detectClusters } from "./graph.js";
 export type { KnowledgeGraph, GraphNode, GraphEdge, GraphOptions } from "./graph.js";
+
+export { startApiServer } from "../api/server.js";
+export type { ApiServerOptions } from "../api/server.js";

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -1,0 +1,509 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { IncomingMessage, ServerResponse } from "node:http";
+import { Socket } from "node:net";
+import type Database from "better-sqlite3";
+import { MockEmbeddingProvider } from "../fixtures/mock-provider.js";
+import { createTestDbWithVec } from "../fixtures/test-db.js";
+import { handleRequest } from "../../src/api/routes.js";
+import { corsMiddleware, parseJsonBody, sendJson, sendError } from "../../src/api/middleware.js";
+import { OPENAPI_SPEC } from "../../src/api/openapi.js";
+import { indexDocument } from "../../src/core/indexing.js";
+import { createTopic } from "../../src/core/topics.js";
+
+interface ApiResponse {
+  data?: Record<string, unknown>;
+  meta?: { took: number };
+  error?: { code: string; message: string };
+  openapi?: string;
+  info?: { title: string };
+  [key: string]: unknown;
+}
+
+function parseResponse(body: string): ApiResponse {
+  return JSON.parse(body) as ApiResponse;
+}
+
+function createMockReq(method: string, url: string, body?: unknown): IncomingMessage {
+  const socket = new Socket();
+  const req = new IncomingMessage(socket);
+  req.method = method;
+  req.url = url;
+  req.headers = { host: "localhost:3378" };
+
+  if (body !== undefined) {
+    const json = typeof body === "string" ? body : JSON.stringify(body);
+    req.headers["content-type"] = "application/json";
+    // Push the body data asynchronously
+    process.nextTick(() => {
+      req.push(Buffer.from(json));
+      req.push(null);
+    });
+  } else {
+    process.nextTick(() => {
+      req.push(null);
+    });
+  }
+
+  return req;
+}
+
+interface MockRes {
+  res: ServerResponse;
+  getStatus: () => number;
+  getBody: () => string;
+  getHeaders: () => Record<string, string | number | string[]>;
+}
+
+function createMockRes(): MockRes {
+  const socket = new Socket();
+  const res = new ServerResponse(new IncomingMessage(socket));
+  let statusCode = 200;
+  let body = "";
+  const headers: Record<string, string | number | string[]> = {};
+
+  res.writeHead = function (code: number, hdrs?: Record<string, unknown>): ServerResponse {
+    statusCode = code;
+    if (hdrs) {
+      for (const [k, v] of Object.entries(hdrs)) {
+        headers[k] = v as string;
+      }
+    }
+    return res;
+  };
+
+  res.end = function (chunk?: unknown): ServerResponse {
+    if (typeof chunk === "string") {
+      body += chunk;
+    } else if (Buffer.isBuffer(chunk)) {
+      body += chunk.toString("utf-8");
+    }
+    return res;
+  };
+
+  res.setHeader = function (
+    name: string,
+    value: string | number | readonly string[],
+  ): ServerResponse {
+    headers[name] = value as string | number | string[];
+    return res;
+  };
+
+  return {
+    res,
+    getStatus: () => statusCode,
+    getBody: () => body,
+    getHeaders: () => headers,
+  };
+}
+
+describe("API middleware", () => {
+  describe("corsMiddleware", () => {
+    it("should handle OPTIONS preflight", () => {
+      const req = createMockReq("OPTIONS", "/api/v1/health");
+      const { res, getStatus, getHeaders } = createMockRes();
+
+      const handled = corsMiddleware(req, res, ["*"]);
+
+      expect(handled).toBe(true);
+      expect(getStatus()).toBe(204);
+      expect(getHeaders()["Access-Control-Allow-Origin"]).toBe("*");
+      expect(getHeaders()["Access-Control-Allow-Methods"]).toBe("GET, POST, DELETE, OPTIONS");
+    });
+
+    it("should set CORS headers for non-preflight requests", () => {
+      const req = createMockReq("GET", "/api/v1/health");
+      const { res, getHeaders } = createMockRes();
+
+      const handled = corsMiddleware(req, res, ["*"]);
+
+      expect(handled).toBe(false);
+      expect(getHeaders()["Access-Control-Allow-Origin"]).toBe("*");
+    });
+
+    it("should restrict origin when not wildcard", () => {
+      const req = createMockReq("GET", "/api/v1/health");
+      req.headers["origin"] = "http://example.com";
+      const { res, getHeaders } = createMockRes();
+
+      corsMiddleware(req, res, ["http://example.com"]);
+
+      expect(getHeaders()["Access-Control-Allow-Origin"]).toBe("http://example.com");
+    });
+  });
+
+  describe("parseJsonBody", () => {
+    it("should parse valid JSON", async () => {
+      const req = createMockReq("POST", "/test", { hello: "world" });
+      const body = await parseJsonBody(req);
+      expect(body).toEqual({ hello: "world" });
+    });
+
+    it("should reject invalid JSON", async () => {
+      const req = createMockReq("POST", "/test", "not json{{{");
+      await expect(parseJsonBody(req)).rejects.toThrow("Invalid JSON body");
+    });
+
+    it("should return null for empty body", async () => {
+      const req = createMockReq("POST", "/test");
+      const body = await parseJsonBody(req);
+      expect(body).toBeNull();
+    });
+  });
+
+  describe("sendJson", () => {
+    it("should send JSON with data envelope", () => {
+      const { res, getStatus, getBody } = createMockRes();
+      sendJson(res, 200, { foo: "bar" }, 10);
+      expect(getStatus()).toBe(200);
+      const parsed = parseResponse(getBody());
+      expect(parsed).toEqual({ data: { foo: "bar" }, meta: { took: 10 } });
+    });
+  });
+
+  describe("sendError", () => {
+    it("should send error with envelope", () => {
+      const { res, getStatus, getBody } = createMockRes();
+      sendError(res, 404, "NOT_FOUND", "Not found");
+      expect(getStatus()).toBe(404);
+      const parsed = parseResponse(getBody());
+      expect(parsed).toEqual({ error: { code: "NOT_FOUND", message: "Not found" } });
+    });
+  });
+});
+
+describe("API routes", () => {
+  let db: Database.Database;
+  let provider: MockEmbeddingProvider;
+
+  beforeEach(() => {
+    db = createTestDbWithVec();
+    provider = new MockEmbeddingProvider();
+  });
+
+  describe("GET /api/v1/health", () => {
+    it("should return health status", async () => {
+      const req = createMockReq("GET", "/api/v1/health");
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleRequest(req, res, db, provider);
+
+      expect(getStatus()).toBe(200);
+      const parsed = parseResponse(getBody());
+      expect(parsed.data.status).toBe("ok");
+      expect(typeof parsed.data.docCount).toBe("number");
+      expect(typeof parsed.meta.took).toBe("number");
+    });
+  });
+
+  describe("GET /openapi.json", () => {
+    it("should return the OpenAPI spec", async () => {
+      const req = createMockReq("GET", "/openapi.json");
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleRequest(req, res, db, provider);
+
+      expect(getStatus()).toBe(200);
+      const parsed = parseResponse(getBody());
+      expect(parsed.openapi).toBe("3.0.3");
+      expect(parsed.info.title).toBe("LibScope REST API");
+    });
+  });
+
+  describe("GET /api/v1/search", () => {
+    it("should return 400 without query param", async () => {
+      const req = createMockReq("GET", "/api/v1/search");
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleRequest(req, res, db, provider);
+
+      expect(getStatus()).toBe(400);
+      const parsed = parseResponse(getBody());
+      expect(parsed.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("should search with query params", async () => {
+      await indexDocument(db, provider, {
+        title: "Test Doc",
+        content: "Hello world content",
+        sourceType: "manual",
+      });
+
+      const req = createMockReq("GET", "/api/v1/search?q=hello&limit=5");
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleRequest(req, res, db, provider);
+
+      expect(getStatus()).toBe(200);
+      const parsed = parseResponse(getBody());
+      expect(parsed.data).toBeDefined();
+      expect(parsed.meta.took).toBeDefined();
+    });
+  });
+
+  describe("POST /api/v1/documents", () => {
+    it("should index a new document", async () => {
+      const req = createMockReq("POST", "/api/v1/documents", {
+        title: "My Doc",
+        content: "Some content here",
+      });
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleRequest(req, res, db, provider);
+
+      expect(getStatus()).toBe(201);
+      const parsed = parseResponse(getBody());
+      expect(parsed.data.id).toBeDefined();
+      expect(parsed.data.chunkCount).toBeGreaterThanOrEqual(1);
+    });
+
+    it("should return 400 for missing fields", async () => {
+      const req = createMockReq("POST", "/api/v1/documents", { title: "No content" });
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleRequest(req, res, db, provider);
+
+      expect(getStatus()).toBe(400);
+      const parsed = parseResponse(getBody());
+      expect(parsed.error.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("should index document with tags", async () => {
+      const req = createMockReq("POST", "/api/v1/documents", {
+        title: "Tagged Doc",
+        content: "Content with tags",
+        tags: ["typescript", "api"],
+      });
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleRequest(req, res, db, provider);
+
+      expect(getStatus()).toBe(201);
+      const parsed = parseResponse(getBody());
+      expect(parsed.data.id).toBeDefined();
+    });
+
+    it("should return 400 for invalid JSON body", async () => {
+      const req = createMockReq("POST", "/api/v1/documents", "not-valid-json{{{");
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleRequest(req, res, db, provider);
+
+      expect(getStatus()).toBe(400);
+      const parsed = parseResponse(getBody());
+      expect(parsed.error.code).toBe("INVALID_JSON");
+    });
+  });
+
+  describe("GET /api/v1/documents/:id", () => {
+    it("should return a document by ID", async () => {
+      const doc = await indexDocument(db, provider, {
+        title: "Fetch Me",
+        content: "Document content",
+        sourceType: "manual",
+      });
+
+      const req = createMockReq("GET", `/api/v1/documents/${doc.id}`);
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleRequest(req, res, db, provider);
+
+      expect(getStatus()).toBe(200);
+      const parsed = parseResponse(getBody());
+      expect(parsed.data.id).toBe(doc.id);
+      expect(parsed.data.title).toBe("Fetch Me");
+    });
+
+    it("should return 404 for non-existent document", async () => {
+      const req = createMockReq("GET", "/api/v1/documents/nonexistent-id");
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleRequest(req, res, db, provider);
+
+      expect(getStatus()).toBe(404);
+      const parsed = parseResponse(getBody());
+      expect(parsed.error.code).toBe("NOT_FOUND");
+    });
+  });
+
+  describe("DELETE /api/v1/documents/:id", () => {
+    it("should delete a document", async () => {
+      const doc = await indexDocument(db, provider, {
+        title: "Delete Me",
+        content: "To be deleted",
+        sourceType: "manual",
+      });
+
+      const req = createMockReq("DELETE", `/api/v1/documents/${doc.id}`);
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleRequest(req, res, db, provider);
+
+      expect(getStatus()).toBe(200);
+      const parsed = parseResponse(getBody());
+      expect(parsed.data.deleted).toBe(true);
+    });
+
+    it("should return 404 for deleting non-existent document", async () => {
+      const req = createMockReq("DELETE", "/api/v1/documents/nonexistent-id");
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleRequest(req, res, db, provider);
+
+      expect(getStatus()).toBe(404);
+      const parsed = parseResponse(getBody());
+      expect(parsed.error.code).toBe("NOT_FOUND");
+    });
+  });
+
+  describe("POST /api/v1/ask", () => {
+    it("should return 400 without question", async () => {
+      const req = createMockReq("POST", "/api/v1/ask", { notQuestion: "test" });
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleRequest(req, res, db, provider);
+
+      expect(getStatus()).toBe(400);
+      const parsed = parseResponse(getBody());
+      expect(parsed.error.code).toBe("VALIDATION_ERROR");
+    });
+  });
+
+  describe("GET /api/v1/documents", () => {
+    it("should list documents", async () => {
+      await indexDocument(db, provider, {
+        title: "Doc 1",
+        content: "Content 1",
+        sourceType: "manual",
+      });
+
+      const req = createMockReq("GET", "/api/v1/documents");
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleRequest(req, res, db, provider);
+
+      expect(getStatus()).toBe(200);
+      const parsed = parseResponse(getBody());
+      expect(Array.isArray(parsed.data)).toBe(true);
+      expect(parsed.data.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("GET /api/v1/topics", () => {
+    it("should list topics", async () => {
+      createTopic(db, { name: "test-topic" });
+
+      const req = createMockReq("GET", "/api/v1/topics");
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleRequest(req, res, db, provider);
+
+      expect(getStatus()).toBe(200);
+      const parsed = parseResponse(getBody());
+      expect(Array.isArray(parsed.data)).toBe(true);
+    });
+  });
+
+  describe("POST /api/v1/topics", () => {
+    it("should create a topic", async () => {
+      const req = createMockReq("POST", "/api/v1/topics", { name: "new-topic" });
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleRequest(req, res, db, provider);
+
+      expect(getStatus()).toBe(201);
+      const parsed = parseResponse(getBody());
+      expect(parsed.data.name).toBe("new-topic");
+    });
+
+    it("should return 400 without name", async () => {
+      const req = createMockReq("POST", "/api/v1/topics", { description: "no name" });
+      const { res, getStatus } = createMockRes();
+
+      await handleRequest(req, res, db, provider);
+
+      expect(getStatus()).toBe(400);
+    });
+  });
+
+  describe("GET /api/v1/tags", () => {
+    it("should list tags", async () => {
+      const req = createMockReq("GET", "/api/v1/tags");
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleRequest(req, res, db, provider);
+
+      expect(getStatus()).toBe(200);
+      const parsed = parseResponse(getBody());
+      expect(Array.isArray(parsed.data)).toBe(true);
+    });
+  });
+
+  describe("POST /api/v1/documents/:id/tags", () => {
+    it("should add tags to a document", async () => {
+      const doc = await indexDocument(db, provider, {
+        title: "Tag Target",
+        content: "Content",
+        sourceType: "manual",
+      });
+
+      const req = createMockReq("POST", `/api/v1/documents/${doc.id}/tags`, {
+        tags: ["alpha", "beta"],
+      });
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleRequest(req, res, db, provider);
+
+      expect(getStatus()).toBe(200);
+      const parsed = parseResponse(getBody());
+      expect(Array.isArray(parsed.data)).toBe(true);
+    });
+  });
+
+  describe("GET /api/v1/stats", () => {
+    it("should return stats", async () => {
+      const req = createMockReq("GET", "/api/v1/stats");
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleRequest(req, res, db, provider);
+
+      expect(getStatus()).toBe(200);
+      const parsed = parseResponse(getBody());
+      expect(typeof parsed.data.totalDocuments).toBe("number");
+    });
+  });
+
+  describe("Unknown route", () => {
+    it("should return 404", async () => {
+      const req = createMockReq("GET", "/api/v1/nonexistent");
+      const { res, getStatus, getBody } = createMockRes();
+
+      await handleRequest(req, res, db, provider);
+
+      expect(getStatus()).toBe(404);
+      const parsed = parseResponse(getBody());
+      expect(parsed.error.code).toBe("NOT_FOUND");
+    });
+  });
+});
+
+describe("OpenAPI spec", () => {
+  it("should have valid structure", () => {
+    expect(OPENAPI_SPEC.openapi).toBe("3.0.3");
+    expect(OPENAPI_SPEC.info.title).toBeDefined();
+    expect(OPENAPI_SPEC.paths).toBeDefined();
+    expect(OPENAPI_SPEC.components).toBeDefined();
+  });
+
+  it("should define all endpoints", () => {
+    const paths = Object.keys(OPENAPI_SPEC.paths);
+    expect(paths).toContain("/api/v1/search");
+    expect(paths).toContain("/api/v1/documents");
+    expect(paths).toContain("/api/v1/documents/{id}");
+    expect(paths).toContain("/api/v1/ask");
+    expect(paths).toContain("/api/v1/topics");
+    expect(paths).toContain("/api/v1/tags");
+    expect(paths).toContain("/api/v1/stats");
+    expect(paths).toContain("/api/v1/health");
+    expect(paths).toContain("/openapi.json");
+  });
+});


### PR DESCRIPTION
Adds a lightweight REST API server exposing all libscope operations over HTTP with OpenAPI 3.0 spec, CORS support, and consistent JSON responses.

## Changes
- `src/api/server.ts` — HTTP server using Node built-in `http` module
- `src/api/routes.ts` — Route handler dispatching to core functions (14 endpoints)
- `src/api/middleware.ts` — CORS, JSON parsing, response helpers
- `src/api/openapi.ts` — OpenAPI 3.0 specification
- `src/cli/index.ts` — `--api` flag on `serve` command
- `src/core/index.ts` — Re-exports `startApiServer`
- `tests/unit/api.test.ts` — 31 unit tests

Closes #150