### PR TITLE
feat: add Slack channel connector with thread aggregation (closes #151)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -59,6 +59,12 @@ import {
 import { loadConnectorConfig, saveConnectorConfig } from "../connectors/index.js";
 import { syncNotion, disconnectNotion } from "../connectors/notion.js";
 import type { NotionConfig } from "../connectors/notion.js";
+import { syncSlack, disconnectSlack, type SlackConfig } from "../connectors/slack.js";
+import {
+  saveNamedConnectorConfig,
+  loadNamedConnectorConfig,
+  hasNamedConnectorConfig,
+} from "../connectors/index.js";
 
 // Graceful shutdown
 process.on("SIGINT", () => {
@@ -1450,6 +1456,81 @@ connectCmd
         for (const e of result.errors) {
           console.log(`    - ${e.file}: ${e.error}`);
         }
+
+        connectCmd
+          .command("slack")
+          .description("Connect a Slack workspace")
+          .option("--token <token>", "Slack bot or user token (xoxb-... or xoxp-...)")
+          .option("--channels <channels>", "Comma-separated channel names or IDs, or 'all'", "all")
+          .option("--exclude <channels>", "Comma-separated channel names to exclude")
+          .option(
+            "--thread-mode <mode>",
+            "Thread handling: aggregate (full thread as one doc) or separate",
+            "aggregate",
+          )
+          .option("--sync", "Sync using saved configuration")
+          .action(
+            async (opts: {
+              token?: string;
+              channels: string;
+              exclude?: string;
+              threadMode: string;
+              sync?: boolean;
+            }) => {
+              const { db, provider } = initializeAppWithEmbedding();
+              try {
+                let slackConfig: SlackConfig;
+
+                if (opts.sync) {
+                  if (!hasNamedConnectorConfig("slack")) {
+                    console.error(
+                      "No Slack configuration found. Run 'libscope connect slack --token ...' first.",
+                    );
+                    process.exit(1);
+                  }
+                  slackConfig = loadNamedConnectorConfig<SlackConfig>("slack");
+                } else {
+                  if (!opts.token) {
+                    console.error("--token is required for initial Slack connection.");
+                    process.exit(1);
+                  }
+                  slackConfig = {
+                    token: opts.token,
+                    channels: opts.channels.split(",").map((c) => c.trim()),
+                    threadMode: opts.threadMode === "separate" ? "separate" : "aggregate",
+                  };
+                  if (opts.exclude) {
+                    slackConfig = {
+                      ...slackConfig,
+                      excludeChannels: opts.exclude.split(",").map((c) => c.trim()),
+                    };
+                  }
+                }
+
+                console.log("Syncing Slack messages...");
+                const result = await syncSlack(db, provider, slackConfig);
+
+                const updatedConfig: SlackConfig = {
+                  ...slackConfig,
+                  lastSync: new Date().toISOString(),
+                };
+                saveNamedConnectorConfig("slack", updatedConfig);
+
+                console.log(`✓ Slack sync complete:`);
+                console.log(`  Channels: ${result.channels}`);
+                console.log(`  Messages indexed: ${result.messagesIndexed}`);
+                console.log(`  Threads indexed: ${result.threadsIndexed}`);
+                if (result.errors.length > 0) {
+                  console.log(`  Errors: ${result.errors.length}`);
+                  for (const err of result.errors) {
+                    console.log(`    - #${err.channel}: ${err.error}`);
+                  }
+                }
+              } finally {
+                closeDatabase();
+              }
+            },
+          );
       }
     },
   );
@@ -1518,6 +1599,19 @@ disconnectCmd
         const { db } = initializeApp();
         const removed = await disconnectNotion(db);
         console.log(`✓ Removed ${removed} Notion documents.`);
+      });
+
+    disconnectCmd
+      .command("slack")
+      .description("Remove all Slack data from the knowledge base")
+      .action(() => {
+        const { db } = initializeApp();
+        try {
+          const count = disconnectSlack(db);
+          console.log(`✓ Removed ${count} Slack documents from the knowledge base.`);
+        } finally {
+          closeDatabase();
+        }
       });
   });
 

--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -69,5 +69,64 @@ export function deleteDbConnectorConfig(db: Database.Database, type: string): bo
   return result.changes > 0;
 }
 
