### PR TITLE
feat: add Confluence space and page connector (closes #153)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1456,81 +1456,135 @@ connectCmd
         for (const e of result.errors) {
           console.log(`    - ${e.file}: ${e.error}`);
         }
+      }
+    },
+  );
 
-        connectCmd
-          .command("slack")
-          .description("Connect a Slack workspace")
-          .option("--token <token>", "Slack bot or user token (xoxb-... or xoxp-...)")
-          .option("--channels <channels>", "Comma-separated channel names or IDs, or 'all'", "all")
-          .option("--exclude <channels>", "Comma-separated channel names to exclude")
-          .option(
-            "--thread-mode <mode>",
-            "Thread handling: aggregate (full thread as one doc) or separate",
-            "aggregate",
-          )
-          .option("--sync", "Sync using saved configuration")
-          .action(
-            async (opts: {
-              token?: string;
-              channels: string;
-              exclude?: string;
-              threadMode: string;
-              sync?: boolean;
-            }) => {
-              const { db, provider } = initializeAppWithEmbedding();
-              try {
-                let slackConfig: SlackConfig;
+connectCmd
+  .command("slack")
+  .description("Connect a Slack workspace")
+  .option("--token <token>", "Slack bot or user token (xoxb-... or xoxp-...)")
+  .option("--channels <channels>", "Comma-separated channel names or IDs, or 'all'", "all")
+  .option("--exclude <channels>", "Comma-separated channel names to exclude")
+  .option(
+    "--thread-mode <mode>",
+    "Thread handling: aggregate (full thread as one doc) or separate",
+    "aggregate",
+  )
+  .option("--sync", "Sync using saved configuration")
+  .action(
+    async (opts: {
+      token?: string;
+      channels: string;
+      exclude?: string;
+      threadMode: string;
+      sync?: boolean;
+    }) => {
+      const { db, provider } = initializeAppWithEmbedding();
+      try {
+        let slackConfig: SlackConfig;
 
-                if (opts.sync) {
-                  if (!hasNamedConnectorConfig("slack")) {
-                    console.error(
-                      "No Slack configuration found. Run 'libscope connect slack --token ...' first.",
-                    );
-                    process.exit(1);
-                  }
-                  slackConfig = loadNamedConnectorConfig<SlackConfig>("slack");
-                } else {
-                  if (!opts.token) {
-                    console.error("--token is required for initial Slack connection.");
-                    process.exit(1);
-                  }
-                  slackConfig = {
-                    token: opts.token,
-                    channels: opts.channels.split(",").map((c) => c.trim()),
-                    threadMode: opts.threadMode === "separate" ? "separate" : "aggregate",
-                  };
-                  if (opts.exclude) {
-                    slackConfig = {
-                      ...slackConfig,
-                      excludeChannels: opts.exclude.split(",").map((c) => c.trim()),
-                    };
-                  }
-                }
+        if (opts.sync) {
+          if (!hasNamedConnectorConfig("slack")) {
+            console.error(
+              "No Slack configuration found. Run 'libscope connect slack --token ...' first.",
+            );
+            process.exit(1);
+          }
+          slackConfig = loadNamedConnectorConfig<SlackConfig>("slack");
+        } else {
+          if (!opts.token) {
+            console.error("--token is required for initial Slack connection.");
+            process.exit(1);
+          }
+          slackConfig = {
+            token: opts.token,
+            channels: opts.channels.split(",").map((c) => c.trim()),
+            threadMode: opts.threadMode === "separate" ? "separate" : "aggregate",
+          };
+          if (opts.exclude) {
+            slackConfig = {
+              ...slackConfig,
+              excludeChannels: opts.exclude.split(",").map((c) => c.trim()),
+            };
+          }
+        }
 
-                console.log("Syncing Slack messages...");
-                const result = await syncSlack(db, provider, slackConfig);
+        console.log("Syncing Slack messages...");
+        const result = await syncSlack(db, provider, slackConfig);
 
-                const updatedConfig: SlackConfig = {
-                  ...slackConfig,
-                  lastSync: new Date().toISOString(),
-                };
-                saveNamedConnectorConfig("slack", updatedConfig);
+        const updatedConfig: SlackConfig = {
+          ...slackConfig,
+          lastSync: new Date().toISOString(),
+        };
+        saveNamedConnectorConfig("slack", updatedConfig);
 
-                console.log(`✓ Slack sync complete:`);
-                console.log(`  Channels: ${result.channels}`);
-                console.log(`  Messages indexed: ${result.messagesIndexed}`);
-                console.log(`  Threads indexed: ${result.threadsIndexed}`);
-                if (result.errors.length > 0) {
-                  console.log(`  Errors: ${result.errors.length}`);
-                  for (const err of result.errors) {
-                    console.log(`    - #${err.channel}: ${err.error}`);
-                  }
-                }
-              } finally {
-                closeDatabase();
-              }
-            },
-          );
+        console.log(`✓ Slack sync complete:`);
+        console.log(`  Channels: ${result.channels}`);
+        console.log(`  Messages indexed: ${result.messagesIndexed}`);
+        console.log(`  Threads indexed: ${result.threadsIndexed}`);
+        if (result.errors.length > 0) {
+          console.log(`  Errors: ${result.errors.length}`);
+          for (const err of result.errors) {
+            console.log(`    - #${err.channel}: ${err.error}`);
+          }
+        }
+      } finally {
+        closeDatabase();
+      }
+    },
+  );
+
+connectCmd
+  .command("confluence")
+  .description("Sync Confluence spaces and pages")
+  .option("--url <url>", "Confluence base URL (e.g. https://acme.atlassian.net)")
+  .option("--email <email>", "Confluence user email")
+  .option("--token <token>", "API token or PAT")
+  .option("--spaces <keys>", "Comma-separated space keys, or 'all'", "all")
+  .option("--exclude-spaces <keys>", "Comma-separated space keys to exclude")
+  .option("--sync", "Sync using previously saved config")
+  .action(
+    async (opts: {
+      url?: string;
+      email?: string;
+      token?: string;
+      spaces?: string;
+      excludeSpaces?: string;
+      sync?: boolean;
+    }) => {
+      const { syncConfluence } = await import("../connectors/confluence.js");
+      const { db, provider } = initializeAppWithEmbedding();
+      try {
+        const url = opts.url ?? process.env["CONFLUENCE_URL"] ?? "";
+        const email = opts.email ?? process.env["CONFLUENCE_EMAIL"] ?? "";
+        const token = opts.token ?? process.env["CONFLUENCE_TOKEN"] ?? "";
+
+        const spaces = (opts.spaces ?? "all").split(",").map((s) => s.trim());
+        const excludeSpaces = opts.excludeSpaces
+          ? opts.excludeSpaces.split(",").map((s) => s.trim())
+          : undefined;
+
+        const result = await syncConfluence(db, provider, {
+          baseUrl: url,
+          email,
+          token,
+          spaces,
+          excludeSpaces,
+        });
+
+        console.log(`✓ Confluence sync complete`);
+        console.log(`  Spaces: ${result.spaces}`);
+        console.log(`  Pages indexed: ${result.pagesIndexed}`);
+        console.log(`  Pages updated: ${result.pagesUpdated}`);
+        if (result.errors.length > 0) {
+          console.log(`  Errors: ${result.errors.length}`);
+          for (const e of result.errors) {
+            console.log(`    - ${e.page}: ${e.error}`);
+          }
+        }
+      } finally {
+        closeDatabase();
       }
     },
   );
