### PR TITLE
fix: validate API params and fix watcher memory leak

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -106,9 +106,9 @@ export async function handleRequest(
       }
       const topic = url.searchParams.get("topic") ?? undefined;
       const tag = url.searchParams.get("tag") ?? undefined;
-      const limit = url.searchParams.has("limit")
-        ? parseInt(url.searchParams.get("limit")!, 10)
-        : undefined;
+      const limitRaw = url.searchParams.get("limit");
+      const limitParsed = limitRaw ? parseInt(limitRaw, 10) : NaN;
+      const limit = Number.isNaN(limitParsed) ? undefined : limitParsed;
       const tags = tag ? [tag] : undefined;
 
       const result = await searchDocuments(db, provider, { query: q, topic, tags, limit });
@@ -120,9 +120,9 @@ export async function handleRequest(
     // List documents
     if (pathname === "/api/v1/documents" && method === "GET") {
       const topicId = url.searchParams.get("topic") ?? undefined;
-      const limit = url.searchParams.has("limit")
-        ? parseInt(url.searchParams.get("limit")!, 10)
-        : undefined;
+      const limitRaw = url.searchParams.get("limit");
+      const limitParsed = limitRaw ? parseInt(limitRaw, 10) : NaN;
+      const limit = Number.isNaN(limitParsed) ? undefined : limitParsed;
       const docs = listDocuments(db, { topicId, limit });
       const took = Math.round(performance.now() - start);
       sendJson(res, 200, docs, took);

--- a/src/core/watcher.ts
+++ b/src/core/watcher.ts
@@ -68,7 +68,10 @@ export class FileWatcher {
     if (!this.extensions.has(ext)) return;
 
     const existing = this.debounceTimers.get(fullPath);
-    if (existing) clearTimeout(existing);
+    if (existing) {
+      clearTimeout(existing);
+      this.debounceTimers.delete(fullPath);
+    }
 
     const timer = setTimeout(() => {
       this.debounceTimers.delete(fullPath);


### PR DESCRIPTION
Fixes two bugs found during code review:

1. **API route parseInt validation** — `/api/v1/search?limit=abc` would pass `NaN` to the database query. Now falls back to `undefined` for invalid values.

2. **Watcher debounce memory leak** — During rapid file changes (e.g., bulk copy), the debounceTimers Map entries were only deleted when the timer fired, causing unbounded growth. Now entries are deleted immediately when cleared.