### PR TITLE
feat: add confirmation prompts for destructive CLI operations (#171)

### DIFF
--- a/src/cli/confirm.ts
+++ b/src/cli/confirm.ts
@@ -1,0 +1,24 @@
+import * as readline from "node:readline/promises";
+import { stdin as input, stdout as output } from "node:process";
+
+/**
+ * Prompt the user for confirmation before a destructive action.
+ * Returns true immediately when `yes` is true (--yes flag).
+ */
+export async function confirmAction(
+  message: string,
+  yes: boolean,
+  /** Overridable for testing */
+  createInterface?: () => readline.Interface,
+): Promise<boolean> {
+  if (yes) return true;
+
+  const rl = createInterface ? createInterface() : readline.createInterface({ input, output });
+
+  try {
+    const answer = await rl.question(`${message} [y/N] `);
+    return /^y(es)?$/i.test(answer.trim());
+  } finally {
+    rl.close();
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -26,6 +26,7 @@ import {
   getSearchTrends,
 } from "../core/analytics.js";
 import { startRepl } from "./repl.js";
+import { confirmAction } from "./confirm.js";
 import {
   addTagsToDocument,
   removeTagFromDocument,
@@ -538,10 +539,20 @@ docsCmd
 docsCmd
   .command("delete <documentId>")
   .description("Delete a document by ID")
-  .action((documentId: string) => {
+  .option("-y, --yes", "Skip confirmation prompt")
+  .action(async (documentId: string, opts: { yes?: boolean }) => {
     const { db } = initializeApp();
     try {
       const doc = getDocument(db, documentId);
+      if (
+        !(await confirmAction(
+          `Delete document "${doc.title}" (${documentId})? This cannot be undone.`,
+          !!opts.yes,
+        ))
+      ) {
+        console.log("Cancelled.");
+        return;
+      }
       deleteDocument(db, documentId);
       console.log(`✓ Deleted "${doc.title}" (${documentId})`);
     } finally {
@@ -1185,7 +1196,12 @@ workspaceCmd
 workspaceCmd
   .command("delete <name>")
   .description("Delete a workspace")
-  .action((name: string) => {
+  .option("-y, --yes", "Skip confirmation prompt")
+  .action(async (name: string, opts: { yes?: boolean }) => {
+    if (!(await confirmAction(`Delete workspace "${name}"? This cannot be undone.`, !!opts.yes))) {
+      console.log("Cancelled.");
+      return;
+    }
     deleteWorkspace(name);
     console.log(`✓ Workspace "${name}" deleted.`);
   });
@@ -1214,7 +1230,17 @@ packCmd
 packCmd
   .command("remove <name>")
   .description("Remove a pack and its documents")
-  .action((name: string) => {
+  .option("-y, --yes", "Skip confirmation prompt")
+  .action(async (name: string, opts: { yes?: boolean }) => {
+    if (
+      !(await confirmAction(
+        `Remove pack "${name}" and its documents? This cannot be undone.`,
+        !!opts.yes,
+      ))
+    ) {
+      console.log("Cancelled.");
+      return;
+    }
     const { db } = initializeApp();
     removePack(db, name);
     console.log(`✓ Pack "${name}" removed.`);
@@ -1399,7 +1425,17 @@ const disconnectCmd = program.command("disconnect").description("Disconnect exte
 disconnectCmd
   .command("onenote")
   .description("Disconnect OneNote and remove its data")
-  .action(() => {
+  .option("-y, --yes", "Skip confirmation prompt")
+  .action(async (opts: { yes?: boolean }) => {
+    if (
+      !(await confirmAction(
+        "Disconnect OneNote and remove all its data? This cannot be undone.",
+        !!opts.yes,
+      ))
+    ) {
+      console.log("Cancelled.");
+      return;
+    }
     const config = loadConfig();
     const logLevel =
       (program.opts().logLevel as LogLevel) ?? (program.opts().verbose ? "debug" : "info");
@@ -1605,7 +1641,17 @@ connectCmd
 disconnectCmd
   .command("obsidian <vault-path>")
   .description("Remove all documents from an Obsidian vault")
-  .action(async (vaultPath: string) => {
+  .option("-y, --yes", "Skip confirmation prompt")
+  .action(async (vaultPath: string, opts: { yes?: boolean }) => {
+    if (
+      !(await confirmAction(
+        `Disconnect Obsidian vault "${vaultPath}" and remove its documents? This cannot be undone.`,
+        !!opts.yes,
+      ))
+    ) {
+      console.log("Cancelled.");
+      return;
+    }
     const { db } = initializeApp();
 
     const { disconnectVault } = await import("../connectors/obsidian.js");
@@ -1663,7 +1709,17 @@ connectCmd
 disconnectCmd
   .command("notion")
   .description("Remove all Notion documents")
-  .action(async () => {
+  .option("-y, --yes", "Skip confirmation prompt")
+  .action(async (opts: { yes?: boolean }) => {
+    if (
+      !(await confirmAction(
+        "Disconnect Notion and remove all its documents? This cannot be undone.",
+        !!opts.yes,
+      ))
+    ) {
+      console.log("Cancelled.");
+      return;
+    }
     const { db } = initializeApp();
     const removed = await disconnectNotion(db);
     console.log(`✓ Removed ${removed} Notion documents.`);
@@ -1672,7 +1728,17 @@ disconnectCmd
 disconnectCmd
   .command("slack")
   .description("Remove all Slack data from the knowledge base")
-  .action(() => {
+  .option("-y, --yes", "Skip confirmation prompt")
+  .action(async (opts: { yes?: boolean }) => {
+    if (
+      !(await confirmAction(
+        "Disconnect Slack and remove all its data? This cannot be undone.",
+        !!opts.yes,
+      ))
+    ) {
+      console.log("Cancelled.");
+      return;
+    }
     const { db } = initializeApp();
     try {
       const count = disconnectSlack(db);
@@ -1685,7 +1751,17 @@ disconnectCmd
 disconnectCmd
   .command("confluence")
   .description("Remove all Confluence-synced content")
-  .action(async () => {
+  .option("-y, --yes", "Skip confirmation prompt")
+  .action(async (opts: { yes?: boolean }) => {
+    if (
+      !(await confirmAction(
+        "Disconnect Confluence and remove all synced content? This cannot be undone.",
+        !!opts.yes,
+      ))
+    ) {
+      console.log("Cancelled.");
+      return;
+    }
     const { disconnectConfluence } = await import("../connectors/confluence.js");
     const { db } = initializeApp();
     try {

--- a/tests/unit/confirm.test.ts
+++ b/tests/unit/confirm.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from "vitest";
+import { confirmAction } from "../../src/cli/confirm.js";
+import { EventEmitter } from "node:events";
+
+function createMockInterface(answer: string) {
+  const emitter = new EventEmitter();
+  return () =>
+    ({
+      question: vi.fn().mockResolvedValue(answer),
+      close: vi.fn(),
+      ...emitter,
+    }) as never;
+}
+
+describe("confirmAction", () => {
+  it("returns true immediately when yes flag is set", async () => {
+    const result = await confirmAction("Delete?", true);
+    expect(result).toBe(true);
+  });
+
+  it("returns true when user answers 'y'", async () => {
+    const result = await confirmAction("Delete?", false, createMockInterface("y"));
+    expect(result).toBe(true);
+  });
+
+  it("returns true when user answers 'yes'", async () => {
+    const result = await confirmAction("Delete?", false, createMockInterface("yes"));
+    expect(result).toBe(true);
+  });
+
+  it("returns true when user answers 'YES' (case-insensitive)", async () => {
+    const result = await confirmAction("Delete?", false, createMockInterface("YES"));
+    expect(result).toBe(true);
+  });
+
+  it("returns false when user answers 'n'", async () => {
+    const result = await confirmAction("Delete?", false, createMockInterface("n"));
+    expect(result).toBe(false);
+  });
+
+  it("returns false when user answers empty string", async () => {
+    const result = await confirmAction("Delete?", false, createMockInterface(""));
+    expect(result).toBe(false);
+  });
+
+  it("returns false when user answers arbitrary text", async () => {
+    const result = await confirmAction("Delete?", false, createMockInterface("maybe"));
+    expect(result).toBe(false);
+  });
+
+  it("closes the readline interface after prompting", async () => {
+    const factory = createMockInterface("y");
+    const rl = factory();
+    await confirmAction("Delete?", false, () => rl);
+    expect(rl.close).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds confirmation prompts before all destructive CLI operations to prevent accidental data loss.

### Changes

- **New utility** `src/cli/confirm.ts`: `confirmAction(message, yes, createInterface?)` prompts the user for `[y/N]` confirmation, skipping when `--yes` is passed
- **`--yes` / `-y` flag** added to all destructive commands:
  - `docs delete`
  - `workspace delete`
  - `pack remove`
  - `disconnect onenote`
  - `disconnect obsidian`
  - `disconnect notion`
  - `disconnect slack`
  - `disconnect confluence`
- **Tests** in `tests/unit/confirm.test.ts` covering:
  - `--yes` flag bypasses prompt
  - Accepts `y`, `yes`, `YES`
  - Rejects `n`, empty, arbitrary input
  - Readline interface is properly closed

Closes #171