+const CONNECTORS_DIR = join(homedir(), ".libscope", "connectors");
+
+function ensureConnectorsDir(): void {
+  if (!existsSync(CONNECTORS_DIR)) {
+    mkdirSync(CONNECTORS_DIR, { recursive: true });
+  }
+}
+
+/** Save a named connector config to ~/.libscope/connectors/<name>.json */
+export function saveNamedConnectorConfig(name: string, config: object): void {
+  ensureConnectorsDir();
+  const filePath = join(CONNECTORS_DIR, `${name}.json`);
+  writeFileSync(filePath, JSON.stringify(config, null, 2), "utf-8");
+  getLogger().info({ connector: name }, "Connector config saved");
+}
+
+/** Load a named connector config from ~/.libscope/connectors/<name>.json */
+export function loadNamedConnectorConfig<T>(name: string): T {
+  const filePath = join(CONNECTORS_DIR, `${name}.json`);
+  if (!existsSync(filePath)) {
+    throw new ConfigError(
+      `No connector config found for "${name}". Run 'libscope connect ${name}' first.`,
+    );
+  }
+  const raw = readFileSync(filePath, "utf-8");
+  return JSON.parse(raw) as T;
+}
+
+/** Check if a named connector config exists */
+export function hasNamedConnectorConfig(name: string): boolean {
+  const filePath = join(CONNECTORS_DIR, `${name}.json`);
+  return existsSync(filePath);
+}
+
+/** Delete documents with a given source_type from the database. Returns count deleted. */
+export function deleteConnectorDocuments(db: Database.Database, sourceType: string): number {
+  const rows = db
+    .prepare("SELECT id FROM documents WHERE source_type = ?")
+    .all(sourceType) as Array<{ id: string }>;
+  if (rows.length === 0) return 0;
+
+  const deleteChunksFts = db.prepare(
+    "DELETE FROM chunks_fts WHERE chunk_id IN (SELECT id FROM chunks WHERE document_id = ?)",
+  );
+  const deleteChunks = db.prepare("DELETE FROM chunks WHERE document_id = ?");
+  const deleteDoc = db.prepare("DELETE FROM documents WHERE id = ?");
+
+  const tx = db.transaction(() => {
+    for (const row of rows) {
+      deleteChunksFts.run(row.id);
+      deleteChunks.run(row.id);
+      deleteDoc.run(row.id);
+    }
+  });
+  tx();
+
+  return rows.length;
+}
+
 export { syncNotion, convertNotionBlocks, disconnectNotion } from "./notion.js";
 export type { NotionConfig, NotionSyncResult, NotionBlock } from "./notion.js";

