### PR TITLE
feat: add Go SDK for REST API (closes #149)

### DIFF
--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -1,0 +1,147 @@
+# libscope Go SDK
+
+A lightweight, idiomatic Go client for the [libscope](https://github.com/RobertLD/libscope) REST API. Zero external dependencies — built entirely on the Go standard library.
+
+## Installation
+
+```bash
+go get github.com/RobertLD/libscope/sdk/go
+```
+
+## Quick Start
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	libscope "github.com/RobertLD/libscope/sdk/go"
+)
+
+func main() {
+	client := libscope.NewClient()
+
+	// Add a document from a URL
+	doc, err := client.AddDocument(context.Background(), "https://go.dev/doc/")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Indexed: %s (%s)\n", doc.Title, doc.ID)
+
+	// Add a text document
+	doc, err = client.AddText(context.Background(), "Go Concurrency", "Goroutines are lightweight threads...")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Added: %s\n", doc.ID)
+
+	// Search
+	results, err := client.Search(context.Background(), "goroutines",
+		libscope.WithLimit(5),
+		libscope.WithMinScore(0.5),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, hit := range results.Results {
+		fmt.Printf("  %s: %.2f\n", hit.Document.Title, hit.Score)
+	}
+
+	// List all topics
+	topics, err := client.ListTopics(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, t := range topics {
+		fmt.Printf("  Topic: %s\n", t.Name)
+	}
+}
+```
+
+## Configuration
+
+```go
+// Custom base URL
+client := libscope.NewClient(
+	libscope.WithBaseURL("http://my-server:3378"),
+)
+
+// Custom timeout
+client := libscope.NewClient(
+	libscope.WithTimeout(10 * time.Second),
+)
+
+// Custom HTTP client
+client := libscope.NewClient(
+	libscope.WithHTTPClient(&http.Client{
+		Transport: myTransport,
+	}),
+)
+```
+
+## API Reference
+
+### Documents
+
+| Method | Description |
+|--------|-------------|
+| `AddDocument(ctx, url, opts...)` | Index a document from a URL |
+| `AddText(ctx, title, content, opts...)` | Index raw text content |
+| `GetDocument(ctx, id)` | Get a document by ID |
+| `ListDocuments(ctx, opts...)` | List documents with optional filters |
+| `DeleteDocument(ctx, id)` | Delete a document |
+
+### Search
+
+| Method | Description |
+|--------|-------------|
+| `Search(ctx, query, opts...)` | Semantic search across documents |
+
+Search options: `WithLimit(n)`, `WithTopic(t)`, `WithTags(tags...)`, `WithMinScore(s)`
+
+### Topics
+
+| Method | Description |
+|--------|-------------|
+| `ListTopics(ctx)` | List all topics |
+| `CreateTopic(ctx, name, opts...)` | Create a new topic |
+
+### Tags
+
+| Method | Description |
+|--------|-------------|
+| `ListTags(ctx)` | List all tags |
+| `AddTagsToDocument(ctx, docID, tags)` | Add tags to a document |
+
+### Analytics
+
+| Method | Description |
+|--------|-------------|
+| `GetStats(ctx)` | Get instance statistics |
+| `Health(ctx)` | Health check |
+
+## Error Handling
+
+All methods return `(*T, error)`. API errors are returned as `*libscope.Error`:
+
+```go
+doc, err := client.GetDocument(ctx, "nonexistent")
+if err != nil {
+	var apiErr *libscope.Error
+	if errors.As(err, &apiErr) {
+		fmt.Printf("API error %d: %s\n", apiErr.StatusCode, apiErr.Message)
+	}
+}
+```
+
+## Testing
+
+```bash
+cd sdk/go
+go test ./... -v -count=1
+```
+
+All tests use `httptest.NewServer` — no running libscope instance required.

--- a/sdk/go/analytics.go
+++ b/sdk/go/analytics.go
@@ -1,0 +1,19 @@
+package libscope
+
+import (
+	"context"
+	"net/http"
+)
+
+// GetStats retrieves analytics/statistics about the libscope instance.
+func (c *Client) GetStats(ctx context.Context) (*Stats, error) {
+	resp, err := c.do(ctx, http.MethodGet, "/api/v1/stats", nil)
+	if err != nil {
+		return nil, err
+	}
+	result, err := decodeResponse[Stats](resp)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -1,0 +1,121 @@
+package libscope
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	defaultBaseURL = "http://localhost:3378"
+	defaultTimeout = 30 * time.Second
+)
+
+// Client is the libscope API client.
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// Option configures a Client.
+type Option func(*Client)
+
+// WithBaseURL sets the base URL for the API.
+func WithBaseURL(url string) Option {
+	return func(c *Client) {
+		c.baseURL = strings.TrimRight(url, "/")
+	}
+}
+
+// WithTimeout sets the HTTP client timeout.
+func WithTimeout(d time.Duration) Option {
+	return func(c *Client) {
+		c.httpClient.Timeout = d
+	}
+}
+
+// WithHTTPClient sets a custom HTTP client.
+func WithHTTPClient(hc *http.Client) Option {
+	return func(c *Client) {
+		c.httpClient = hc
+	}
+}
+
+// NewClient creates a new libscope API client with the given options.
+func NewClient(opts ...Option) *Client {
+	c := &Client{
+		baseURL:    defaultBaseURL,
+		httpClient: &http.Client{Timeout: defaultTimeout},
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// do executes an HTTP request and returns the response body.
+func (c *Client) do(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
+	url := c.baseURL + path
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return nil, fmt.Errorf("libscope: creating request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("libscope: executing request: %w", err)
+	}
+	return resp, nil
+}
+
+// decodeResponse reads the response body and decodes the API envelope.
+// On non-2xx status, it returns an *Error.
+func decodeResponse[T any](resp *http.Response) (T, error) {
+	var zero T
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return zero, fmt.Errorf("libscope: reading response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		var errResp apiErrorResponse
+		if json.Unmarshal(data, &errResp) == nil && errResp.Error.Message != "" {
+			return zero, &Error{
+				StatusCode: resp.StatusCode,
+				Code:       errResp.Error.Code,
+				Message:    errResp.Error.Message,
+			}
+		}
+		return zero, &Error{
+			StatusCode: resp.StatusCode,
+			Message:    string(data),
+		}
+	}
+
+	var envelope apiResponse[T]
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return zero, fmt.Errorf("libscope: decoding response: %w", err)
+	}
+	return envelope.Data, nil
+}
+
+// Health checks the health of the libscope server.
+func (c *Client) Health(ctx context.Context) (*HealthStatus, error) {
+	resp, err := c.do(ctx, http.MethodGet, "/api/v1/health", nil)
+	if err != nil {
+		return nil, err
+	}
+	result, err := decodeResponse[HealthStatus](resp)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/sdk/go/client_test.go
+++ b/sdk/go/client_test.go
@@ -1,0 +1,106 @@
+package libscope
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestNewClientDefaults(t *testing.T) {
+	c := NewClient()
+	if c.baseURL != defaultBaseURL {
+		t.Errorf("expected base URL %q, got %q", defaultBaseURL, c.baseURL)
+	}
+	if c.httpClient.Timeout != defaultTimeout {
+		t.Errorf("expected timeout %v, got %v", defaultTimeout, c.httpClient.Timeout)
+	}
+}
+
+func TestNewClientWithOptions(t *testing.T) {
+	c := NewClient(
+		WithBaseURL("http://example.com/"),
+		WithTimeout(5*time.Second),
+	)
+	if c.baseURL != "http://example.com" {
+		t.Errorf("expected base URL %q, got %q", "http://example.com", c.baseURL)
+	}
+	if c.httpClient.Timeout != 5*time.Second {
+		t.Errorf("expected timeout 5s, got %v", c.httpClient.Timeout)
+	}
+}
+
+func TestWithHTTPClient(t *testing.T) {
+	custom := &http.Client{Timeout: 10 * time.Second}
+	c := NewClient(WithHTTPClient(custom))
+	if c.httpClient != custom {
+		t.Error("expected custom HTTP client")
+	}
+}
+
+func TestHealth(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/health" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(`{"data":{"status":"ok","docCount":42,"dbSize":1024},"meta":{"took":5}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(WithBaseURL(srv.URL))
+	health, err := c.Health(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if health.Status != "ok" {
+		t.Errorf("expected status ok, got %q", health.Status)
+	}
+	if health.DocCount != 42 {
+		t.Errorf("expected 42 docs, got %d", health.DocCount)
+	}
+}
+
+func TestContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	c := NewClient(WithBaseURL(srv.URL))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	_, err := c.Health(ctx)
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+}
+
+func TestErrorResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(500)
+		w.Write([]byte(`{"error":{"code":"INTERNAL_ERROR","message":"something broke"}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(WithBaseURL(srv.URL))
+	_, err := c.Health(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	apiErr, ok := err.(*Error)
+	if !ok {
+		t.Fatalf("expected *Error, got %T", err)
+	}
+	if apiErr.StatusCode != 500 {
+		t.Errorf("expected status 500, got %d", apiErr.StatusCode)
+	}
+	if apiErr.Code != "INTERNAL_ERROR" {
+		t.Errorf("expected code INTERNAL_ERROR, got %q", apiErr.Code)
+	}
+}

--- a/sdk/go/connectors.go
+++ b/sdk/go/connectors.go
@@ -1,0 +1,4 @@
+package libscope
+
+// Connector operations will be added as the REST API exposes connector sync endpoints.
+// This file is a placeholder for future connector sync operations.

--- a/sdk/go/documents.go
+++ b/sdk/go/documents.go
@@ -1,0 +1,166 @@
+package libscope
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+// AddDocumentOption configures AddDocument.
+type AddDocumentOption func(map[string]interface{})
+
+// WithDocumentTopic sets the topic for a new document.
+func WithDocumentTopic(topic string) AddDocumentOption {
+	return func(m map[string]interface{}) {
+		m["topic"] = topic
+	}
+}
+
+// WithDocumentTags sets the tags for a new document.
+func WithDocumentTags(tags ...string) AddDocumentOption {
+	return func(m map[string]interface{}) {
+		m["tags"] = tags
+	}
+}
+
+// AddDocument indexes a document from a URL.
+func (c *Client) AddDocument(ctx context.Context, docURL string, opts ...AddDocumentOption) (*Document, error) {
+	body := map[string]interface{}{
+		"url": docURL,
+	}
+	for _, opt := range opts {
+		opt(body)
+	}
+
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("libscope: encoding request: %w", err)
+	}
+
+	resp, err := c.do(ctx, http.MethodPost, "/api/v1/documents/url", bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	result, err := decodeResponse[Document](resp)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// AddTextOption configures AddText.
+type AddTextOption func(map[string]interface{})
+
+// WithTextTopic sets the topic for a text document.
+func WithTextTopic(topic string) AddTextOption {
+	return func(m map[string]interface{}) {
+		m["topic"] = topic
+	}
+}
+
+// WithTextTags sets the tags for a text document.
+func WithTextTags(tags ...string) AddTextOption {
+	return func(m map[string]interface{}) {
+		m["tags"] = tags
+	}
+}
+
+// WithTextSource sets the source type for a text document.
+func WithTextSource(source string) AddTextOption {
+	return func(m map[string]interface{}) {
+		m["source"] = source
+	}
+}
+
+// AddText indexes a document from raw text content.
+func (c *Client) AddText(ctx context.Context, title, content string, opts ...AddTextOption) (*Document, error) {
+	body := map[string]interface{}{
+		"title":   title,
+		"content": content,
+	}
+	for _, opt := range opts {
+		opt(body)
+	}
+
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("libscope: encoding request: %w", err)
+	}
+
+	resp, err := c.do(ctx, http.MethodPost, "/api/v1/documents", bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	result, err := decodeResponse[Document](resp)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GetDocument retrieves a single document by ID.
+func (c *Client) GetDocument(ctx context.Context, id string) (*Document, error) {
+	resp, err := c.do(ctx, http.MethodGet, "/api/v1/documents/"+url.PathEscape(id), nil)
+	if err != nil {
+		return nil, err
+	}
+	result, err := decodeResponse[Document](resp)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// ListOption configures ListDocuments.
+type ListOption func(*url.Values)
+
+// WithListTopic filters documents by topic.
+func WithListTopic(topic string) ListOption {
+	return func(v *url.Values) {
+		v.Set("topic", topic)
+	}
+}
+
+// WithListLimit limits the number of documents returned.
+func WithListLimit(n int) ListOption {
+	return func(v *url.Values) {
+		v.Set("limit", strconv.Itoa(n))
+	}
+}
+
+// ListDocuments lists documents with optional filters.
+func (c *Client) ListDocuments(ctx context.Context, opts ...ListOption) ([]Document, error) {
+	params := url.Values{}
+	for _, opt := range opts {
+		opt(&params)
+	}
+
+	path := "/api/v1/documents"
+	if len(params) > 0 {
+		path += "?" + params.Encode()
+	}
+
+	resp, err := c.do(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	result, err := decodeResponse[[]Document](resp)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// DeleteDocument deletes a document by ID.
+func (c *Client) DeleteDocument(ctx context.Context, id string) error {
+	resp, err := c.do(ctx, http.MethodDelete, "/api/v1/documents/"+url.PathEscape(id), nil)
+	if err != nil {
+		return err
+	}
+	_, err = decodeResponse[map[string]interface{}](resp)
+	return err
+}

--- a/sdk/go/documents_test.go
+++ b/sdk/go/documents_test.go
@@ -1,0 +1,186 @@
+package libscope
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAddText(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/documents" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		var body map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&body)
+		if body["title"] != "Test Doc" {
+			t.Errorf("expected title 'Test Doc', got %v", body["title"])
+		}
+		if body["content"] != "hello world" {
+			t.Errorf("expected content 'hello world', got %v", body["content"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(201)
+		w.Write([]byte(`{"data":{"id":"doc-1","title":"Test Doc","source":"manual"}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(WithBaseURL(srv.URL))
+	doc, err := c.AddText(context.Background(), "Test Doc", "hello world")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc.ID != "doc-1" {
+		t.Errorf("expected id doc-1, got %q", doc.ID)
+	}
+}
+
+func TestAddTextWithOptions(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&body)
+		if body["topic"] != "golang" {
+			t.Errorf("expected topic 'golang', got %v", body["topic"])
+		}
+		tags, ok := body["tags"].([]interface{})
+		if !ok || len(tags) != 2 {
+			t.Errorf("expected 2 tags, got %v", body["tags"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(201)
+		w.Write([]byte(`{"data":{"id":"doc-2","title":"Go Guide","topic":"golang","tags":["go","tutorial"]}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(WithBaseURL(srv.URL))
+	doc, err := c.AddText(context.Background(), "Go Guide", "content",
+		WithTextTopic("golang"),
+		WithTextTags("go", "tutorial"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc.Topic != "golang" {
+		t.Errorf("expected topic golang, got %q", doc.Topic)
+	}
+}
+
+func TestAddDocument(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/documents/url" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		var body map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&body)
+		if body["url"] != "https://go.dev/doc/" {
+			t.Errorf("expected url, got %v", body["url"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(201)
+		w.Write([]byte(`{"data":{"id":"doc-3","title":"Go Documentation","url":"https://go.dev/doc/"}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(WithBaseURL(srv.URL))
+	doc, err := c.AddDocument(context.Background(), "https://go.dev/doc/")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc.URL != "https://go.dev/doc/" {
+		t.Errorf("expected url, got %q", doc.URL)
+	}
+}
+
+func TestGetDocument(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/documents/doc-1" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":{"id":"doc-1","title":"Test"}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(WithBaseURL(srv.URL))
+	doc, err := c.GetDocument(context.Background(), "doc-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc.ID != "doc-1" {
+		t.Errorf("expected doc-1, got %q", doc.ID)
+	}
+}
+
+func TestGetDocumentNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(404)
+		w.Write([]byte(`{"error":{"code":"NOT_FOUND","message":"Document not found"}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(WithBaseURL(srv.URL))
+	_, err := c.GetDocument(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	apiErr, ok := err.(*Error)
+	if !ok {
+		t.Fatalf("expected *Error, got %T", err)
+	}
+	if apiErr.StatusCode != 404 {
+		t.Errorf("expected 404, got %d", apiErr.StatusCode)
+	}
+}
+
+func TestListDocuments(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("topic") != "go" {
+			t.Errorf("expected topic=go, got %q", r.URL.Query().Get("topic"))
+		}
+		if r.URL.Query().Get("limit") != "10" {
+			t.Errorf("expected limit=10, got %q", r.URL.Query().Get("limit"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":[{"id":"doc-1","title":"Doc 1"},{"id":"doc-2","title":"Doc 2"}]}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(WithBaseURL(srv.URL))
+	docs, err := c.ListDocuments(context.Background(), WithListTopic("go"), WithListLimit(10))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(docs) != 2 {
+		t.Errorf("expected 2 docs, got %d", len(docs))
+	}
+}
+
+func TestDeleteDocument(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/documents/doc-1" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":{"deleted":true}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(WithBaseURL(srv.URL))
+	err := c.DeleteDocument(context.Background(), "doc-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/sdk/go/errors.go
+++ b/sdk/go/errors.go
@@ -1,0 +1,23 @@
+package libscope
+
+import "fmt"
+
+// Error represents an API error returned by libscope.
+type Error struct {
+	StatusCode int
+	Code       string
+	Message    string
+}
+
+func (e *Error) Error() string {
+	if e.Code != "" {
+		return fmt.Sprintf("libscope: %s (HTTP %d): %s", e.Code, e.StatusCode, e.Message)
+	}
+	return fmt.Sprintf("libscope: HTTP %d: %s", e.StatusCode, e.Message)
+}
+
+var (
+	ErrNotFound    = &Error{StatusCode: 404, Message: "not found"}
+	ErrBadRequest  = &Error{StatusCode: 400, Message: "bad request"}
+	ErrServerError = &Error{StatusCode: 500, Message: "server error"}
+)

--- a/sdk/go/examples/quickstart/main.go
+++ b/sdk/go/examples/quickstart/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	libscope "github.com/RobertLD/libscope/sdk/go"
+)
+
+func main() {
+	client := libscope.NewClient()
+
+	// Add a document from a URL
+	doc, err := client.AddDocument(context.Background(), "https://go.dev/doc/")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Indexed: %s (%s)\n", doc.Title, doc.ID)
+
+	// Add a text document
+	textDoc, err := client.AddText(context.Background(), "Go Concurrency",
+		"Goroutines are lightweight threads managed by the Go runtime.",
+		libscope.WithTextTags("go", "concurrency"),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Added: %s (%s)\n", textDoc.Title, textDoc.ID)
+
+	// Search
+	results, err := client.Search(context.Background(), "goroutines",
+		libscope.WithLimit(5),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("\nSearch results for 'goroutines' (%d total):\n", results.Total)
+	for _, hit := range results.Results {
+		fmt.Printf("  %s: %.2f\n", hit.Document.Title, hit.Score)
+	}
+}

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/RobertLD/libscope/sdk/go
+
+go 1.21

--- a/sdk/go/graph.go
+++ b/sdk/go/graph.go
@@ -1,0 +1,4 @@
+package libscope
+
+// Knowledge graph operations will be added as the REST API exposes graph endpoints.
+// This file is a placeholder for future knowledge graph operations.

--- a/sdk/go/models.go
+++ b/sdk/go/models.go
@@ -1,0 +1,81 @@
+package libscope
+
+// Document represents an indexed document in libscope.
+type Document struct {
+	ID          string   `json:"id"`
+	Title       string   `json:"title"`
+	URL         string   `json:"url,omitempty"`
+	Topic       string   `json:"topic,omitempty"`
+	TopicID     string   `json:"topicId,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+	ContentHash string   `json:"content_hash,omitempty"`
+	Source      string   `json:"source,omitempty"`
+	CreatedAt   string   `json:"created_at,omitempty"`
+	UpdatedAt   string   `json:"updated_at,omitempty"`
+}
+
+// SearchResult holds the result of a search query.
+type SearchResult struct {
+	Results []SearchHit `json:"results"`
+	Total   int         `json:"total"`
+	Query   string      `json:"query"`
+}
+
+// SearchHit represents a single search match.
+type SearchHit struct {
+	Document  Document `json:"document"`
+	Score     float64  `json:"score"`
+	ChunkText string   `json:"chunk_text"`
+}
+
+// Topic represents a topic grouping for documents.
+type Topic struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	ParentID string `json:"parentId,omitempty"`
+}
+
+// Tag represents a tag applied to documents.
+type Tag struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name"`
+}
+
+// Stats holds analytics/statistics about the libscope instance.
+type Stats struct {
+	TotalDocuments int64 `json:"totalDocuments"`
+	DatabaseSize   int64 `json:"databaseSizeBytes"`
+}
+
+// HealthStatus holds the health check response.
+type HealthStatus struct {
+	Status   string `json:"status"`
+	DocCount int64  `json:"docCount"`
+	DBSize   int64  `json:"dbSize"`
+}
+
+// AskResult holds the response from the RAG ask endpoint.
+type AskResult struct {
+	Answer  string      `json:"answer"`
+	Sources []SearchHit `json:"sources,omitempty"`
+}
+
+// apiResponse is the standard success envelope from the REST API.
+type apiResponse[T any] struct {
+	Data T            `json:"data"`
+	Meta *apiMeta     `json:"meta,omitempty"`
+}
+
+type apiMeta struct {
+	Took int `json:"took,omitempty"`
+}
+
+// apiErrorResponse is the standard error envelope from the REST API.
+type apiErrorResponse struct {
+	Error apiErrorDetail `json:"error"`
+}
+
+type apiErrorDetail struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}

--- a/sdk/go/search.go
+++ b/sdk/go/search.go
@@ -1,0 +1,91 @@
+package libscope
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+// SearchOptions holds the configuration for a search query.
+type SearchOptions struct {
+	Limit    int
+	Topic    string
+	Tags     []string
+	MinScore float64
+}
+
+// SearchOption configures a search query.
+type SearchOption func(*SearchOptions)
+
+// WithLimit sets the maximum number of results.
+func WithLimit(n int) SearchOption {
+	return func(o *SearchOptions) {
+		o.Limit = n
+	}
+}
+
+// WithTopic filters results by topic.
+func WithTopic(t string) SearchOption {
+	return func(o *SearchOptions) {
+		o.Topic = t
+	}
+}
+
+// WithTags filters results by tags.
+func WithTags(tags ...string) SearchOption {
+	return func(o *SearchOptions) {
+		o.Tags = tags
+	}
+}
+
+// WithMinScore filters results below a minimum score.
+func WithMinScore(s float64) SearchOption {
+	return func(o *SearchOptions) {
+		o.MinScore = s
+	}
+}
+
+// Search performs a semantic search across indexed documents.
+func (c *Client) Search(ctx context.Context, query string, opts ...SearchOption) (*SearchResult, error) {
+	options := &SearchOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	params := url.Values{}
+	params.Set("q", query)
+	if options.Limit > 0 {
+		params.Set("limit", strconv.Itoa(options.Limit))
+	}
+	if options.Topic != "" {
+		params.Set("topic", options.Topic)
+	}
+	if len(options.Tags) > 0 {
+		// The API supports a single "tag" query param
+		params.Set("tag", options.Tags[0])
+	}
+
+	resp, err := c.do(ctx, http.MethodGet, "/api/v1/search?"+params.Encode(), nil)
+	if err != nil {
+		return nil, err
+	}
+	result, err := decodeResponse[SearchResult](resp)
+	if err != nil {
+		return nil, err
+	}
+
+	// Client-side min score filtering
+	if options.MinScore > 0 {
+		filtered := make([]SearchHit, 0, len(result.Results))
+		for _, hit := range result.Results {
+			if hit.Score >= options.MinScore {
+				filtered = append(filtered, hit)
+			}
+		}
+		result.Results = filtered
+		result.Total = len(filtered)
+	}
+
+	return &result, nil
+}

--- a/sdk/go/search_test.go
+++ b/sdk/go/search_test.go
@@ -1,0 +1,113 @@
+package libscope
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSearch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("q") != "goroutines" {
+			t.Errorf("expected q=goroutines, got %q", r.URL.Query().Get("q"))
+		}
+		if r.URL.Query().Get("limit") != "5" {
+			t.Errorf("expected limit=5, got %q", r.URL.Query().Get("limit"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":{"results":[{"document":{"id":"doc-1","title":"Go Concurrency"},"score":0.95,"chunk_text":"goroutines are..."}],"total":1,"query":"goroutines"}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(WithBaseURL(srv.URL))
+	result, err := c.Search(context.Background(), "goroutines", WithLimit(5))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Total != 1 {
+		t.Errorf("expected 1 result, got %d", result.Total)
+	}
+	if result.Results[0].Score != 0.95 {
+		t.Errorf("expected score 0.95, got %f", result.Results[0].Score)
+	}
+}
+
+func TestSearchWithTopic(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("topic") != "golang" {
+			t.Errorf("expected topic=golang, got %q", r.URL.Query().Get("topic"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":{"results":[],"total":0,"query":"test"}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(WithBaseURL(srv.URL))
+	result, err := c.Search(context.Background(), "test", WithTopic("golang"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Total != 0 {
+		t.Errorf("expected 0 results, got %d", result.Total)
+	}
+}
+
+func TestSearchWithTags(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("tag") != "tutorial" {
+			t.Errorf("expected tag=tutorial, got %q", r.URL.Query().Get("tag"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":{"results":[],"total":0,"query":"test"}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(WithBaseURL(srv.URL))
+	_, err := c.Search(context.Background(), "test", WithTags("tutorial"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSearchWithMinScore(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":{"results":[{"document":{"id":"d1","title":"High"},"score":0.9,"chunk_text":"high"},{"document":{"id":"d2","title":"Low"},"score":0.3,"chunk_text":"low"}],"total":2,"query":"test"}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(WithBaseURL(srv.URL))
+	result, err := c.Search(context.Background(), "test", WithMinScore(0.5))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Results) != 1 {
+		t.Errorf("expected 1 result after min score filter, got %d", len(result.Results))
+	}
+	if result.Results[0].Document.ID != "d1" {
+		t.Errorf("expected d1, got %q", result.Results[0].Document.ID)
+	}
+}
+
+func TestSearchError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(400)
+		w.Write([]byte(`{"error":{"code":"VALIDATION_ERROR","message":"Query parameter 'q' is required"}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(WithBaseURL(srv.URL))
+	_, err := c.Search(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	apiErr, ok := err.(*Error)
+	if !ok {
+		t.Fatalf("expected *Error, got %T", err)
+	}
+	if apiErr.StatusCode != 400 {
+		t.Errorf("expected 400, got %d", apiErr.StatusCode)
+	}
+}

--- a/sdk/go/tags.go
+++ b/sdk/go/tags.go
@@ -1,0 +1,45 @@
+package libscope
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// ListTags lists all tags.
+func (c *Client) ListTags(ctx context.Context) ([]Tag, error) {
+	resp, err := c.do(ctx, http.MethodGet, "/api/v1/tags", nil)
+	if err != nil {
+		return nil, err
+	}
+	result, err := decodeResponse[[]Tag](resp)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// AddTagsToDocument adds tags to a document.
+func (c *Client) AddTagsToDocument(ctx context.Context, docID string, tags []string) ([]Tag, error) {
+	body := map[string]interface{}{
+		"tags": tags,
+	}
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("libscope: encoding request: %w", err)
+	}
+
+	path := "/api/v1/documents/" + url.PathEscape(docID) + "/tags"
+	resp, err := c.do(ctx, http.MethodPost, path, bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	result, err := decodeResponse[[]Tag](resp)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/sdk/go/topics.go
+++ b/sdk/go/topics.go
@@ -1,0 +1,57 @@
+package libscope
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// CreateTopicOption configures CreateTopic.
+type CreateTopicOption func(map[string]interface{})
+
+// WithParentID sets the parent topic ID.
+func WithParentID(id string) CreateTopicOption {
+	return func(m map[string]interface{}) {
+		m["parentId"] = id
+	}
+}
+
+// ListTopics lists all topics.
+func (c *Client) ListTopics(ctx context.Context) ([]Topic, error) {
+	resp, err := c.do(ctx, http.MethodGet, "/api/v1/topics", nil)
+	if err != nil {
+		return nil, err
+	}
+	result, err := decodeResponse[[]Topic](resp)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// CreateTopic creates a new topic.
+func (c *Client) CreateTopic(ctx context.Context, name string, opts ...CreateTopicOption) (*Topic, error) {
+	body := map[string]interface{}{
+		"name": name,
+	}
+	for _, opt := range opts {
+		opt(body)
+	}
+
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("libscope: encoding request: %w", err)
+	}
+
+	resp, err := c.do(ctx, http.MethodPost, "/api/v1/topics", bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	result, err := decodeResponse[Topic](resp)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}


### PR DESCRIPTION
## Summary

Adds an idiomatic Go client library at `sdk/go/` for the libscope REST API.

Closes #149

## What's included

- **`client.go`** — Main `Client` struct with functional options (`WithBaseURL`, `WithTimeout`, `WithHTTPClient`)
- **`documents.go`** — Document CRUD: `AddDocument`, `AddText`, `GetDocument`, `ListDocuments`, `DeleteDocument`
- **`search.go`** — Semantic search with `WithLimit`, `WithTopic`, `WithTags`, `WithMinScore` options
- **`topics.go`** — `ListTopics`, `CreateTopic`
- **`tags.go`** — `ListTags`, `AddTagsToDocument`
- **`analytics.go`** — `GetStats` endpoint
- **`models.go`** — All type definitions with JSON tags
- **`errors.go`** — Typed error handling
- **`README.md`** — Usage docs and API reference
- **`examples/quickstart/main.go`** — Working example

## Design decisions

- **Zero external dependencies** — stdlib only (`net/http`, `encoding/json`, `net/http/httptest`)
- **Functional options pattern** — idiomatic Go configuration
- **`context.Context`** on all operations — supports cancellation and timeouts
- **Generics** for API response envelope decoding (Go 1.21+)
- **18 tests** using `httptest.NewServer` — no running server required

## Testing

```bash
cd sdk/go && go test ./... -v -count=1
# All 18 tests pass
go vet ./...
# No issues
```