@@ -1550,69 +1604,83 @@ disconnectCmd
 
     const removed = disconnectVault(db, resolvedPath);
     console.log(`✓ Disconnected vault. Removed ${removed} documents.`);
+  });
 
-    connectCmd
-      .command("notion")
-      .description("Connect and sync Notion pages and databases")
-      .option("--token <token>", "Notion integration token (secret_...)")
-      .option("--sync", "Sync pages using a previously stored token")
-      .option("--exclude <ids...>", "Page/database IDs to exclude")
-      .action(async (opts: { token?: string; sync?: boolean; exclude?: string[] }) => {
-        const { db, provider } = initializeAppWithEmbedding();
-        let token = opts.token;
+connectCmd
+  .command("notion")
+  .description("Connect and sync Notion pages and databases")
+  .option("--token <token>", "Notion integration token (secret_...)")
+  .option("--sync", "Sync pages using a previously stored token")
+  .option("--exclude <ids...>", "Page/database IDs to exclude")
+  .action(async (opts: { token?: string; sync?: boolean; exclude?: string[] }) => {
+    const { db, provider } = initializeAppWithEmbedding();
+    let token = opts.token;
 
-        if (opts.sync && !token) {
-          token = process.env["NOTION_TOKEN"];
-          if (!token) {
-            console.error("Error: --token is required, or set NOTION_TOKEN environment variable.");
-            process.exitCode = 1;
-            return;
-          }
-        }
+    if (opts.sync && !token) {
+      token = process.env["NOTION_TOKEN"];
+      if (!token) {
+        console.error("Error: --token is required, or set NOTION_TOKEN environment variable.");
+        process.exitCode = 1;
+        return;
+      }
+    }
 
-        if (!token) {
-          console.error("Error: --token <token> is required.");
-          process.exitCode = 1;
-          return;
-        }
+    if (!token) {
+      console.error("Error: --token <token> is required.");
+      process.exitCode = 1;
+      return;
+    }
 
-        const config: NotionConfig = { token };
-        if (opts.exclude) {
-          config.excludePages = opts.exclude;
-        }
+    const config: NotionConfig = { token };
+    if (opts.exclude) {
+      config.excludePages = opts.exclude;
+    }
 
-        console.log("Syncing Notion...");
-        const result = await syncNotion(db, provider, config);
-        console.log(
-          `✓ Synced: ${result.pagesIndexed} pages, ${result.databasesIndexed} databases` +
-            (result.errors.length > 0 ? `, ${result.errors.length} errors` : ""),
-        );
-        for (const err of result.errors) {
-          console.log(`  ⚠ ${err.page}: ${err.error}`);
-        }
-      });
+    console.log("Syncing Notion...");
+    const result = await syncNotion(db, provider, config);
+    console.log(
+      `✓ Synced: ${result.pagesIndexed} pages, ${result.databasesIndexed} databases` +
+        (result.errors.length > 0 ? `, ${result.errors.length} errors` : ""),
+    );
+    for (const err of result.errors) {
+      console.log(`  ⚠ ${err.page}: ${err.error}`);
+    }
+  });
 
-    disconnectCmd
-      .command("notion")
-      .description("Remove all Notion documents")
-      .action(async () => {
-        const { db } = initializeApp();
-        const removed = await disconnectNotion(db);
-        console.log(`✓ Removed ${removed} Notion documents.`);
-      });
+disconnectCmd
+  .command("notion")
+  .description("Remove all Notion documents")
+  .action(async () => {
+    const { db } = initializeApp();
+    const removed = await disconnectNotion(db);
+    console.log(`✓ Removed ${removed} Notion documents.`);
+  });
 
-    disconnectCmd
-      .command("slack")
-      .description("Remove all Slack data from the knowledge base")
-      .action(() => {
-        const { db } = initializeApp();
-        try {
-          const count = disconnectSlack(db);
-          console.log(`✓ Removed ${count} Slack documents from the knowledge base.`);
-        } finally {
-          closeDatabase();
-        }
-      });
+disconnectCmd
+  .command("slack")
+  .description("Remove all Slack data from the knowledge base")
+  .action(() => {
+    const { db } = initializeApp();
+    try {
+      const count = disconnectSlack(db);
+      console.log(`✓ Removed ${count} Slack documents from the knowledge base.`);
+    } finally {
+      closeDatabase();
+    }
+  });
+
+disconnectCmd
+  .command("confluence")
+  .description("Remove all Confluence-synced content")
+  .action(async () => {
+    const { disconnectConfluence } = await import("../connectors/confluence.js");
+    const { db } = initializeApp();
+    try {
+      const removed = disconnectConfluence(db);
+      console.log(`✓ Removed ${removed} Confluence documents`);
+    } finally {
+      closeDatabase();
+    }
   });
 
 program.parse();