--- a/src/connectors/slack.ts
+++ b/src/connectors/slack.ts
@@ -1,0 +1,442 @@
+import type Database from "better-sqlite3";
+import type { EmbeddingProvider } from "../providers/embedding.js";
+import { indexDocument } from "../core/indexing.js";
+import { getLogger } from "../logger.js";
+import { LibScopeError, ValidationError } from "../errors.js";
+
+export interface SlackConfig {
+  token: string;
+  channels: string[];
+  lastSync?: string | undefined;
+  excludeChannels?: string[] | undefined;
+  threadMode: "aggregate" | "separate";
+}
+
+export interface SlackSyncResult {
+  channels: number;
+  messagesIndexed: number;
+  threadsIndexed: number;
+  errors: Array<{ channel: string; error: string }>;
+}
+
+interface SlackChannel {
+  id: string;
+  name: string;
+}
+
+interface SlackMessage {
+  ts: string;
+  text?: string;
+  user?: string;
+  thread_ts?: string;
+  reply_count?: number;
+  subtype?: string;
+}
+
+interface SlackUser {
+  id: string;
+  real_name?: string;
+  name: string;
+  profile?: { display_name?: string };
+}
+
+interface SlackApiResponse {
+  ok: boolean;
+  error?: string;
+  channels?: SlackChannel[];
+  messages?: SlackMessage[];
+  members?: SlackUser[];
+  user?: SlackUser;
+  has_more?: boolean;
+  response_metadata?: { next_cursor?: string };
+}
+
+const SLACK_BASE_URL = "https://slack.com/api";
+let rateLimitDelayMs = 1200;
+
+/** Override rate limit delay (for testing). */
+export function _setRateLimitDelay(ms: number): void {
+  rateLimitDelayMs = ms;
+}
+
+const userCache = new Map<string, string>();
+
+/** Clear the user resolution cache (for testing). */
+export function _clearUserCache(): void {
+  userCache.clear();
+}
+
+async function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function slackApi(
+  method: string,
+  token: string,
+  params: Record<string, string> = {},
+): Promise<SlackApiResponse> {
+  const url = new URL(`${SLACK_BASE_URL}/${method}`);
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+
+  const response = await fetch(url.toString(), {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!response.ok) {
+    throw new LibScopeError(
+      `Slack API HTTP error: ${response.status} ${response.statusText}`,
+      "SLACK_API_ERROR",
+    );
+  }
+
+  const data = (await response.json()) as SlackApiResponse;
+  if (!data.ok) {
+    throw new LibScopeError(`Slack API error: ${data.error ?? "unknown"}`, "SLACK_API_ERROR");
+  }
+
+  return data;
+}
+
+async function resolveUser(token: string, userId: string): Promise<string> {
+  const cached = userCache.get(userId);
+  if (cached) return cached;
+
+  try {
+    const data = await slackApi("users.info", token, { user: userId });
+    await delay(rateLimitDelayMs);
+
+    const user = data.user;
+    const displayName = user?.profile?.display_name ?? user?.real_name ?? user?.name ?? userId;
+    userCache.set(userId, displayName);
+    return displayName;
+  } catch {
+    userCache.set(userId, userId);
+    return userId;
+  }
+}
+
+export function convertSlackMrkdwn(text: string): string {
+  let result = text;
+
+  // Preserve code blocks — replace with placeholders
+  const codeBlocks: string[] = [];
+  result = result.replace(/```[\s\S]*?```/g, (match) => {
+    codeBlocks.push(match);
+    return `__CODEBLOCK_${String(codeBlocks.length - 1)}__`;
+  });
+
+  const inlineCodes: string[] = [];
+  result = result.replace(/`[^`]+`/g, (match) => {
+    inlineCodes.push(match);
+    return `__INLINECODE_${String(inlineCodes.length - 1)}__`;
+  });
+
+  // Channel links: <#C1234|channel> → #channel
+  result = result.replace(/<#[A-Z0-9]+\|([^>]+)>/g, "#$1");
+
+  // URL links: <url|text> → [text](url)
+  result = result.replace(/<(https?:\/\/[^|>]+)\|([^>]+)>/g, "[$2]($1)");
+
+  // Plain URLs: <url> → url
+  result = result.replace(/<(https?:\/\/[^>]+)>/g, "$1");
+
+  // Bold: *text* → **text** (but not inside words)
+  result = result.replace(/(^|[\s(])\*([^*\n]+)\*([\s).,!?]|$)/g, "$1**$2**$3");
+
+  // Italic: _text_ → *text*
+  result = result.replace(/(^|[\s(])_([^_\n]+)_([\s).,!?]|$)/g, "$1*$2*$3");
+
+  // Strikethrough: ~text~ → ~~text~~
+  result = result.replace(/(^|[\s(])~([^~\n]+)~([\s).,!?]|$)/g, "$1~~$2~~$3");
+
+  // Restore code blocks
+  result = result.replace(
+    /__CODEBLOCK_(\d+)__/g,
+    (_match, idx: string) => codeBlocks[Number(idx)] ?? "",
+  );
+  result = result.replace(
+    /__INLINECODE_(\d+)__/g,
+    (_match, idx: string) => inlineCodes[Number(idx)] ?? "",
+  );
+
+  return result;
+}
+
+export async function resolveUserMentions(text: string, token: string): Promise<string> {
+  const mentionRegex = /<@(U[A-Z0-9]+)>/g;
+  const mentions = [...text.matchAll(mentionRegex)];
+  let result = text;
+
+  for (const match of mentions) {
+    const userId = match[1];
+    if (userId) {
+      const displayName = await resolveUser(token, userId);
+      result = result.replace(match[0], `@${displayName}`);
+    }
+  }
+
+  return result;
+}
+
+async function listChannels(token: string): Promise<SlackChannel[]> {
+  const channels: SlackChannel[] = [];
+  let cursor: string | undefined;
+
+  do {
+    const params: Record<string, string> = {
+      types: "public_channel,private_channel",
+      limit: "200",
+    };
+    if (cursor) params["cursor"] = cursor;
+
+    const data = await slackApi("conversations.list", token, params);
+    await delay(rateLimitDelayMs);
+
+    if (data.channels) {
+      channels.push(...data.channels);
+    }
+    cursor = data.response_metadata?.next_cursor ?? undefined;
+  } while (cursor);
+
+  return channels;
+}
+
+function filterChannels(
+  allChannels: SlackChannel[],
+  include: string[],
+  exclude: string[] = [],
+): SlackChannel[] {
+  const excludeSet = new Set(exclude.map((c) => c.toLowerCase()));
+  let filtered: SlackChannel[];
+
+  if (include.length === 1 && include[0] === "all") {
+    filtered = allChannels;
+  } else {
+    const includeSet = new Set(include.map((c) => c.toLowerCase()));
+    filtered = allChannels.filter(
+      (ch) => includeSet.has(ch.name.toLowerCase()) || includeSet.has(ch.id),
+    );
+  }
+
+  return filtered.filter((ch) => !excludeSet.has(ch.name.toLowerCase()) && !excludeSet.has(ch.id));
+}
+
+async function fetchMessages(
+  token: string,
+  channelId: string,
+  oldest?: string,
+): Promise<SlackMessage[]> {
+  const messages: SlackMessage[] = [];
+  let cursor: string | undefined;
+
+  do {
+    const params: Record<string, string> = {
+      channel: channelId,
+      limit: "200",
+    };
+    if (oldest) params["oldest"] = oldest;
+    if (cursor) params["cursor"] = cursor;
+
+    const data = await slackApi("conversations.history", token, params);
+    await delay(rateLimitDelayMs);
+
+    if (data.messages) {
+      messages.push(...data.messages);
+    }
+    cursor = data.response_metadata?.next_cursor ?? undefined;
+  } while (cursor);
+
+  return messages;
+}
+
+async function fetchThreadReplies(
+  token: string,
+  channelId: string,
+  threadTs: string,
+): Promise<SlackMessage[]> {
+  const params: Record<string, string> = {
+    channel: channelId,
+    ts: threadTs,
+    limit: "200",
+  };
+
+  const data = await slackApi("conversations.replies", token, params);
+  await delay(rateLimitDelayMs);
+
+  return data.messages ?? [];
+}
+
+function formatTimestamp(ts: string): string {
+  const seconds = Number(ts.split(".")[0]);
+  return new Date(seconds * 1000).toISOString();
+}
+
+function truncateTitle(text: string, maxLen: number = 80): string {
+  const cleaned = text.replace(/\n/g, " ").trim();
+  if (cleaned.length <= maxLen) return cleaned;
+  return cleaned.slice(0, maxLen - 3) + "...";
+}
+
+async function buildThreadDocument(
+  token: string,
+  channelName: string,
+  replies: SlackMessage[],
+): Promise<string> {
+  const lines: string[] = [];
+  for (const reply of replies) {
+    const username = reply.user ? await resolveUser(token, reply.user) : "unknown";
+    const timestamp = formatTimestamp(reply.ts);
+    const text = reply.text ? convertSlackMrkdwn(await resolveUserMentions(reply.text, token)) : "";
+    lines.push(`**${username}** (${timestamp}):\n${text}`);
+  }
+  return `# Thread in #${channelName}\n\n${lines.join("\n\n---\n\n")}`;
+}
+
+export async function syncSlack(
+  db: Database.Database,
+  provider: EmbeddingProvider,
+  config: SlackConfig,
+): Promise<SlackSyncResult> {
+  const log = getLogger();
+
+  if (!config.token) {
+    throw new ValidationError("Slack token is required");
+  }
+  if (!config.channels || config.channels.length === 0) {
+    throw new ValidationError("At least one channel must be specified");
+  }
+
+  userCache.clear();
+
+  const result: SlackSyncResult = {
+    channels: 0,
+    messagesIndexed: 0,
+    threadsIndexed: 0,
+    errors: [],
+  };
+
+  log.info("Fetching Slack channel list");
+  const allChannels = await listChannels(config.token);
+  const channels = filterChannels(allChannels, config.channels, config.excludeChannels);
+  result.channels = channels.length;
+
+  log.info({ channelCount: channels.length }, "Processing Slack channels");
+
+  for (const channel of channels) {
+    try {
+      log.info({ channel: channel.name }, "Syncing channel");
+
+      const oldest = config.lastSync ?? undefined;
+      const messages = await fetchMessages(config.token, channel.id, oldest);
+
+      // Separate thread parents from standalone messages
+      const threadParents = messages.filter(
+        (m) => m.reply_count != null && m.reply_count > 0 && !m.subtype,
+      );
+      const standaloneMessages = messages.filter(
+        (m) => (m.reply_count == null || m.reply_count === 0) && !m.thread_ts && !m.subtype,
+      );
+
+      // Index standalone messages
+      for (const msg of standaloneMessages) {
+        if (!msg.text) continue;
+
+        const username = msg.user ? await resolveUser(config.token, msg.user) : "unknown";
+        const text = convertSlackMrkdwn(await resolveUserMentions(msg.text, config.token));
+        const title = `#${channel.name} — ${username}: ${truncateTitle(msg.text)}`;
+
+        await indexDocument(db, provider, {
+          title,
+          content: `**${username}** (${formatTimestamp(msg.ts)}):\n${text}`,
+          sourceType: "manual",
+          url: `slack://${channel.name}/${msg.ts}`,
+          submittedBy: "crawler",
+        });
+        result.messagesIndexed++;
+      }
+
+      // Index threads
+      if (config.threadMode === "aggregate") {
+        for (const threadParent of threadParents) {
+          const replies = await fetchThreadReplies(config.token, channel.id, threadParent.ts);
+          const content = await buildThreadDocument(config.token, channel.name, replies);
+          const parentText = threadParent.text ?? "";
+          const title = `#${channel.name} thread: ${truncateTitle(parentText)}`;
+
+          await indexDocument(db, provider, {
+            title,
+            content,
+            sourceType: "manual",
+            url: `slack://${channel.name}/thread/${threadParent.ts}`,
+            submittedBy: "crawler",
+          });
+          result.threadsIndexed++;
+        }
+      } else {
+        // separate mode: each reply is its own document
+        for (const threadParent of threadParents) {
+          const replies = await fetchThreadReplies(config.token, channel.id, threadParent.ts);
+          for (const reply of replies) {
+            if (!reply.text) continue;
+
+            const username = reply.user ? await resolveUser(config.token, reply.user) : "unknown";
+            const text = convertSlackMrkdwn(await resolveUserMentions(reply.text, config.token));
+            const title = `#${channel.name} thread reply — ${username}: ${truncateTitle(reply.text)}`;
+
+            await indexDocument(db, provider, {
+              title,
+              content: `**${username}** (${formatTimestamp(reply.ts)}):\n${text}`,
+              sourceType: "manual",
+              url: `slack://${channel.name}/thread/${threadParent.ts}/${reply.ts}`,
+              submittedBy: "crawler",
+            });
+            result.messagesIndexed++;
+          }
+          result.threadsIndexed++;
+        }
+      }
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      log.error({ channel: channel.name, err }, "Error syncing Slack channel");
+      result.errors.push({ channel: channel.name, error: errMsg });
+    }
+  }
+
+  log.info(
+    {
+      channels: result.channels,
+      messages: result.messagesIndexed,
+      threads: result.threadsIndexed,
+    },
+    "Slack sync complete",
+  );
+
+  return result;
+}
+
+export function disconnectSlack(db: Database.Database): number {
+  const rows = db.prepare("SELECT id FROM documents WHERE url LIKE 'slack://%'").all() as Array<{
+    id: string;
+  }>;
+
+  if (rows.length === 0) return 0;
+
+  const deleteChunksFts = db.prepare(
+    "DELETE FROM chunks_fts WHERE chunk_id IN (SELECT id FROM chunks WHERE document_id = ?)",
+  );
+  const deleteChunks = db.prepare("DELETE FROM chunks WHERE document_id = ?");
+  const deleteDoc = db.prepare("DELETE FROM documents WHERE id = ?");
+
+  const tx = db.transaction(() => {
+    for (const row of rows) {
+      deleteChunksFts.run(row.id);
+      deleteChunks.run(row.id);
+      deleteDoc.run(row.id);
+    }
+  });
+  tx();
+
+  return rows.length;
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -143,11 +143,19 @@ export type { ApiServerOptions } from "../api/server.js";
 
 export { syncNotion, convertNotionBlocks, disconnectNotion } from "../connectors/notion.js";
 export type { NotionConfig, NotionSyncResult, NotionBlock } from "../connectors/notion.js";
+
+export { syncSlack, convertSlackMrkdwn, disconnectSlack } from "../connectors/slack.js";
+export type { SlackConfig, SlackSyncResult } from "../connectors/slack.js";
+
 export {
   saveDbConnectorConfig,
   loadDbConnectorConfig,
   deleteDbConnectorConfig,
   loadConnectorConfig,
   saveConnectorConfig,
+  saveNamedConnectorConfig,
+  loadNamedConnectorConfig,
+  hasNamedConnectorConfig,
+  deleteConnectorDocuments,
 } from "../connectors/index.js";
 export type { ConnectorConfig } from "../connectors/index.js";

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -530,6 +530,51 @@ async function main(): Promise<void> {
     }),
   );
 
