### PR TITLE
feat: add Python SDK for REST API (closes #148)

### DIFF
--- a/sdk/python/.gitignore
+++ b/sdk/python/.gitignore
@@ -1,0 +1,5 @@
+
+# Python
+__pycache__/
+*.pyc
+*.egg-info/

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,0 +1,110 @@
+# libscope Python SDK
+
+Python client library for the [libscope](https://github.com/RobertLD/libscope) AI knowledge base.
+
+## Installation
+
+```bash
+pip install libscope
+```
+
+Or for development:
+
+```bash
+pip install -e ".[dev]"
+```
+
+## Quick Start
+
+```python
+from libscope import LibscopeClient
+
+with LibscopeClient() as client:
+    # Add a document from a URL
+    doc = client.add_document("https://docs.python.org/3/tutorial/")
+
+    # Add a document from raw text
+    client.add_text("My Notes", "Some useful content...", topic="python")
+
+    # Search
+    results = client.search("how to use decorators")
+    for hit in results.results:
+        print(f"{hit.title}: {hit.score:.2f}")
+
+    # Manage tags
+    client.add_tags(doc.id, ["python", "tutorial"])
+
+    # Ask a question (RAG)
+    answer = client.ask("What is the best practice for error handling?")
+    print(answer.answer)
+```
+
+## Async Usage
+
+```python
+import asyncio
+from libscope import AsyncLibscopeClient
+
+async def main():
+    async with AsyncLibscopeClient() as client:
+        results = await client.search("decorators")
+        for hit in results.results:
+            print(f"{hit.title}: {hit.score:.2f}")
+
+asyncio.run(main())
+```
+
+## Configuration
+
+```python
+# Custom server URL and timeout
+client = LibscopeClient(
+    base_url="http://my-server:3378",
+    timeout=60.0,
+)
+```
+
+## API Reference
+
+### Document Operations
+
+| Method | Description |
+|--------|-------------|
+| `search(query, *, limit, topic, tags, min_score)` | Semantic search |
+| `add_document(url, *, topic, tags)` | Index a document from URL |
+| `add_text(title, content, *, topic, tags)` | Index raw text |
+| `get_document(doc_id)` | Get a document by ID |
+| `list_documents(*, topic, limit, offset)` | List documents |
+| `delete_document(doc_id)` | Delete a document |
+
+### Topic Operations
+
+| Method | Description |
+|--------|-------------|
+| `list_topics()` | List all topics |
+| `create_topic(name, *, parent_id)` | Create a topic |
+
+### Tag Operations
+
+| Method | Description |
+|--------|-------------|
+| `add_tags(doc_id, tags)` | Add tags to a document |
+| `remove_tags(doc_id, tags)` | Remove tags from a document |
+| `list_tags()` | List all tags |
+
+### Analytics & Q&A
+
+| Method | Description |
+|--------|-------------|
+| `get_analytics()` | Get knowledge base statistics |
+| `ask(question, *, topic)` | RAG-powered question answering |
+| `health()` | Check server health |
+
+## Requirements
+
+- Python 3.9+
+- A running libscope server (default: `http://localhost:3378`)
+
+## License
+
+MIT

--- a/sdk/python/examples/quickstart.py
+++ b/sdk/python/examples/quickstart.py
@@ -1,0 +1,38 @@
+"""Quick-start example for the libscope Python SDK."""
+
+from libscope import LibscopeClient
+
+# Connect to a local libscope server (default: http://localhost:3378)
+with LibscopeClient() as client:
+    # Add a document from a URL
+    doc = client.add_document("https://docs.python.org/3/tutorial/")
+    print(f"Indexed: {doc.title} (id={doc.id})")
+
+    # Add a document from raw text
+    text_doc = client.add_text(
+        "Error Handling Guide",
+        "Use try/except blocks to handle exceptions in Python...",
+        topic="python",
+        tags=["tutorial", "errors"],
+    )
+
+    # Search the knowledge base
+    results = client.search("how to use decorators")
+    for hit in results.results:
+        print(f"  {hit.title}: {hit.score:.2f}")
+
+    # Manage tags
+    client.add_tags(doc.id, ["python", "tutorial"])
+
+    # List topics
+    topics = client.list_topics()
+    for t in topics:
+        print(f"Topic: {t.name}")
+
+    # Get analytics
+    stats = client.get_analytics()
+    print(f"Total documents: {stats.total_documents}")
+
+    # Ask a question (RAG)
+    answer = client.ask("What is the recommended error handling pattern?")
+    print(f"Answer: {answer.answer}")

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "libscope"
+version = "0.1.0"
+description = "Python SDK for libscope AI knowledge base"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.9"
+dependencies = [
+    "httpx>=0.25.0",
+    "pydantic>=2.0.0",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0", "pytest-asyncio>=0.21", "respx>=0.20"]

--- a/sdk/python/src/libscope/__init__.py
+++ b/sdk/python/src/libscope/__init__.py
@@ -1,0 +1,44 @@
+"""Python SDK for the libscope AI knowledge base."""
+
+from libscope.client import AsyncLibscopeClient, LibscopeClient
+from libscope.exceptions import (
+    ConnectionError,
+    LibscopeError,
+    NotFoundError,
+    ServerError,
+    ValidationError,
+)
+from libscope.models import (
+    Analytics,
+    AskResult,
+    Document,
+    Graph,
+    GraphEdge,
+    GraphNode,
+    SearchHit,
+    SearchResult,
+    SyncResult,
+    Topic,
+)
+
+__all__ = [
+    "LibscopeClient",
+    "AsyncLibscopeClient",
+    "Document",
+    "SearchResult",
+    "SearchHit",
+    "Topic",
+    "Analytics",
+    "AskResult",
+    "Graph",
+    "GraphNode",
+    "GraphEdge",
+    "SyncResult",
+    "LibscopeError",
+    "ConnectionError",
+    "NotFoundError",
+    "ValidationError",
+    "ServerError",
+]
+
+__version__ = "0.1.0"

--- a/sdk/python/src/libscope/client.py
+++ b/sdk/python/src/libscope/client.py
@@ -1,0 +1,557 @@
+"""Synchronous and asynchronous clients for the libscope REST API."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from libscope.connectors import build_connector_config
+from libscope.exceptions import (
+    ConnectionError,
+    LibscopeError,
+    NotFoundError,
+    ServerError,
+    ValidationError,
+)
+from libscope.models import (
+    Analytics,
+    AskResult,
+    Document,
+    Graph,
+    GraphEdge,
+    GraphNode,
+    SearchHit,
+    SearchResult,
+    SyncResult,
+    Topic,
+)
+
+_API = "/api/v1"
+
+
+def _raise_for_error(response: httpx.Response) -> None:
+    """Translate HTTP error responses into SDK exceptions."""
+    if response.status_code < 400:
+        return
+
+    try:
+        body = response.json()
+    except Exception:
+        body = {}
+
+    error = body.get("error", {})
+    code = error.get("code", "UNKNOWN")
+    message = error.get("message", response.text)
+
+    if response.status_code == 404:
+        raise NotFoundError(message)
+    if response.status_code == 400:
+        raise ValidationError(message)
+    if response.status_code >= 500:
+        raise ServerError(message)
+    raise LibscopeError(message, code=code)
+
+
+def _extract_data(response: httpx.Response) -> Any:
+    """Extract the ``data`` envelope from a JSON response."""
+    body = response.json()
+    return body.get("data", body)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for normalising API responses into SDK models
+# ---------------------------------------------------------------------------
+
+def _parse_document(raw: Any) -> Document:
+    if isinstance(raw, dict):
+        return Document(
+            id=raw.get("id", ""),
+            title=raw.get("title", ""),
+            url=raw.get("url"),
+            topic=raw.get("topic"),
+            topic_id=raw.get("topicId"),
+            tags=raw.get("tags", []),
+            content_hash=raw.get("contentHash"),
+            source_type=raw.get("sourceType"),
+            created_at=raw.get("createdAt"),
+            updated_at=raw.get("updatedAt"),
+        )
+    return Document.model_validate(raw)
+
+
+def _parse_search_result(data: Any) -> SearchResult:
+    results = []
+    raw_results = data.get("results", []) if isinstance(data, dict) else []
+    for r in raw_results:
+        results.append(
+            SearchHit(
+                document_id=r.get("documentId"),
+                title=r.get("title"),
+                content=r.get("content"),
+                score=r.get("score", 0.0),
+            )
+        )
+    total = data.get("totalCount", len(results)) if isinstance(data, dict) else len(results)
+    return SearchResult(results=results, total_count=total)
+
+
+def _parse_topic(raw: Any) -> Topic:
+    if isinstance(raw, dict):
+        return Topic(
+            id=raw.get("id", ""),
+            name=raw.get("name", ""),
+            parent_id=raw.get("parentId"),
+            document_count=raw.get("documentCount"),
+        )
+    return Topic.model_validate(raw)
+
+
+def _parse_analytics(raw: Any) -> Analytics:
+    if isinstance(raw, dict):
+        return Analytics(
+            total_documents=raw.get("totalDocuments", 0),
+            total_chunks=raw.get("totalChunks", 0),
+            total_topics=raw.get("totalTopics", 0),
+            total_tags=raw.get("totalTags", 0),
+            database_size_bytes=raw.get("databaseSizeBytes", 0),
+        )
+    return Analytics.model_validate(raw)
+
+
+# ---------------------------------------------------------------------------
+# Synchronous client
+# ---------------------------------------------------------------------------
+
+
+class LibscopeClient:
+    """Synchronous client for the libscope REST API."""
+
+    def __init__(
+        self,
+        base_url: str = "http://localhost:3378",
+        timeout: float = 30.0,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._client = httpx.Client(base_url=self._base_url, timeout=timeout)
+
+    # -- context manager -----------------------------------------------------
+
+    def __enter__(self) -> "LibscopeClient":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Close the underlying HTTP client."""
+        self._client.close()
+
+    # -- helpers -------------------------------------------------------------
+
+    def _url(self, path: str) -> str:
+        return f"{_API}{path}"
+
+    def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        try:
+            resp = self._client.request(method, self._url(path), **kwargs)
+        except httpx.ConnectError as exc:
+            raise ConnectionError(str(exc)) from exc
+        _raise_for_error(resp)
+        return resp
+
+    # -- document operations -------------------------------------------------
+
+    def search(
+        self,
+        query: str,
+        *,
+        limit: int = 10,
+        topic: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        min_score: Optional[float] = None,
+    ) -> SearchResult:
+        """Perform a semantic search across the knowledge base."""
+        params: Dict[str, Any] = {"q": query, "limit": limit}
+        if topic is not None:
+            params["topic"] = topic
+        if tags:
+            params["tag"] = tags[0]
+        resp = self._request("GET", "/search", params=params)
+        data = _extract_data(resp)
+        result = _parse_search_result(data)
+        if min_score is not None:
+            result.results = [h for h in result.results if h.score >= min_score]
+            result.total_count = len(result.results)
+        return result
+
+    def add_document(
+        self,
+        url: str,
+        *,
+        topic: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+    ) -> Document:
+        """Index a document from a URL."""
+        payload: Dict[str, Any] = {"url": url}
+        if topic is not None:
+            payload["topic"] = topic
+        if tags:
+            payload["tags"] = tags
+        resp = self._request("POST", "/documents/url", json=payload)
+        return _parse_document(_extract_data(resp))
+
+    def add_text(
+        self,
+        title: str,
+        content: str,
+        *,
+        topic: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+    ) -> Document:
+        """Index a document from raw text."""
+        payload: Dict[str, Any] = {"title": title, "content": content}
+        if topic is not None:
+            payload["topic"] = topic
+        if tags:
+            payload["tags"] = tags
+        resp = self._request("POST", "/documents", json=payload)
+        return _parse_document(_extract_data(resp))
+
+    def get_document(self, doc_id: str) -> Document:
+        """Retrieve a single document by ID."""
+        resp = self._request("GET", f"/documents/{doc_id}")
+        return _parse_document(_extract_data(resp))
+
+    def list_documents(
+        self,
+        *,
+        topic: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> List[Document]:
+        """List documents, optionally filtered by topic."""
+        params: Dict[str, Any] = {"limit": limit, "offset": offset}
+        if topic is not None:
+            params["topic"] = topic
+        resp = self._request("GET", "/documents", params=params)
+        data = _extract_data(resp)
+        if isinstance(data, list):
+            return [_parse_document(d) for d in data]
+        return []
+
+    def delete_document(self, doc_id: str) -> None:
+        """Delete a document by ID."""
+        self._request("DELETE", f"/documents/{doc_id}")
+
+    # -- topic operations ----------------------------------------------------
+
+    def list_topics(self) -> List[Topic]:
+        """List all topics."""
+        resp = self._request("GET", "/topics")
+        data = _extract_data(resp)
+        if isinstance(data, list):
+            return [_parse_topic(t) for t in data]
+        return []
+
+    def create_topic(self, name: str, *, parent_id: Optional[str] = None) -> Topic:
+        """Create a new topic."""
+        payload: Dict[str, Any] = {"name": name}
+        if parent_id is not None:
+            payload["parentId"] = parent_id
+        resp = self._request("POST", "/topics", json=payload)
+        return _parse_topic(_extract_data(resp))
+
+    # -- tag operations ------------------------------------------------------
+
+    def add_tags(self, doc_id: str, tags: List[str]) -> None:
+        """Add tags to a document."""
+        self._request("POST", f"/documents/{doc_id}/tags", json={"tags": tags})
+
+    def remove_tags(self, doc_id: str, tags: List[str]) -> None:
+        """Remove tags from a document.
+
+        Note: The REST API may not support tag removal yet.
+        This sends a DELETE request to the document tags endpoint.
+        """
+        self._request("DELETE", f"/documents/{doc_id}/tags", json={"tags": tags})
+
+    def list_tags(self) -> List[str]:
+        """List all tags in the knowledge base."""
+        resp = self._request("GET", "/tags")
+        data = _extract_data(resp)
+        if isinstance(data, list):
+            return [t if isinstance(t, str) else t.get("name", "") for t in data]
+        return []
+
+    # -- analytics -----------------------------------------------------------
+
+    def get_analytics(self) -> Analytics:
+        """Get knowledge base statistics."""
+        resp = self._request("GET", "/stats")
+        return _parse_analytics(_extract_data(resp))
+
+    # -- knowledge graph -----------------------------------------------------
+
+    def get_graph(self, *, min_similarity: float = 0.7) -> Graph:
+        """Get the knowledge graph.
+
+        Note: This endpoint may not be available in all server versions.
+        """
+        resp = self._request(
+            "GET", "/graph", params={"min_similarity": min_similarity}
+        )
+        data = _extract_data(resp)
+        nodes = [GraphNode(**n) for n in data.get("nodes", [])] if isinstance(data, dict) else []
+        edges = [GraphEdge(**e) for e in data.get("edges", [])] if isinstance(data, dict) else []
+        return Graph(nodes=nodes, edges=edges)
+
+    # -- RAG Q&A -------------------------------------------------------------
+
+    def ask(
+        self,
+        question: str,
+        *,
+        topic: Optional[str] = None,
+    ) -> AskResult:
+        """Ask a question using RAG-powered Q&A."""
+        payload: Dict[str, Any] = {"question": question}
+        if topic is not None:
+            payload["topic"] = topic
+        resp = self._request("POST", "/ask", json=payload)
+        data = _extract_data(resp)
+        if isinstance(data, dict):
+            return AskResult(
+                answer=data.get("answer", ""),
+                sources=data.get("sources", []),
+            )
+        return AskResult()
+
+    # -- connector operations ------------------------------------------------
+
+    def sync_connector(self, connector: str, **config: Any) -> SyncResult:
+        """Trigger a connector sync.
+
+        Note: This endpoint may not be available in all server versions.
+        """
+        payload = build_connector_config(connector, **config)
+        resp = self._request("POST", "/connectors/sync", json=payload)
+        data = _extract_data(resp)
+        if isinstance(data, dict):
+            return SyncResult(
+                connector=data.get("connector", connector),
+                documents_synced=data.get("documentsSynced", 0),
+                errors=data.get("errors", []),
+            )
+        return SyncResult(connector=connector)
+
+    # -- health --------------------------------------------------------------
+
+    def health(self) -> Dict[str, Any]:
+        """Check server health."""
+        resp = self._request("GET", "/health")
+        return _extract_data(resp)
+
+
+# ---------------------------------------------------------------------------
+# Async client
+# ---------------------------------------------------------------------------
+
+
+class AsyncLibscopeClient:
+    """Asynchronous client for the libscope REST API."""
+
+    def __init__(
+        self,
+        base_url: str = "http://localhost:3378",
+        timeout: float = 30.0,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._client = httpx.AsyncClient(base_url=self._base_url, timeout=timeout)
+
+    async def __aenter__(self) -> "AsyncLibscopeClient":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.close()
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()
+
+    def _url(self, path: str) -> str:
+        return f"{_API}{path}"
+
+    async def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        try:
+            resp = await self._client.request(method, self._url(path), **kwargs)
+        except httpx.ConnectError as exc:
+            raise ConnectionError(str(exc)) from exc
+        _raise_for_error(resp)
+        return resp
+
+    # -- document operations -------------------------------------------------
+
+    async def search(
+        self,
+        query: str,
+        *,
+        limit: int = 10,
+        topic: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+        min_score: Optional[float] = None,
+    ) -> SearchResult:
+        params: Dict[str, Any] = {"q": query, "limit": limit}
+        if topic is not None:
+            params["topic"] = topic
+        if tags:
+            params["tag"] = tags[0]
+        resp = await self._request("GET", "/search", params=params)
+        data = _extract_data(resp)
+        result = _parse_search_result(data)
+        if min_score is not None:
+            result.results = [h for h in result.results if h.score >= min_score]
+            result.total_count = len(result.results)
+        return result
+
+    async def add_document(
+        self,
+        url: str,
+        *,
+        topic: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+    ) -> Document:
+        payload: Dict[str, Any] = {"url": url}
+        if topic is not None:
+            payload["topic"] = topic
+        if tags:
+            payload["tags"] = tags
+        resp = await self._request("POST", "/documents/url", json=payload)
+        return _parse_document(_extract_data(resp))
+
+    async def add_text(
+        self,
+        title: str,
+        content: str,
+        *,
+        topic: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+    ) -> Document:
+        payload: Dict[str, Any] = {"title": title, "content": content}
+        if topic is not None:
+            payload["topic"] = topic
+        if tags:
+            payload["tags"] = tags
+        resp = await self._request("POST", "/documents", json=payload)
+        return _parse_document(_extract_data(resp))
+
+    async def get_document(self, doc_id: str) -> Document:
+        resp = await self._request("GET", f"/documents/{doc_id}")
+        return _parse_document(_extract_data(resp))
+
+    async def list_documents(
+        self,
+        *,
+        topic: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> List[Document]:
+        params: Dict[str, Any] = {"limit": limit, "offset": offset}
+        if topic is not None:
+            params["topic"] = topic
+        resp = await self._request("GET", "/documents", params=params)
+        data = _extract_data(resp)
+        if isinstance(data, list):
+            return [_parse_document(d) for d in data]
+        return []
+
+    async def delete_document(self, doc_id: str) -> None:
+        await self._request("DELETE", f"/documents/{doc_id}")
+
+    # -- topic operations ----------------------------------------------------
+
+    async def list_topics(self) -> List[Topic]:
+        resp = await self._request("GET", "/topics")
+        data = _extract_data(resp)
+        if isinstance(data, list):
+            return [_parse_topic(t) for t in data]
+        return []
+
+    async def create_topic(self, name: str, *, parent_id: Optional[str] = None) -> Topic:
+        payload: Dict[str, Any] = {"name": name}
+        if parent_id is not None:
+            payload["parentId"] = parent_id
+        resp = await self._request("POST", "/topics", json=payload)
+        return _parse_topic(_extract_data(resp))
+
+    # -- tag operations ------------------------------------------------------
+
+    async def add_tags(self, doc_id: str, tags: List[str]) -> None:
+        await self._request("POST", f"/documents/{doc_id}/tags", json={"tags": tags})
+
+    async def remove_tags(self, doc_id: str, tags: List[str]) -> None:
+        await self._request("DELETE", f"/documents/{doc_id}/tags", json={"tags": tags})
+
+    async def list_tags(self) -> List[str]:
+        resp = await self._request("GET", "/tags")
+        data = _extract_data(resp)
+        if isinstance(data, list):
+            return [t if isinstance(t, str) else t.get("name", "") for t in data]
+        return []
+
+    # -- analytics -----------------------------------------------------------
+
+    async def get_analytics(self) -> Analytics:
+        resp = await self._request("GET", "/stats")
+        return _parse_analytics(_extract_data(resp))
+
+    # -- knowledge graph -----------------------------------------------------
+
+    async def get_graph(self, *, min_similarity: float = 0.7) -> Graph:
+        resp = await self._request(
+            "GET", "/graph", params={"min_similarity": min_similarity}
+        )
+        data = _extract_data(resp)
+        nodes = [GraphNode(**n) for n in data.get("nodes", [])] if isinstance(data, dict) else []
+        edges = [GraphEdge(**e) for e in data.get("edges", [])] if isinstance(data, dict) else []
+        return Graph(nodes=nodes, edges=edges)
+
+    # -- RAG Q&A -------------------------------------------------------------
+
+    async def ask(
+        self,
+        question: str,
+        *,
+        topic: Optional[str] = None,
+    ) -> AskResult:
+        payload: Dict[str, Any] = {"question": question}
+        if topic is not None:
+            payload["topic"] = topic
+        resp = await self._request("POST", "/ask", json=payload)
+        data = _extract_data(resp)
+        if isinstance(data, dict):
+            return AskResult(
+                answer=data.get("answer", ""),
+                sources=data.get("sources", []),
+            )
+        return AskResult()
+
+    # -- connector operations ------------------------------------------------
+
+    async def sync_connector(self, connector: str, **config: Any) -> SyncResult:
+        payload = build_connector_config(connector, **config)
+        resp = await self._request("POST", "/connectors/sync", json=payload)
+        data = _extract_data(resp)
+        if isinstance(data, dict):
+            return SyncResult(
+                connector=data.get("connector", connector),
+                documents_synced=data.get("documentsSynced", 0),
+                errors=data.get("errors", []),
+            )
+        return SyncResult(connector=connector)
+
+    # -- health --------------------------------------------------------------
+
+    async def health(self) -> Dict[str, Any]:
+        resp = await self._request("GET", "/health")
+        return _extract_data(resp)

--- a/sdk/python/src/libscope/connectors.py
+++ b/sdk/python/src/libscope/connectors.py
@@ -1,0 +1,18 @@
+"""Connector management helpers for libscope SDK."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def build_connector_config(connector: str, **kwargs: Any) -> Dict[str, Any]:
+    """Build a connector configuration payload.
+
+    Args:
+        connector: Connector name (e.g., "obsidian", "onenote").
+        **kwargs: Connector-specific configuration options.
+
+    Returns:
+        A dict suitable for posting to the connector sync endpoint.
+    """
+    return {"connector": connector, "config": kwargs}

--- a/sdk/python/src/libscope/exceptions.py
+++ b/sdk/python/src/libscope/exceptions.py
@@ -1,0 +1,37 @@
+"""Custom exceptions for the libscope Python SDK."""
+
+
+class LibscopeError(Exception):
+    """Base exception for all libscope SDK errors."""
+
+    def __init__(self, message: str, code: str = "UNKNOWN") -> None:
+        self.code = code
+        super().__init__(message)
+
+
+class ConnectionError(LibscopeError):
+    """Raised when the SDK cannot connect to the libscope server."""
+
+    def __init__(self, message: str = "Could not connect to libscope server") -> None:
+        super().__init__(message, code="CONNECTION_ERROR")
+
+
+class NotFoundError(LibscopeError):
+    """Raised when a requested resource is not found (HTTP 404)."""
+
+    def __init__(self, message: str = "Resource not found") -> None:
+        super().__init__(message, code="NOT_FOUND")
+
+
+class ValidationError(LibscopeError):
+    """Raised when the server rejects a request due to invalid input (HTTP 400)."""
+
+    def __init__(self, message: str = "Validation error") -> None:
+        super().__init__(message, code="VALIDATION_ERROR")
+
+
+class ServerError(LibscopeError):
+    """Raised when the server returns an internal error (HTTP 5xx)."""
+
+    def __init__(self, message: str = "Internal server error") -> None:
+        super().__init__(message, code="INTERNAL_ERROR")

--- a/sdk/python/src/libscope/models.py
+++ b/sdk/python/src/libscope/models.py
@@ -1,0 +1,95 @@
+"""Pydantic models for libscope API types."""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+from pydantic import BaseModel
+
+
+class Document(BaseModel):
+    """A document stored in the knowledge base."""
+
+    id: str
+    title: str
+    url: Optional[str] = None
+    topic: Optional[str] = None
+    topic_id: Optional[str] = None
+    tags: List[str] = []
+    content_hash: Optional[str] = None
+    source_type: Optional[str] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+class SearchHit(BaseModel):
+    """A single search result with relevance score."""
+
+    document_id: Optional[str] = None
+    title: Optional[str] = None
+    content: Optional[str] = None
+    score: float = 0.0
+
+
+class SearchResult(BaseModel):
+    """Response from a search query."""
+
+    results: List[SearchHit] = []
+    total_count: int = 0
+
+
+class Topic(BaseModel):
+    """A topic/category for organizing documents."""
+
+    id: str
+    name: str
+    parent_id: Optional[str] = None
+    document_count: Optional[int] = None
+
+
+class Analytics(BaseModel):
+    """Knowledge base statistics."""
+
+    total_documents: int = 0
+    total_chunks: int = 0
+    total_topics: int = 0
+    total_tags: int = 0
+    database_size_bytes: int = 0
+
+
+class AskResult(BaseModel):
+    """Response from a RAG question-answering query."""
+
+    answer: str = ""
+    sources: List[Any] = []
+
+
+class GraphNode(BaseModel):
+    """A node in the knowledge graph."""
+
+    id: str
+    label: str
+    type: Optional[str] = None
+
+
+class GraphEdge(BaseModel):
+    """An edge in the knowledge graph."""
+
+    source: str
+    target: str
+    weight: float = 0.0
+
+
+class Graph(BaseModel):
+    """Knowledge graph representation."""
+
+    nodes: List[GraphNode] = []
+    edges: List[GraphEdge] = []
+
+
+class SyncResult(BaseModel):
+    """Result from a connector sync operation."""
+
+    connector: str
+    documents_synced: int = 0
+    errors: List[str] = []

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -1,0 +1,374 @@
+"""Tests for libscope sync and async clients."""
+
+import httpx
+import pytest
+import respx
+
+from libscope.client import AsyncLibscopeClient, LibscopeClient
+from libscope.exceptions import (
+    ConnectionError,
+    NotFoundError,
+    ServerError,
+    ValidationError,
+)
+from libscope.models import Analytics, AskResult, Document, SearchResult, Topic
+
+BASE = "http://localhost:3378"
+API = f"{BASE}/api/v1"
+
+
+# ---------------------------------------------------------------------------
+# Synchronous client tests
+# ---------------------------------------------------------------------------
+
+
+class TestLibscopeClientSearch:
+    @respx.mock
+    def test_search(self):
+        respx.get(f"{API}/search").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "results": [
+                            {"documentId": "d1", "title": "Doc 1", "content": "hello", "score": 0.9}
+                        ],
+                        "totalCount": 1,
+                    },
+                    "meta": {"took": 10},
+                },
+            )
+        )
+        with LibscopeClient() as client:
+            result = client.search("hello")
+        assert isinstance(result, SearchResult)
+        assert result.total_count == 1
+        assert result.results[0].score == 0.9
+
+    @respx.mock
+    def test_search_with_filters(self):
+        route = respx.get(f"{API}/search").mock(
+            return_value=httpx.Response(200, json={"data": {"results": [], "totalCount": 0}})
+        )
+        with LibscopeClient() as client:
+            client.search("test", topic="python", tags=["tutorial"], limit=5)
+        assert "topic=python" in str(route.calls[0].request.url)
+        assert "tag=tutorial" in str(route.calls[0].request.url)
+        assert "limit=5" in str(route.calls[0].request.url)
+
+    @respx.mock
+    def test_search_min_score_filter(self):
+        respx.get(f"{API}/search").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "results": [
+                            {"documentId": "d1", "title": "High", "content": "", "score": 0.95},
+                            {"documentId": "d2", "title": "Low", "content": "", "score": 0.3},
+                        ],
+                        "totalCount": 2,
+                    }
+                },
+            )
+        )
+        with LibscopeClient() as client:
+            result = client.search("test", min_score=0.5)
+        assert len(result.results) == 1
+        assert result.results[0].document_id == "d1"
+
+
+class TestLibscopeClientDocuments:
+    @respx.mock
+    def test_add_document_url(self):
+        respx.post(f"{API}/documents/url").mock(
+            return_value=httpx.Response(
+                201,
+                json={"data": {"id": "d1", "title": "Python Tutorial", "url": "https://example.com"}},
+            )
+        )
+        with LibscopeClient() as client:
+            doc = client.add_document("https://example.com")
+        assert isinstance(doc, Document)
+        assert doc.id == "d1"
+
+    @respx.mock
+    def test_add_text(self):
+        respx.post(f"{API}/documents").mock(
+            return_value=httpx.Response(
+                201, json={"data": {"id": "d2", "title": "My Doc"}}
+            )
+        )
+        with LibscopeClient() as client:
+            doc = client.add_text("My Doc", "Some content")
+        assert doc.title == "My Doc"
+
+    @respx.mock
+    def test_get_document(self):
+        respx.get(f"{API}/documents/d1").mock(
+            return_value=httpx.Response(200, json={"data": {"id": "d1", "title": "Test"}})
+        )
+        with LibscopeClient() as client:
+            doc = client.get_document("d1")
+        assert doc.id == "d1"
+
+    @respx.mock
+    def test_list_documents(self):
+        respx.get(f"{API}/documents").mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": [{"id": "d1", "title": "A"}, {"id": "d2", "title": "B"}]},
+            )
+        )
+        with LibscopeClient() as client:
+            docs = client.list_documents()
+        assert len(docs) == 2
+
+    @respx.mock
+    def test_delete_document(self):
+        respx.delete(f"{API}/documents/d1").mock(
+            return_value=httpx.Response(200, json={"data": {"deleted": True}})
+        )
+        with LibscopeClient() as client:
+            client.delete_document("d1")  # should not raise
+
+
+class TestLibscopeClientTopics:
+    @respx.mock
+    def test_list_topics(self):
+        respx.get(f"{API}/topics").mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": [{"id": "t1", "name": "Python"}, {"id": "t2", "name": "Rust"}]},
+            )
+        )
+        with LibscopeClient() as client:
+            topics = client.list_topics()
+        assert len(topics) == 2
+        assert all(isinstance(t, Topic) for t in topics)
+
+    @respx.mock
+    def test_create_topic(self):
+        respx.post(f"{API}/topics").mock(
+            return_value=httpx.Response(201, json={"data": {"id": "t3", "name": "Go"}})
+        )
+        with LibscopeClient() as client:
+            topic = client.create_topic("Go")
+        assert topic.name == "Go"
+
+
+class TestLibscopeClientTags:
+    @respx.mock
+    def test_add_tags(self):
+        respx.post(f"{API}/documents/d1/tags").mock(
+            return_value=httpx.Response(200, json={"data": ["alpha", "beta"]})
+        )
+        with LibscopeClient() as client:
+            client.add_tags("d1", ["alpha", "beta"])
+
+    @respx.mock
+    def test_list_tags(self):
+        respx.get(f"{API}/tags").mock(
+            return_value=httpx.Response(200, json={"data": ["python", "tutorial"]})
+        )
+        with LibscopeClient() as client:
+            tags = client.list_tags()
+        assert tags == ["python", "tutorial"]
+
+
+class TestLibscopeClientAnalytics:
+    @respx.mock
+    def test_get_analytics(self):
+        respx.get(f"{API}/stats").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "totalDocuments": 42,
+                        "totalChunks": 100,
+                        "totalTopics": 3,
+                        "totalTags": 7,
+                        "databaseSizeBytes": 2048,
+                    }
+                },
+            )
+        )
+        with LibscopeClient() as client:
+            stats = client.get_analytics()
+        assert isinstance(stats, Analytics)
+        assert stats.total_documents == 42
+
+
+class TestLibscopeClientAsk:
+    @respx.mock
+    def test_ask(self):
+        respx.post(f"{API}/ask").mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": {"answer": "Use decorators.", "sources": [{"id": "d1"}]}},
+            )
+        )
+        with LibscopeClient() as client:
+            result = client.ask("How to use decorators?")
+        assert isinstance(result, AskResult)
+        assert result.answer == "Use decorators."
+
+
+class TestLibscopeClientHealth:
+    @respx.mock
+    def test_health(self):
+        respx.get(f"{API}/health").mock(
+            return_value=httpx.Response(
+                200, json={"data": {"status": "ok", "docCount": 10}}
+            )
+        )
+        with LibscopeClient() as client:
+            h = client.health()
+        assert h["status"] == "ok"
+
+
+class TestLibscopeClientErrors:
+    @respx.mock
+    def test_not_found(self):
+        respx.get(f"{API}/documents/missing").mock(
+            return_value=httpx.Response(
+                404, json={"error": {"code": "NOT_FOUND", "message": "Document not found"}}
+            )
+        )
+        with LibscopeClient() as client:
+            with pytest.raises(NotFoundError):
+                client.get_document("missing")
+
+    @respx.mock
+    def test_validation_error(self):
+        respx.post(f"{API}/documents").mock(
+            return_value=httpx.Response(
+                400,
+                json={"error": {"code": "VALIDATION_ERROR", "message": "title is required"}},
+            )
+        )
+        with LibscopeClient() as client:
+            with pytest.raises(ValidationError):
+                client.add_text("", "")
+
+    @respx.mock
+    def test_server_error(self):
+        respx.get(f"{API}/stats").mock(
+            return_value=httpx.Response(
+                500, json={"error": {"code": "INTERNAL_ERROR", "message": "oops"}}
+            )
+        )
+        with LibscopeClient() as client:
+            with pytest.raises(ServerError):
+                client.get_analytics()
+
+    def test_connection_refused(self):
+        client = LibscopeClient(base_url="http://localhost:19999")
+        with pytest.raises(ConnectionError):
+            client.search("hello")
+        client.close()
+
+
+class TestLibscopeClientContextManager:
+    @respx.mock
+    def test_context_manager(self):
+        respx.get(f"{API}/health").mock(
+            return_value=httpx.Response(200, json={"data": {"status": "ok"}})
+        )
+        with LibscopeClient() as client:
+            h = client.health()
+            assert h["status"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Async client tests
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncLibscopeClient:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_search(self):
+        respx.get(f"{API}/search").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "results": [
+                            {"documentId": "d1", "title": "Doc", "content": "hi", "score": 0.8}
+                        ],
+                        "totalCount": 1,
+                    }
+                },
+            )
+        )
+        async with AsyncLibscopeClient() as client:
+            result = await client.search("hi")
+        assert result.total_count == 1
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_add_text(self):
+        respx.post(f"{API}/documents").mock(
+            return_value=httpx.Response(201, json={"data": {"id": "d1", "title": "Test"}})
+        )
+        async with AsyncLibscopeClient() as client:
+            doc = await client.add_text("Test", "content")
+        assert doc.id == "d1"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_list_documents(self):
+        respx.get(f"{API}/documents").mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "d1", "title": "A"}]}
+            )
+        )
+        async with AsyncLibscopeClient() as client:
+            docs = await client.list_documents()
+        assert len(docs) == 1
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_error_handling(self):
+        respx.get(f"{API}/documents/bad").mock(
+            return_value=httpx.Response(
+                404, json={"error": {"code": "NOT_FOUND", "message": "not found"}}
+            )
+        )
+        async with AsyncLibscopeClient() as client:
+            with pytest.raises(NotFoundError):
+                await client.get_document("bad")
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_get_analytics(self):
+        respx.get(f"{API}/stats").mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": {"totalDocuments": 5, "totalChunks": 20, "totalTopics": 1, "totalTags": 3, "databaseSizeBytes": 512}},
+            )
+        )
+        async with AsyncLibscopeClient() as client:
+            stats = await client.get_analytics()
+        assert stats.total_documents == 5
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_ask(self):
+        respx.post(f"{API}/ask").mock(
+            return_value=httpx.Response(200, json={"data": {"answer": "yes", "sources": []}})
+        )
+        async with AsyncLibscopeClient() as client:
+            result = await client.ask("is it?")
+        assert result.answer == "yes"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_context_manager(self):
+        respx.get(f"{API}/health").mock(
+            return_value=httpx.Response(200, json={"data": {"status": "ok"}})
+        )
+        async with AsyncLibscopeClient() as client:
+            h = await client.health()
+            assert h["status"] == "ok"

--- a/sdk/python/tests/test_models.py
+++ b/sdk/python/tests/test_models.py
@@ -1,0 +1,105 @@
+"""Tests for libscope Pydantic models."""
+
+from libscope.models import (
+    Analytics,
+    AskResult,
+    Document,
+    Graph,
+    GraphEdge,
+    GraphNode,
+    SearchHit,
+    SearchResult,
+    SyncResult,
+    Topic,
+)
+
+
+class TestDocument:
+    def test_minimal(self):
+        doc = Document(id="1", title="Hello")
+        assert doc.id == "1"
+        assert doc.title == "Hello"
+        assert doc.url is None
+        assert doc.tags == []
+
+    def test_full(self):
+        doc = Document(
+            id="abc",
+            title="Test",
+            url="https://example.com",
+            topic="python",
+            topic_id="t1",
+            tags=["a", "b"],
+            content_hash="sha256:...",
+            source_type="manual",
+            created_at="2024-01-01",
+            updated_at="2024-01-02",
+        )
+        assert doc.url == "https://example.com"
+        assert doc.tags == ["a", "b"]
+        assert doc.source_type == "manual"
+
+
+class TestSearchResult:
+    def test_empty(self):
+        sr = SearchResult()
+        assert sr.results == []
+        assert sr.total_count == 0
+
+    def test_with_hits(self):
+        hit = SearchHit(document_id="1", title="Doc", content="text", score=0.95)
+        sr = SearchResult(results=[hit], total_count=1)
+        assert len(sr.results) == 1
+        assert sr.results[0].score == 0.95
+        assert sr.results[0].document_id == "1"
+
+
+class TestTopic:
+    def test_basic(self):
+        t = Topic(id="t1", name="Python")
+        assert t.name == "Python"
+        assert t.parent_id is None
+
+    def test_with_parent(self):
+        t = Topic(id="t2", name="Flask", parent_id="t1")
+        assert t.parent_id == "t1"
+
+
+class TestAnalytics:
+    def test_defaults(self):
+        a = Analytics()
+        assert a.total_documents == 0
+        assert a.database_size_bytes == 0
+
+    def test_values(self):
+        a = Analytics(total_documents=42, total_chunks=100, total_topics=5, total_tags=10, database_size_bytes=1024)
+        assert a.total_documents == 42
+
+
+class TestAskResult:
+    def test_basic(self):
+        r = AskResult(answer="42", sources=[{"id": "1"}])
+        assert r.answer == "42"
+        assert len(r.sources) == 1
+
+
+class TestGraph:
+    def test_empty(self):
+        g = Graph()
+        assert g.nodes == []
+        assert g.edges == []
+
+    def test_with_data(self):
+        g = Graph(
+            nodes=[GraphNode(id="1", label="Doc1")],
+            edges=[GraphEdge(source="1", target="2", weight=0.8)],
+        )
+        assert len(g.nodes) == 1
+        assert g.edges[0].weight == 0.8
+
+
+class TestSyncResult:
+    def test_basic(self):
+        s = SyncResult(connector="obsidian", documents_synced=5)
+        assert s.connector == "obsidian"
+        assert s.errors == []


### PR DESCRIPTION
## Summary

Adds a pip-installable Python SDK at `sdk/python/` that provides a clean Pythonic interface to the libscope REST API.

## Changes

- **`sdk/python/src/libscope/client.py`** — Sync (`LibscopeClient`) and async (`AsyncLibscopeClient`) clients wrapping all REST API endpoints
- **`sdk/python/src/libscope/models.py`** — Pydantic v2 models for Document, SearchResult, Topic, Analytics, AskResult, Graph, SyncResult
- **`sdk/python/src/libscope/exceptions.py`** — Custom exception hierarchy (NotFoundError, ValidationError, ServerError, ConnectionError)
- **`sdk/python/src/libscope/connectors.py`** — Connector management helpers
- **`sdk/python/tests/`** — 39 tests covering all client methods, error handling, model validation, both sync/async clients, and context manager usage
- **`sdk/python/pyproject.toml`** — Modern Python packaging with hatchling
- **`sdk/python/README.md`** — Quick-start guide with usage examples
- **`sdk/python/examples/quickstart.py`** — Example script

## Usage

```python
from libscope import LibscopeClient

with LibscopeClient() as client:
    doc = client.add_document("https://docs.python.org/3/tutorial/")
    results = client.search("how to use decorators")
    for hit in results.results:
        print(f"{hit.title}: {hit.score:.2f}")
    client.add_tags(doc.id, ["python", "tutorial"])
```

## Test Results

All 39 tests pass:
- Sync client: search, documents CRUD, topics, tags, analytics, ask, health, error handling, context manager
- Async client: search, add_text, list_documents, error handling, analytics, ask, context manager
- Models: Document, SearchResult, Topic, Analytics, AskResult, Graph, SyncResult

Closes #148