--- a/src/connectors/confluence.ts
+++ b/src/connectors/confluence.ts
@@ -1,0 +1,370 @@
+import type Database from "better-sqlite3";
+import { NodeHtmlMarkdown } from "node-html-markdown";
+import type { EmbeddingProvider } from "../providers/embedding.js";
+import { indexDocument } from "../core/indexing.js";
+import { createTopic } from "../core/topics.js";
+import { addTagsToDocument } from "../core/tags.js";
+import { deleteDocument } from "../core/documents.js";
+import { getLogger } from "../logger.js";
+import { FetchError, ValidationError } from "../errors.js";
+
+export interface ConfluenceConfig {
+  baseUrl: string;
+  email: string;
+  token: string;
+  spaces: string[];
+  lastSync?: string | undefined;
+  excludeSpaces?: string[] | undefined;
+}
+
+export interface ConfluenceSyncResult {
+  spaces: number;
+  pagesIndexed: number;
+  pagesUpdated: number;
+  errors: Array<{ page: string; error: string }>;
+}
+
+interface ConfluenceSpace {
+  id: string;
+  key: string;
+  name: string;
+}
+
+interface ConfluencePage {
+  id: string;
+  title: string;
+  spaceId: string;
+  version: { number: number };
+  body?: { storage?: { value: string } };
+  labels?: { results: Array<{ name: string }> };
+  _links?: { webui?: string };
+}
+
+interface PaginatedResponse<T> {
+  results: T[];
+  _links?: { next?: string };
+}
+
+function buildAuthHeader(email: string, token: string): string {
+  const encoded = Buffer.from(`${email}:${token}`).toString("base64");
+  return `Basic ${encoded}`;
+}
+
+async function confluenceFetch<T>(url: string, auth: string): Promise<T> {
+  const log = getLogger();
+  log.debug({ url }, "Confluence API request");
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: auth,
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new FetchError(
+      `Confluence API error ${response.status}: ${response.statusText} — ${body}`,
+    );
+  }
+
+  return (await response.json()) as T;
+}
+
+async function fetchAllPages<T>(initialUrl: string, baseUrl: string, auth: string): Promise<T[]> {
+  const all: T[] = [];
+  let url: string | undefined = initialUrl;
+
+  while (url) {
+    const resp: PaginatedResponse<T> = await confluenceFetch<PaginatedResponse<T>>(url, auth);
+    all.push(...resp.results);
+    const next: string | undefined = resp._links?.next;
+    url = next ? `${baseUrl}${next}` : undefined;
+  }
+
+  return all;
+}
+
+export function convertConfluenceStorage(html: string): string {
+  let processed = html;
+
+  // Code blocks: <ac:structured-macro ac:name="code">
+  processed = processed.replace(
+    /<ac:structured-macro\s[^>]*ac:name="code"[^>]*>([\s\S]*?)<\/ac:structured-macro>/gi,
+    (_match, inner: string) => {
+      const langMatch = /<ac:parameter\s+ac:name="language">(.*?)<\/ac:parameter>/i.exec(inner);
+      const lang = langMatch?.[1] ?? "";
+      const bodyMatch =
+        /<ac:plain-text-body>\s*<!\[CDATA\[([\s\S]*?)\]\]>\s*<\/ac:plain-text-body>/i.exec(inner);
+      const code = bodyMatch?.[1] ?? "";
+      const langAttr = lang ? ` class="language-${lang}"` : "";
+      return `<pre><code${langAttr}>${code}</code></pre>`;
+    },
+  );
+
+  // Info/note/warning/tip panels
+  processed = processed.replace(
+    /<ac:structured-macro\s[^>]*ac:name="(info|note|warning|tip)"[^>]*>([\s\S]*?)<\/ac:structured-macro>/gi,
+    (_match, type: string, inner: string) => {
+      const bodyMatch = /<ac:rich-text-body>([\s\S]*?)<\/ac:rich-text-body>/i.exec(inner);
+      const body = bodyMatch?.[1] ?? "";
+      const prefix = type.charAt(0).toUpperCase() + type.slice(1);
+      return `<blockquote><strong>${prefix}:</strong> ${body.trim()}</blockquote>`;
+    },
+  );
+
+  // Panel → blockquote
+  processed = processed.replace(
+    /<ac:structured-macro\s[^>]*ac:name="panel"[^>]*>([\s\S]*?)<\/ac:structured-macro>/gi,
+    (_match, inner: string) => {
+      const bodyMatch = /<ac:rich-text-body>([\s\S]*?)<\/ac:rich-text-body>/i.exec(inner);
+      const body = bodyMatch?.[1] ?? "";
+      return `<blockquote>${body.trim()}</blockquote>`;
+    },
+  );
+
+  // Expand → just content
+  processed = processed.replace(
+    /<ac:structured-macro\s[^>]*ac:name="expand"[^>]*>([\s\S]*?)<\/ac:structured-macro>/gi,
+    (_match, inner: string) => {
+      const titleMatch = /<ac:parameter\s+ac:name="title">(.*?)<\/ac:parameter>/i.exec(inner);
+      const bodyMatch = /<ac:rich-text-body>([\s\S]*?)<\/ac:rich-text-body>/i.exec(inner);
+      const title = titleMatch?.[1] ?? "Details";
+      const body = bodyMatch?.[1] ?? "";
+      return `<p><strong>${title}</strong></p>${body.trim()}`;
+    },
+  );
+
+  // TOC → strip
+  processed = processed.replace(
+    /<ac:structured-macro\s[^>]*ac:name="toc"[^>]*>[\s\S]*?<\/ac:structured-macro>/gi,
+    "",
+  );
+  // Self-closing TOC
+  processed = processed.replace(/<ac:structured-macro\s[^>]*ac:name="toc"[^>]*\/>/gi, "");
+
+  // JIRA macro → [JIRA: KEY-123] as a span to avoid escaping
+  processed = processed.replace(
+    /<ac:structured-macro\s[^>]*ac:name="jira"[^>]*>([\s\S]*?)<\/ac:structured-macro>/gi,
+    (_match, inner: string) => {
+      const keyMatch = /<ac:parameter\s+ac:name="key">(.*?)<\/ac:parameter>/i.exec(inner);
+      const key = keyMatch?.[1] ?? "UNKNOWN";
+      return `<span>[JIRA: ${key}]</span>`;
+    },
+  );
+
+  // ac:image → [image] as span
+  processed = processed.replace(/<ac:image[^>]*>[\s\S]*?<\/ac:image>/gi, "<span>[image]</span>");
+
+  // ac:link → extract URL/title as an anchor
+  processed = processed.replace(
+    /<ac:link[^>]*>([\s\S]*?)<\/ac:link>/gi,
+    (_match, inner: string) => {
+      const titleMatch =
+        /<ac:link-body>(.*?)<\/ac:link-body>/i.exec(inner) ??
+        /<ac:plain-text-link-body>\s*<!\[CDATA\[(.*?)\]\]>\s*<\/ac:plain-text-link-body>/i.exec(
+          inner,
+        );
+      const title = titleMatch?.[1] ?? "link";
+      const hrefMatch = /<ri:page\s+ri:content-title="([^"]*)"[^>]*/i.exec(inner);
+      if (hrefMatch?.[1]) {
+        return `<a href="${hrefMatch[1]}">${title}</a>`;
+      }
+      return `<span>[${title}]</span>`;
+    },
+  );
+
+  // ri:attachment → [attached: filename] as span
+  processed = processed.replace(
+    /<ri:attachment\s+ri:filename="([^"]*)"[^>]*\/?>/gi,
+    (_match, filename: string) => `<span>[attached: ${filename}]</span>`,
+  );
+
+  // Strip remaining ac:parameter tags
+  processed = processed.replace(/<ac:parameter[^>]*>[\s\S]*?<\/ac:parameter>/gi, "");
+
+  // Strip remaining ac:structured-macro wrappers but keep body
+  processed = processed.replace(/<\/?ac:structured-macro[^>]*>/gi, "");
+  processed = processed.replace(/<\/?ac:rich-text-body>/gi, "");
+  processed = processed.replace(/<\/?ac:plain-text-body>/gi, "");
+
+  // Convert remaining HTML to markdown
+  let markdown = NodeHtmlMarkdown.translate(processed);
+
+  // Un-escape bracket patterns that NHM escaped
+  markdown = markdown.replace(/\\\[JIRA: ([^\]]+)\\\]/g, "[JIRA: $1]");
+  markdown = markdown.replace(/\\\[image\\\]/g, "[image]");
+  markdown = markdown.replace(/\\\[attached: ([^\]]+)\\\]/g, "[attached: $1]");
+
+  return markdown;
+}
+
+function extractLabels(page: ConfluencePage): string[] {
+  return page.labels?.results.map((l) => l.name) ?? [];
+}
+
+export async function syncConfluence(
+  db: Database.Database,
+  provider: EmbeddingProvider,
+  config: ConfluenceConfig,
+): Promise<ConfluenceSyncResult> {
+  const log = getLogger();
+
+  if (!config.baseUrl.trim()) {
+    throw new ValidationError("Confluence baseUrl is required");
+  }
+  if (!config.email.trim()) {
+    throw new ValidationError("Confluence email is required");
+  }
+  if (!config.token.trim()) {
+    throw new ValidationError("Confluence token is required");
+  }
+
+  const auth = buildAuthHeader(config.email, config.token);
+  const base = config.baseUrl.replace(/\/+$/, "");
+  const result: ConfluenceSyncResult = { spaces: 0, pagesIndexed: 0, pagesUpdated: 0, errors: [] };
+
+  log.info({ baseUrl: base }, "Starting Confluence sync");
+
+  // Fetch all spaces
+  const allSpaces = await fetchAllPages<ConfluenceSpace>(`${base}/wiki/api/v2/spaces`, base, auth);
+
+  // Filter spaces
+  const excludeSet = new Set(config.excludeSpaces ?? []);
+  const requestedAll = config.spaces.length === 1 && config.spaces[0] === "all";
+  const spacesToSync = allSpaces.filter((s) => {
+    if (excludeSet.has(s.key)) return false;
+    return requestedAll || config.spaces.includes(s.key);
+  });
+
+  result.spaces = spacesToSync.length;
+  log.info({ spaceCount: spacesToSync.length }, "Spaces to sync");
+
+  for (const space of spacesToSync) {
+    // Create or get topic for this space
+    const topic = createTopic(db, { name: space.name });
+
+    // Fetch pages in space
+    let pages: ConfluencePage[];
+    try {
+      pages = await fetchAllPages<ConfluencePage>(
+        `${base}/wiki/api/v2/spaces/${space.id}/pages`,
+        base,
+        auth,
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error({ spaceKey: space.key, err }, "Failed to fetch pages for space");
+      result.errors.push({ page: `space:${space.key}`, error: msg });
+      continue;
+    }
+
+    for (const page of pages) {
+      try {
+        // Fetch full page content with body
+        const fullPage = await confluenceFetch<ConfluencePage>(
+          `${base}/wiki/api/v2/pages/${page.id}?body-format=storage`,
+          auth,
+        );
+
+        const storageHtml = fullPage.body?.storage?.value ?? "";
+        const pageUrl = fullPage._links?.webui
+          ? `${base}${fullPage._links.webui}`
+          : `${base}/wiki/spaces/${space.key}/pages/${page.id}`;
+
+        // Incremental sync: check existing doc version
+        const existingDoc = db
+          .prepare("SELECT id, url FROM documents WHERE url = ?")
+          .get(pageUrl) as { id: string; url: string } | undefined;
+
+        const existingMeta = existingDoc
+          ? (db
+              .prepare(
+                "SELECT id FROM document_tags dt JOIN tags t ON dt.tag_id = t.id WHERE dt.document_id = ? AND t.name = ?",
+              )
+              .get(existingDoc.id, `confluence-version:${fullPage.version.number}`) as
+              | { id: string }
+              | undefined)
+          : undefined;
+
+        if (existingDoc && existingMeta) {
+          // Same version — skip
+          log.debug({ pageId: page.id, title: page.title }, "Page unchanged, skipping");
+          continue;
+        }
+
+        if (existingDoc) {
+          // Version changed — delete old doc and re-index
+          deleteDocument(db, existingDoc.id);
+          result.pagesUpdated++;
+        }
+
+        const markdown = convertConfluenceStorage(storageHtml);
+
+        const indexed = await indexDocument(db, provider, {
+          title: fullPage.title,
+          content: markdown,
+          sourceType: "topic",
+          topicId: topic.id,
+          url: pageUrl,
+          submittedBy: "crawler",
+          dedup: "force",
+        });
+
+        // Extract labels as tags + add version tag for incremental sync
+        const labels = extractLabels(fullPage);
+        const allTags = [
+          ...labels,
+          `confluence-space:${space.key}`,
+          `confluence-version:${fullPage.version.number}`,
+        ];
+        addTagsToDocument(db, indexed.id, allTags);
+
+        result.pagesIndexed++;
+        log.info(
+          { pageId: page.id, title: fullPage.title, chunkCount: indexed.chunkCount },
+          "Page indexed",
+        );
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        log.error({ pageId: page.id, title: page.title, err }, "Failed to index page");
+        result.errors.push({ page: page.title, error: msg });
+      }
+    }
+  }
+
+  log.info(
+    {
+      spaces: result.spaces,
+      indexed: result.pagesIndexed,
+      updated: result.pagesUpdated,
+      errors: result.errors.length,
+    },
+    "Confluence sync complete",
+  );
+
+  return result;
+}
+
+export function disconnectConfluence(db: Database.Database): number {
+  const log = getLogger();
+
+  // Find all documents tagged as confluence content
+  const rows = db
+    .prepare(
+      `SELECT DISTINCT dt.document_id
+       FROM document_tags dt
+       JOIN tags t ON dt.tag_id = t.id
+       WHERE t.name LIKE 'confluence-space:%'`,
+    )
+    .all() as Array<{ document_id: string }>;
+
+  for (const row of rows) {
+    deleteDocument(db, row.document_id);
+  }
+
+  log.info({ removedCount: rows.length }, "Confluence disconnected");
+  return rows.length;
+}
+
+export { buildAuthHeader };

--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -130,3 +130,11 @@ export function deleteConnectorDocuments(db: Database.Database, sourceType: stri
 
 export { syncNotion, convertNotionBlocks, disconnectNotion } from "./notion.js";
 export type { NotionConfig, NotionSyncResult, NotionBlock } from "./notion.js";
+
+export {
+  syncConfluence,
+  convertConfluenceStorage,
+  disconnectConfluence,
+  buildAuthHeader,
+} from "./confluence.js";
+export type { ConfluenceConfig, ConfluenceSyncResult } from "./confluence.js";

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -159,3 +159,10 @@ export {
   deleteConnectorDocuments,
 } from "../connectors/index.js";
 export type { ConnectorConfig } from "../connectors/index.js";
+
+export {
+  syncConfluence,
+  convertConfluenceStorage,
+  disconnectConfluence,
+} from "../connectors/confluence.js";
+export type { ConfluenceConfig, ConfluenceSyncResult } from "../connectors/confluence.js";

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -747,6 +747,43 @@ async function main(): Promise<void> {
     }),
   );
 