+  // Tool: sync-slack
+  server.tool(
+    "sync-slack",
+    "Sync Slack channel messages and threads into the knowledge base",
+    {
+      token: z.string().describe("Slack bot token (xoxb-...) or user token (xoxp-...)"),
+      channels: z
+        .array(z.string())
+        .describe("Channel names or IDs to sync, or ['all'] for all channels"),
+      excludeChannels: z
+        .array(z.string())
+        .optional()
+        .describe("Channel names to exclude from sync"),
+      threadMode: z
+        .enum(["aggregate", "separate"])
+        .optional()
+        .describe(
+          "Thread handling: aggregate (default) combines thread into one doc, separate creates one doc per reply",
+        ),
+    },
+    withErrorHandling(async (params) => {
+      const { syncSlack: doSyncSlack } = await import("../connectors/slack.js");
+
+      const slackConfig = {
+        token: params.token,
+        channels: params.channels,
+        excludeChannels: params.excludeChannels,
+        threadMode: params.threadMode ?? ("aggregate" as const),
+      };
+
+      const result = await doSyncSlack(db, provider, slackConfig);
+
+      const text =
+        `Slack sync complete.\n` +
+        `Channels: ${result.channels}\n` +
+        `Messages indexed: ${result.messagesIndexed}\n` +
+        `Threads indexed: ${result.threadsIndexed}` +
+        (result.errors.length > 0
+          ? `\nErrors:\n${result.errors.map((e) => `  #${e.channel}: ${e.error}`).join("\n")}`
+          : "");
+
+      return { content: [{ type: "text" as const, text }] };
+    }),
+  );
+
   // Tool: install-pack
   server.tool(
     "install-pack",

--- a/tests/unit/slack.test.ts
+++ b/tests/unit/slack.test.ts
@@ -1,0 +1,355 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  convertSlackMrkdwn,
+  syncSlack,
+  disconnectSlack,
+  _setRateLimitDelay,
+  _clearUserCache,
+} from "../../src/connectors/slack.js";
+import type { SlackConfig } from "../../src/connectors/slack.js";
+import { createTestDbWithVec } from "../fixtures/test-db.js";
+import { MockEmbeddingProvider } from "../fixtures/mock-provider.js";
+import type Database from "better-sqlite3";
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function slackOk(data: Record<string, unknown> = {}): Response {
+  return new Response(JSON.stringify({ ok: true, ...data }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function slackError(error: string): Response {
+  return new Response(JSON.stringify({ ok: false, error }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("convertSlackMrkdwn", () => {
+  it("converts bold", () => {
+    expect(convertSlackMrkdwn("this is *bold* text")).toBe("this is **bold** text");
+  });
+
+  it("converts italic", () => {
+    expect(convertSlackMrkdwn("this is _italic_ text")).toBe("this is *italic* text");
+  });
+
+  it("converts strikethrough", () => {
+    expect(convertSlackMrkdwn("this is ~strike~ text")).toBe("this is ~~strike~~ text");
+  });
+
+  it("converts channel links", () => {
+    expect(convertSlackMrkdwn("see <#C1234|general>")).toBe("see #general");
+  });
+
+  it("converts URL with text", () => {
+    expect(convertSlackMrkdwn("check <https://example.com|Example>")).toBe(
+      "check [Example](https://example.com)",
+    );
+  });
+
+  it("converts plain URLs", () => {
+    expect(convertSlackMrkdwn("visit <https://example.com>")).toBe("visit https://example.com");
+  });
+
+  it("preserves code blocks", () => {
+    const input = "before ```const x = 1;``` after";
+    const result = convertSlackMrkdwn(input);
+    expect(result).toContain("```const x = 1;```");
+  });
+
+  it("preserves inline code", () => {
+    const input = "use `*bold*` for emphasis";
+    const result = convertSlackMrkdwn(input);
+    expect(result).toContain("`*bold*`");
+    expect(result).not.toContain("**bold**");
+  });
+
+  it("preserves emoji", () => {
+    expect(convertSlackMrkdwn("hello :wave: world")).toBe("hello :wave: world");
+  });
+
+  it("handles multiple conversions together", () => {
+    const input = "*bold* and _italic_ and ~strike~";
+    const result = convertSlackMrkdwn(input);
+    expect(result).toContain("**bold**");
+    expect(result).toContain("*italic*");
+    expect(result).toContain("~~strike~~");
+  });
+});
+
+describe("syncSlack", () => {
+  let db: Database.Database;
+  let provider: MockEmbeddingProvider;
+
+  beforeEach(() => {
+    db = createTestDbWithVec();
+    provider = new MockEmbeddingProvider();
+    mockFetch.mockReset();
+    _setRateLimitDelay(0);
+    _clearUserCache();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  const baseConfig: SlackConfig = {
+    token: "xoxb-test-token",
+    channels: ["general"],
+    threadMode: "aggregate",
+  };
+
+  function setupChannelList(channels: Array<{ id: string; name: string }> = []): void {
+    mockFetch.mockImplementationOnce(() =>
+      Promise.resolve(slackOk({ channels, response_metadata: {} })),
+    );
+  }
+
+  function setupMessages(messages: Array<Record<string, unknown>> = []): void {
+    mockFetch.mockImplementationOnce(() =>
+      Promise.resolve(slackOk({ messages, response_metadata: {} })),
+    );
+  }
+
+  function setupUserInfo(user: Record<string, unknown>): void {
+    mockFetch.mockImplementationOnce(() => Promise.resolve(slackOk({ user })));
+  }
+
+  function setupThreadReplies(messages: Array<Record<string, unknown>> = []): void {
+    mockFetch.mockImplementationOnce(() => Promise.resolve(slackOk({ messages })));
+  }
+
+  it("lists and filters channels", async () => {
+    setupChannelList([
+      { id: "C001", name: "general" },
+      { id: "C002", name: "random" },
+    ]);
+    setupMessages([]);
+
+    const result = await syncSlack(db, provider, baseConfig);
+    expect(result.channels).toBe(1);
+    expect(result.messagesIndexed).toBe(0);
+  });
+
+  it("fetches and indexes standalone messages", async () => {
+    setupChannelList([{ id: "C001", name: "general" }]);
+    setupMessages([{ ts: "1700000000.000000", text: "Hello world", user: "U001" }]);
+    setupUserInfo({ id: "U001", name: "alice", real_name: "Alice Smith" });
+
+    const result = await syncSlack(db, provider, baseConfig);
+    expect(result.messagesIndexed).toBe(1);
+
+    const docs = db.prepare("SELECT * FROM documents WHERE url LIKE 'slack://%'").all() as Array<{
+      title: string;
+    }>;
+    expect(docs).toHaveLength(1);
+    expect(docs[0]?.title).toContain("general");
+  });
+
+  it("handles pagination in channel listing", async () => {
+    mockFetch.mockImplementationOnce(() =>
+      Promise.resolve(
+        slackOk({
+          channels: [{ id: "C001", name: "general" }],
+          response_metadata: { next_cursor: "cursor123" },
+        }),
+      ),
+    );
+    mockFetch.mockImplementationOnce(() =>
+      Promise.resolve(
+        slackOk({
+          channels: [{ id: "C002", name: "random" }],
+          response_metadata: {},
+        }),
+      ),
+    );
+    // Two channels need messages fetched
+    setupMessages([]);
+    setupMessages([]);
+
+    const config: SlackConfig = { ...baseConfig, channels: ["all"] };
+    const result = await syncSlack(db, provider, config);
+    expect(result.channels).toBe(2);
+  });
+
+  it("aggregates threads into a single document", async () => {
+    setupChannelList([{ id: "C001", name: "general" }]);
+    setupMessages([
+      {
+        ts: "1700000000.000000",
+        text: "Thread parent message",
+        user: "U001",
+        reply_count: 2,
+        thread_ts: "1700000000.000000",
+      },
+    ]);
+    setupThreadReplies([
+      { ts: "1700000000.000000", text: "Thread parent message", user: "U001" },
+      { ts: "1700000001.000000", text: "First reply", user: "U002" },
+    ]);
+    setupUserInfo({ id: "U001", name: "alice", real_name: "Alice" });
+    setupUserInfo({ id: "U002", name: "bob", real_name: "Bob" });
+
+    const result = await syncSlack(db, provider, baseConfig);
+    expect(result.threadsIndexed).toBe(1);
+    expect(result.messagesIndexed).toBe(0);
+
+    const docs = db
+      .prepare("SELECT * FROM documents WHERE url LIKE 'slack://%/thread/%'")
+      .all() as Array<{ content: string }>;
+    expect(docs).toHaveLength(1);
+    expect(docs[0]?.content).toContain("Thread parent message");
+    expect(docs[0]?.content).toContain("First reply");
+  });
+
+  it("handles separate thread mode", async () => {
+    setupChannelList([{ id: "C001", name: "general" }]);
+    setupMessages([
+      {
+        ts: "1700000000.000000",
+        text: "Thread parent",
+        user: "U001",
+        reply_count: 1,
+        thread_ts: "1700000000.000000",
+      },
+    ]);
+    setupThreadReplies([
+      { ts: "1700000000.000000", text: "Thread parent", user: "U001" },
+      { ts: "1700000001.000000", text: "Reply", user: "U001" },
+    ]);
+    setupUserInfo({ id: "U001", name: "alice", real_name: "Alice" });
+
+    const config: SlackConfig = { ...baseConfig, threadMode: "separate" };
+    const result = await syncSlack(db, provider, config);
+    expect(result.threadsIndexed).toBe(1);
+    expect(result.messagesIndexed).toBe(2);
+  });
+
+  it("uses oldest param for incremental sync", async () => {
+    const syncTime = "2024-01-01T00:00:00.000Z";
+    setupChannelList([{ id: "C001", name: "general" }]);
+    setupMessages([]);
+
+    const config: SlackConfig = { ...baseConfig, lastSync: syncTime };
+    await syncSlack(db, provider, config);
+
+    const historyCall = mockFetch.mock.calls.find(
+      (call: unknown[]) => typeof call[0] === "string" && call[0].includes("conversations.history"),
+    );
+    expect(historyCall).toBeDefined();
+    expect(String(historyCall?.[0])).toContain("oldest=" + encodeURIComponent(syncTime));
+  });
+
+  it("resolves user mentions in message text", async () => {
+    setupChannelList([{ id: "C001", name: "general" }]);
+    setupMessages([{ ts: "1700000000.000000", text: "Hello <@U001>!", user: "U002" }]);
+    setupUserInfo({ id: "U002", name: "bob", real_name: "Bob" });
+    setupUserInfo({ id: "U001", name: "alice", real_name: "Alice" });
+
+    const result = await syncSlack(db, provider, baseConfig);
+    expect(result.messagesIndexed).toBe(1);
+
+    const docs = db
+      .prepare("SELECT content FROM documents WHERE url LIKE 'slack://%'")
+      .all() as Array<{ content: string }>;
+    expect(docs[0]?.content).toContain("@Alice");
+  });
+
+  it("handles rate limiting with delays between requests", async () => {
+    setupChannelList([{ id: "C001", name: "general" }]);
+    setupMessages([]);
+
+    await syncSlack(db, provider, baseConfig);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("handles channel errors gracefully", async () => {
+    setupChannelList([
+      { id: "C001", name: "general" },
+      { id: "C002", name: "random" },
+    ]);
+    mockFetch.mockImplementationOnce(() => Promise.resolve(slackError("channel_not_found")));
+    setupMessages([]);
+
+    const config: SlackConfig = { ...baseConfig, channels: ["all"] };
+    const result = await syncSlack(db, provider, config);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]?.channel).toBe("general");
+    expect(result.channels).toBe(2);
+  });
+
+  it("excludes specified channels", async () => {
+    setupChannelList([
+      { id: "C001", name: "general" },
+      { id: "C002", name: "random" },
+    ]);
+    setupMessages([]);
+
+    const config: SlackConfig = {
+      ...baseConfig,
+      channels: ["all"],
+      excludeChannels: ["random"],
+    };
+    const result = await syncSlack(db, provider, config);
+    expect(result.channels).toBe(1);
+  });
+
+  it("throws on missing token", async () => {
+    const config: SlackConfig = { ...baseConfig, token: "" };
+    await expect(syncSlack(db, provider, config)).rejects.toThrow("Slack token is required");
+  });
+
+  it("throws on empty channels", async () => {
+    const config: SlackConfig = { ...baseConfig, channels: [] };
+    await expect(syncSlack(db, provider, config)).rejects.toThrow(
+      "At least one channel must be specified",
+    );
+  });
+});
+
+describe("disconnectSlack", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDbWithVec();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("removes Slack documents from the database", () => {
+    db.prepare(
+      "INSERT INTO documents (id, source_type, title, content, url, submitted_by) VALUES (?, ?, ?, ?, ?, ?)",
+    ).run("slack-1", "manual", "Slack msg", "content", "slack://general/123", "crawler");
+    db.prepare(
+      "INSERT INTO documents (id, source_type, title, content, url, submitted_by) VALUES (?, ?, ?, ?, ?, ?)",
+    ).run("other-1", "manual", "Other doc", "content", "https://example.com", "manual");
+
+    db.prepare(
+      "INSERT INTO chunks (id, document_id, content, chunk_index) VALUES (?, ?, ?, ?)",
+    ).run("chunk-1", "slack-1", "chunk content", 0);
+
+    const count = disconnectSlack(db);
+    expect(count).toBe(1);
+
+    const slackDocs = db.prepare("SELECT * FROM documents WHERE url LIKE 'slack://%'").all();
+    expect(slackDocs).toHaveLength(0);
+
+    const otherDocs = db.prepare("SELECT * FROM documents WHERE id = 'other-1'").all();
+    expect(otherDocs).toHaveLength(1);
+
+    const chunks = db.prepare("SELECT * FROM chunks WHERE document_id = 'slack-1'").all();
+    expect(chunks).toHaveLength(0);
+  });
+
+  it("returns 0 when no Slack documents exist", () => {
+    const count = disconnectSlack(db);
+    expect(count).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Implements a Slack connector that indexes channel messages and threads into the LibScope knowledge base (#151).

## Changes

### New files
- **`src/connectors/index.ts`** — Shared connector infrastructure (config save/load, document cleanup)
- **`src/connectors/slack.ts`** — Slack connector with:
  - `syncSlack()` — Fetch and index channels, messages, and threads
  - `convertSlackMrkdwn()` — Convert Slack mrkdwn to standard markdown
  - `disconnectSlack()` — Remove all Slack-sourced documents
- **`tests/unit/slack.test.ts`** — 24 tests covering all functionality

### Modified files
- **`src/cli/index.ts`** — Added `connect slack` and `disconnect slack` commands
- **`src/mcp/server.ts`** — Added `sync-slack` MCP tool
- **`src/core/index.ts`** — Re-exports for Slack connector and connector infra

## Features
- Channel listing, filtering, and exclusion
- Thread aggregation (full thread as one doc) and separate modes
- User mention resolution (`<@U1234>` → `@username`) with caching
- Incremental sync via `lastSync`/`oldest` parameter
- Rate limiting (1.2s delay between Slack API calls)
- Mrkdwn → Markdown conversion (bold, italic, strike, links, channels, code)
- Uses native `fetch` — no Slack SDK dependency

## Testing
- 24 new tests, all passing
- Full suite: 394 tests passing
- Typecheck, lint, and format all clean

Closes #151