### PR TITLE
fix: OneNote rate limiter race condition and CLI lint warnings

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,7 +3,7 @@
 import { Command } from "commander";
 import { loadConfig, saveUserConfig } from "../config.js";
 import { getDatabase, runMigrations, createVectorTable, closeDatabase } from "../db/index.js";
-import { createEmbeddingProvider } from "../providers/index.js";
+import { createEmbeddingProvider, type EmbeddingProvider } from "../providers/index.js";
 import { indexDocument } from "../core/indexing.js";
 import { searchDocuments } from "../core/search.js";
 import { askQuestion, createLlmProvider } from "../core/rag.js";
@@ -735,7 +735,10 @@ function setupLogging(opts: ProgramOpts): void {
 }
 
 /** Shared CLI initialization: loadConfig → setupLogging → getDatabase → runMigrations. */
-function initializeApp() {
+function initializeApp(): {
+  config: ReturnType<typeof loadConfig>;
+  db: ReturnType<typeof getDatabase>;
+} {
   const config = loadConfig();
   const opts = program.opts<ProgramOpts>();
   setupLogging(opts);
@@ -752,7 +755,11 @@ function initializeApp() {
 }
 
 /** Initialization with an embedding provider and vector table. */
-function initializeAppWithEmbedding() {
+function initializeAppWithEmbedding(): {
+  config: ReturnType<typeof loadConfig>;
+  db: ReturnType<typeof getDatabase>;
+  provider: EmbeddingProvider;
+} {
   const { config, db } = initializeApp();
   const provider = createEmbeddingProvider(config);
   createVectorTable(db, provider.dimensions);
@@ -829,9 +836,15 @@ program
       directory,
       extensions,
       debounceMs,
-      onIndex: (path) => console.log(`  ✓ Indexed: ${path}`),
-      onRemove: (path) => console.log(`  ✗ Removed: ${path}`),
-      onError: (err) => console.error(`  ⚠ Error: ${err.message}`),
+      onIndex: (path: string): void => {
+        console.log(`  ✓ Indexed: ${path}`);
+      },
+      onRemove: (path: string): void => {
+        console.log(`  ✗ Removed: ${path}`);
+      },
+      onError: (err: Error): void => {
+        console.error(`  ⚠ Error: ${err.message}`);
+      },
     });
 
     const cleanup = (): void => {

--- a/src/connectors/onenote.ts
+++ b/src/connectors/onenote.ts
@@ -56,8 +56,19 @@ const MAX_RETRIES = 3;
 const MAX_REQUESTS_PER_MINUTE = 50;
 
 let requestTimestamps: number[] = [];
+let rateLimitLock: Promise<void> = Promise.resolve();
 
 async function rateLimitedFetch(url: string, options: RequestInit): Promise<Response> {
+  // Serialize rate-limit checks to prevent concurrent async contexts from
+  // exceeding the budget. Each call awaits the previous one's gate.
+  let unlock: () => void;
+  const gate = new Promise<void>((resolve) => {
+    unlock = resolve;
+  });
+  const prev = rateLimitLock;
+  rateLimitLock = gate;
+  await prev;
+
   const log = getLogger();
   const now = Date.now();
   requestTimestamps = requestTimestamps.filter((t) => now - t < 60_000);
@@ -66,10 +77,14 @@ async function rateLimitedFetch(url: string, options: RequestInit): Promise<Resp
     log.debug({ waitMs }, "Rate limit reached, waiting");
     await new Promise((resolve) => setTimeout(resolve, waitMs));
   }
+  requestTimestamps.push(Date.now());
+  unlock!();
 
   let lastError: unknown;
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-    requestTimestamps.push(Date.now());
+    if (attempt > 0) {
+      requestTimestamps.push(Date.now());
+    }
     const response = await fetch(url, options);
 
     if (response.status === 429) {


### PR DESCRIPTION
- Serializes rate-limit checks in OneNote connector with an async lock to prevent concurrent requests from exceeding the 50 req/min API budget
- Adds explicit return types to CLI helper functions (17→12 lint warnings)