+  // Tool: sync-confluence
+  server.tool(
+    "sync-confluence",
+    "Sync Confluence spaces and pages into the knowledge base",
+    {
+      baseUrl: z.string().describe("Confluence base URL (e.g. https://acme.atlassian.net)"),
+      email: z.string().describe("Confluence user email"),
+      token: z.string().describe("API token or PAT"),
+      spaces: z
+        .array(z.string())
+        .optional()
+        .describe("Space keys to sync, or ['all'] (default: ['all'])"),
+      excludeSpaces: z.array(z.string()).optional().describe("Space keys to exclude"),
+    },
+    withErrorHandling(async (params) => {
+      const { syncConfluence } = await import("../connectors/confluence.js");
+      const result = await syncConfluence(db, provider, {
+        baseUrl: params.baseUrl,
+        email: params.email,
+        token: params.token,
+        spaces: params.spaces ?? ["all"],
+        excludeSpaces: params.excludeSpaces,
+      });
+
+      const text =
+        `Confluence sync complete.\n` +
+        `Spaces: ${result.spaces}\n` +
+        `Pages indexed: ${result.pagesIndexed}\n` +
+        `Pages updated: ${result.pagesUpdated}` +
+        (result.errors.length > 0
+          ? `\nErrors: ${result.errors.map((e) => `${e.page}: ${e.error}`).join(", ")}`
+          : "");
+
+      return { content: [{ type: "text" as const, text }] };
+    }),
+  );
+
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/tests/unit/confluence.test.ts
+++ b/tests/unit/confluence.test.ts
@@ -1,0 +1,498 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createTestDbWithVec } from "../fixtures/test-db.js";
+import { MockEmbeddingProvider } from "../fixtures/mock-provider.js";
+import {
+  syncConfluence,
+  convertConfluenceStorage,
+  disconnectConfluence,
+  buildAuthHeader,
+} from "../../src/connectors/confluence.js";
+import type { ConfluenceConfig } from "../../src/connectors/confluence.js";
+import type Database from "better-sqlite3";
+
+function makeSpacesResponse(spaces: Array<{ id: string; key: string; name: string }>) {
+  return { results: spaces, _links: {} };
+}
+
+function makePagesResponse(
+  pages: Array<{
+    id: string;
+    title: string;
+    spaceId: string;
+    version?: { number: number };
+  }>,
+  nextLink?: string,
+) {
+  return {
+    results: pages.map((p) => ({
+      ...p,
+      version: p.version ?? { number: 1 },
+    })),
+    _links: nextLink ? { next: nextLink } : {},
+  };
+}
+
+function makePageDetail(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "page-1",
+    title: "Test Page",
+    spaceId: "space-1",
+    version: { number: 1 },
+    body: { storage: { value: "<p>Hello world</p>" } },
+    labels: { results: [{ name: "docs" }, { name: "api" }] },
+    _links: { webui: "/wiki/spaces/ENG/pages/page-1" },
+    ...overrides,
+  };
+}
+
+describe("Confluence connector", () => {
+  let db: Database.Database;
+  let provider: MockEmbeddingProvider;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    db = createTestDbWithVec();
+    provider = new MockEmbeddingProvider();
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    db.close();
+  });
+
+  function mockFetchResponse(body: unknown, ok = true, status = 200): Response {
+    return {
+      ok,
+      status,
+      statusText: ok ? "OK" : "Error",
+      json: () => Promise.resolve(body),
+      text: () => Promise.resolve(JSON.stringify(body)),
+      headers: new Headers(),
+      redirected: false,
+      type: "basic",
+      url: "",
+      clone: () => mockFetchResponse(body, ok, status),
+      body: null,
+      bodyUsed: false,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+      blob: () => Promise.resolve(new Blob()),
+      formData: () => Promise.resolve(new FormData()),
+    } as Response;
+  }
+
+  const baseConfig: ConfluenceConfig = {
+    baseUrl: "https://acme.atlassian.net",
+    email: "user@example.com",
+    token: "test-token",
+    spaces: ["ENG"],
+  };
+
+  describe("buildAuthHeader", () => {
+    it("should encode email:token as base64", () => {
+      const header = buildAuthHeader("user@co.com", "mytoken");
+      const expected = Buffer.from("user@co.com:mytoken").toString("base64");
+      expect(header).toBe(`Basic ${expected}`);
+    });
+  });
+
+  describe("convertConfluenceStorage", () => {
+    it("should convert basic HTML to markdown", () => {
+      const result = convertConfluenceStorage("<h1>Title</h1><p>Hello world</p>");
+      expect(result).toContain("Title");
+      expect(result).toContain("Hello world");
+    });
+
+    it("should convert code macros to fenced code blocks", () => {
+      const html = `<ac:structured-macro ac:name="code"><ac:parameter ac:name="language">javascript</ac:parameter><ac:plain-text-body><![CDATA[const x = 1;]]></ac:plain-text-body></ac:structured-macro>`;
+      const result = convertConfluenceStorage(html);
+      expect(result).toContain("```javascript");
+      expect(result).toContain("const x = 1;");
+      expect(result).toContain("```");
+    });
+
+    it("should convert info/note/warning/tip macros to blockquotes", () => {
+      const html = `<ac:structured-macro ac:name="info"><ac:rich-text-body>This is info</ac:rich-text-body></ac:structured-macro>`;
+      const result = convertConfluenceStorage(html);
+      expect(result).toContain("Info:");
+      expect(result).toContain("This is info");
+    });
+
+    it("should convert warning macros", () => {
+      const html = `<ac:structured-macro ac:name="warning"><ac:rich-text-body>Danger!</ac:rich-text-body></ac:structured-macro>`;
+      const result = convertConfluenceStorage(html);
+      expect(result).toContain("Warning:");
+      expect(result).toContain("Danger!");
+    });
+
+    it("should convert panel macros to blockquotes", () => {
+      const html = `<ac:structured-macro ac:name="panel"><ac:rich-text-body>Panel content</ac:rich-text-body></ac:structured-macro>`;
+      const result = convertConfluenceStorage(html);
+      expect(result).toContain("Panel content");
+    });
+
+    it("should handle expand macros", () => {
+      const html = `<ac:structured-macro ac:name="expand"><ac:parameter ac:name="title">More info</ac:parameter><ac:rich-text-body>Expanded content</ac:rich-text-body></ac:structured-macro>`;
+      const result = convertConfluenceStorage(html);
+      expect(result).toContain("More info");
+      expect(result).toContain("Expanded content");
+    });
+
+    it("should strip toc macros", () => {
+      const html = `<ac:structured-macro ac:name="toc"><ac:parameter ac:name="maxLevel">3</ac:parameter></ac:structured-macro><p>Content</p>`;
+      const result = convertConfluenceStorage(html);
+      expect(result).not.toContain("toc");
+      expect(result).toContain("Content");
+    });
+
+    it("should convert jira macros to JIRA references", () => {
+      const html = `<ac:structured-macro ac:name="jira"><ac:parameter ac:name="key">PROJ-123</ac:parameter></ac:structured-macro>`;
+      const result = convertConfluenceStorage(html);
+      expect(result).toContain("[JIRA: PROJ-123]");
+    });
+
+    it("should convert ac:image to [image]", () => {
+      const html = `<ac:image><ri:attachment ri:filename="diagram.png"/></ac:image>`;
+      const result = convertConfluenceStorage(html);
+      expect(result).toContain("[image]");
+    });
+
+    it("should convert ac:link to markdown links", () => {
+      const html = `<ac:link><ri:page ri:content-title="Other Page"/><ac:link-body>Other Page</ac:link-body></ac:link>`;
+      const result = convertConfluenceStorage(html);
+      expect(result).toContain("Other Page");
+    });
+
+    it("should convert ri:attachment to attached reference", () => {
+      const html = `<ri:attachment ri:filename="report.pdf"/>`;
+      const result = convertConfluenceStorage(html);
+      expect(result).toContain("[attached: report.pdf]");
+    });
+
+    it("should convert tables to markdown", () => {
+      const html = `<table><tr><th>Name</th><th>Value</th></tr><tr><td>A</td><td>1</td></tr></table>`;
+      const result = convertConfluenceStorage(html);
+      expect(result).toContain("Name");
+      expect(result).toContain("Value");
+    });
+
+    it("should strip ac:parameter tags", () => {
+      const html = `<ac:parameter ac:name="foo">bar</ac:parameter><p>Content</p>`;
+      const result = convertConfluenceStorage(html);
+      expect(result).not.toContain("ac:parameter");
+      expect(result).toContain("Content");
+    });
+  });
+
+  describe("syncConfluence", () => {
+    it("should validate required config fields", async () => {
+      await expect(syncConfluence(db, provider, { ...baseConfig, baseUrl: "" })).rejects.toThrow(
+        "baseUrl is required",
+      );
+      await expect(syncConfluence(db, provider, { ...baseConfig, email: "" })).rejects.toThrow(
+        "email is required",
+      );
+      await expect(syncConfluence(db, provider, { ...baseConfig, token: "" })).rejects.toThrow(
+        "token is required",
+      );
+    });
+
+    it("should list spaces and index pages", async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          mockFetchResponse(
+            makeSpacesResponse([{ id: "space-1", key: "ENG", name: "Engineering" }]),
+          ),
+        )
+        .mockResolvedValueOnce(
+          mockFetchResponse(
+            makePagesResponse([{ id: "page-1", title: "Getting Started", spaceId: "space-1" }]),
+          ),
+        )
+        .mockResolvedValueOnce(mockFetchResponse(makePageDetail()));
+
+      const result = await syncConfluence(db, provider, baseConfig);
+
+      expect(result.spaces).toBe(1);
+      expect(result.pagesIndexed).toBe(1);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it("should handle pagination", async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          mockFetchResponse(
+            makeSpacesResponse([{ id: "space-1", key: "ENG", name: "Engineering" }]),
+          ),
+        )
+        // First page of pages with next link
+        .mockResolvedValueOnce(
+          mockFetchResponse(
+            makePagesResponse(
+              [{ id: "page-1", title: "Page 1", spaceId: "space-1" }],
+              "/wiki/api/v2/spaces/space-1/pages?cursor=abc",
+            ),
+          ),
+        )
+        // Second page of pages (no next link)
+        .mockResolvedValueOnce(
+          mockFetchResponse(
+            makePagesResponse([{ id: "page-2", title: "Page 2", spaceId: "space-1" }]),
+          ),
+        )
+        // Page detail for page-1
+        .mockResolvedValueOnce(
+          mockFetchResponse(
+            makePageDetail({
+              id: "page-1",
+              title: "Page 1",
+              _links: { webui: "/wiki/spaces/ENG/pages/page-1" },
+            }),
+          ),
+        )
+        // Page detail for page-2
+        .mockResolvedValueOnce(
+          mockFetchResponse(
+            makePageDetail({
+              id: "page-2",
+              title: "Page 2",
+              body: { storage: { value: "<p>Different content for page two</p>" } },
+              _links: { webui: "/wiki/spaces/ENG/pages/page-2" },
+            }),
+          ),
+        );
+
+      const result = await syncConfluence(db, provider, baseConfig);
+
+      expect(result.pagesIndexed).toBe(2);
+    });
+
+    it("should extract labels as tags", async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          mockFetchResponse(
+            makeSpacesResponse([{ id: "space-1", key: "ENG", name: "Engineering" }]),
+          ),
+        )
+        .mockResolvedValueOnce(
+          mockFetchResponse(
+            makePagesResponse([{ id: "page-1", title: "Test Page", spaceId: "space-1" }]),
+          ),
+        )
+        .mockResolvedValueOnce(
+          mockFetchResponse(
+            makePageDetail({
+              labels: { results: [{ name: "api" }, { name: "internal" }] },
+            }),
+          ),
+        );
+
+      await syncConfluence(db, provider, baseConfig);
+
+      // Check tags were created
+      const tags = db.prepare("SELECT name FROM tags ORDER BY name").all() as Array<{
+        name: string;
+      }>;
+      const tagNames = tags.map((t) => t.name);
+      expect(tagNames).toContain("api");
+      expect(tagNames).toContain("internal");
+      expect(tagNames).toContain("confluence-space:eng");
+    });
+
+    it("should skip unchanged pages on incremental sync", async () => {
+      // First sync
+      fetchMock
+        .mockResolvedValueOnce(
+          mockFetchResponse(
+            makeSpacesResponse([{ id: "space-1", key: "ENG", name: "Engineering" }]),
+          ),
+        )
+        .mockResolvedValueOnce(
+          mockFetchResponse(
+            makePagesResponse([{ id: "page-1", title: "Test", spaceId: "space-1" }]),
+          ),
+        )
+        .mockResolvedValueOnce(mockFetchResponse(makePageDetail()));
+
+      await syncConfluence(db, provider, baseConfig);
+
+      // Second sync — same version
+      fetchMock
+        .mockResolvedValueOnce(
+          mockFetchResponse(
+            makeSpacesResponse([{ id: "space-1", key: "ENG", name: "Engineering" }]),
+          ),
+        )
+        .mockResolvedValueOnce(
+          mockFetchResponse(
+            makePagesResponse([{ id: "page-1", title: "Test", spaceId: "space-1" }]),
+          ),
+        )
+        .mockResolvedValueOnce(mockFetchResponse(makePageDetail()));
+
+      const result = await syncConfluence(db, provider, baseConfig);
+
+      expect(result.pagesIndexed).toBe(0);
+      expect(result.pagesUpdated).toBe(0);
+    });
+
+    it("should update pages when version changes", async () => {
+      // First sync
+      fetchMock
+        .mockResolvedValueOnce(
+          mockFetchResponse(
+            makeSpacesResponse([{ id: "space-1", key: "ENG", name: "Engineering" }]),
+          ),
+        )
+        .mockResolvedValueOnce(
+          mockFetchResponse(
+            makePagesResponse([{ id: "page-1", title: "Test", spaceId: "space-1" }]),
+          ),
+        )
+        .mockResolvedValueOnce(mockFetchResponse(makePageDetail()));
+
+      await syncConfluence(db, provider, baseConfig);
+
+      // Second sync — new version
+      fetchMock
+        .mockResolvedValueOnce(
+          mockFetchResponse(
+            makeSpacesResponse([{ id: "space-1", key: "ENG", name: "Engineering" }]),
+          ),
+        )
+        .mockResolvedValueOnce(
+          mockFetchResponse(
+            makePagesResponse([
+              { id: "page-1", title: "Test", spaceId: "space-1", version: { number: 2 } },
+            ]),
+          ),
+        )
+        .mockResolvedValueOnce(
+          mockFetchResponse(
+            makePageDetail({
+              version: { number: 2 },
+              body: { storage: { value: "<p>Updated</p>" } },
+            }),
+          ),
+        );
+
+      const result = await syncConfluence(db, provider, baseConfig);
+
+      expect(result.pagesUpdated).toBe(1);
+      expect(result.pagesIndexed).toBe(1);
+    });
+
+    it("should handle API errors gracefully", async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          mockFetchResponse(
+            makeSpacesResponse([{ id: "space-1", key: "ENG", name: "Engineering" }]),
+          ),
+        )
+        .mockResolvedValueOnce(
+          mockFetchResponse(
+            makePagesResponse([{ id: "page-1", title: "Fail Page", spaceId: "space-1" }]),
+          ),
+        )
+        .mockResolvedValueOnce(mockFetchResponse({ error: "Not found" }, false, 404));
+
+      const result = await syncConfluence(db, provider, baseConfig);
+
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]?.page).toBe("Fail Page");
+    });
+
+    it("should filter spaces by config", async () => {
+      fetchMock.mockResolvedValueOnce(
+        mockFetchResponse(
+          makeSpacesResponse([
+            { id: "space-1", key: "ENG", name: "Engineering" },
+            { id: "space-2", key: "HR", name: "Human Resources" },
+          ]),
+        ),
+      );
+
+      // Only ENG pages
+      fetchMock.mockResolvedValueOnce(mockFetchResponse(makePagesResponse([])));
+
+      const result = await syncConfluence(db, provider, {
+        ...baseConfig,
+        spaces: ["ENG"],
+      });
+
+      expect(result.spaces).toBe(1);
+    });
+
+    it("should exclude spaces", async () => {
+      fetchMock.mockResolvedValueOnce(
+        mockFetchResponse(
+          makeSpacesResponse([
+            { id: "space-1", key: "ENG", name: "Engineering" },
+            { id: "space-2", key: "HR", name: "Human Resources" },
+          ]),
+        ),
+      );
+
+      // Only HR pages (ENG excluded)
+      fetchMock.mockResolvedValueOnce(mockFetchResponse(makePagesResponse([])));
+
+      const result = await syncConfluence(db, provider, {
+        ...baseConfig,
+        spaces: ["all"],
+        excludeSpaces: ["ENG"],
+      });
+
+      expect(result.spaces).toBe(1);
+    });
+
+    it("should use correct auth header in requests", async () => {
+      fetchMock.mockResolvedValueOnce(mockFetchResponse(makeSpacesResponse([])));
+
+      await syncConfluence(db, provider, baseConfig);
+
+      const expectedAuth = buildAuthHeader(baseConfig.email, baseConfig.token);
+      const firstCall = fetchMock.mock.calls[0] as [string, RequestInit];
+      const headers = firstCall[1].headers as Record<string, string>;
+      expect(headers["Authorization"]).toBe(expectedAuth);
+      expect(firstCall[0]).toContain("/wiki/api/v2/spaces");
+    });
+  });
+
+  describe("disconnectConfluence", () => {
+    it("should remove all confluence documents", async () => {
+      // First sync some pages
+      fetchMock
+        .mockResolvedValueOnce(
+          mockFetchResponse(
+            makeSpacesResponse([{ id: "space-1", key: "ENG", name: "Engineering" }]),
+          ),
+        )
+        .mockResolvedValueOnce(
+          mockFetchResponse(
+            makePagesResponse([{ id: "page-1", title: "Page 1", spaceId: "space-1" }]),
+          ),
+        )
+        .mockResolvedValueOnce(mockFetchResponse(makePageDetail()));
+
+      await syncConfluence(db, provider, baseConfig);
+
+      const docsBefore = db.prepare("SELECT COUNT(*) as count FROM documents").get() as {
+        count: number;
+      };
+      expect(docsBefore.count).toBeGreaterThan(0);
+
+      const removed = disconnectConfluence(db);
+      expect(removed).toBeGreaterThan(0);
+      const docsAfter = db.prepare("SELECT COUNT(*) as count FROM documents").get() as {
+        count: number;
+      };
+      expect(docsAfter.count).toBe(0);
+    });
+
+    it("should return 0 when no confluence docs exist", () => {
+      const removed = disconnectConfluence(db);
+      expect(removed).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a Confluence connector that indexes spaces and pages into the LibScope knowledge base.

### New Files
- `src/connectors/confluence.ts` — Core connector with `syncConfluence`, `convertConfluenceStorage`, `disconnectConfluence`
- `src/connectors/index.ts` — Barrel file for connectors
- `tests/unit/confluence.test.ts` — 26 unit tests

### Changes to Existing Files
- `src/core/index.ts` — Re-exports connector types and functions
- `src/cli/index.ts` — `connect confluence` and `disconnect confluence` CLI commands
- `src/mcp/server.ts` — `sync-confluence` MCP tool

### Features
- **Confluence REST API v2** integration with Basic auth
- **Storage format → Markdown** conversion (code blocks, info/note/warning/tip panels, JIRA macros, images, links, attachments, tables)
- **Incremental sync** via page version tracking using tags
- **Space filtering** and exclusion support
- **Pagination** handling for both spaces and pages
- **Label extraction** as LibScope tags
- **Topic mapping**: space name → topic

### Testing
- 26 unit tests covering storage format conversion, sync flow, pagination, incremental sync, auth, error handling, and disconnect
- All 396 tests pass across 30 test files

Closes #153