### PR TITLE
fix: add retry logic for Notion/Slack/Confluence connectors (#176)

### DIFF
--- a/src/connectors/confluence.ts
+++ b/src/connectors/confluence.ts
@@ -7,6 +7,7 @@ import { addTagsToDocument } from "../core/tags.js";
 import { deleteDocument } from "../core/documents.js";
 import { getLogger } from "../logger.js";
 import { FetchError, ValidationError } from "../errors.js";
+import { fetchWithRetry } from "./http-utils.js";
 
 export interface ConfluenceConfig {
   baseUrl: string;
@@ -54,7 +55,7 @@ async function confluenceFetch<T>(url: string, auth: string): Promise<T> {
   const log = getLogger();
   log.debug({ url }, "Confluence API request");
 
-  const response = await fetch(url, {
+  const response = await fetchWithRetry(url, {
     headers: {
       Authorization: auth,
       Accept: "application/json",

--- a/src/connectors/http-utils.ts
+++ b/src/connectors/http-utils.ts
@@ -1,0 +1,55 @@
+import { getLogger } from "../logger.js";
+import { FetchError } from "../errors.js";
+
+export interface RetryConfig {
+  maxRetries?: number;
+  baseDelay?: number;
+}
+
+/**
+ * Fetch wrapper with retry logic for 429 (rate-limit) and 5xx responses.
+ * Uses Retry-After header when available, otherwise exponential backoff.
+ */
+export async function fetchWithRetry(
+  url: string,
+  options?: RequestInit,
+  retryConfig?: RetryConfig,
+): Promise<Response> {
+  const maxRetries = retryConfig?.maxRetries ?? 3;
+  const baseDelay = retryConfig?.baseDelay ?? 1000;
+  const log = getLogger();
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const response = await fetch(url, options);
+
+    if (response.status === 429 || (response.status >= 500 && response.status < 600)) {
+      if (attempt >= maxRetries) {
+        const body = await response.text().catch(() => "");
+        throw new FetchError(`HTTP ${response.status} after ${maxRetries + 1} attempts: ${body}`);
+      }
+
+      let delayMs = baseDelay * 2 ** attempt;
+      if (response.status === 429) {
+        const retryAfter = response.headers.get("Retry-After");
+        if (retryAfter) {
+          const parsed = Number(retryAfter);
+          if (!Number.isNaN(parsed)) {
+            delayMs = parsed * 1000;
+          }
+        }
+      }
+
+      log.warn(
+        { status: response.status, attempt: attempt + 1, delayMs },
+        "Retrying after transient error",
+      );
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      continue;
+    }
+
+    return response;
+  }
+
+  // Unreachable, but satisfies TypeScript
+  throw new FetchError("fetchWithRetry: unexpected code path");
+}

--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -152,6 +152,9 @@ export function deleteConnectorDocuments(db: Database.Database, sourceType: stri
 export { syncNotion, convertNotionBlocks, disconnectNotion } from "./notion.js";
 export type { NotionConfig, NotionSyncResult, NotionBlock } from "./notion.js";
 
+export { fetchWithRetry } from "./http-utils.js";
+export type { RetryConfig } from "./http-utils.js";
+
 export {
   syncConfluence,
   convertConfluenceStorage,

--- a/src/connectors/notion.ts
+++ b/src/connectors/notion.ts
@@ -2,6 +2,7 @@ import type Database from "better-sqlite3";
 import type { EmbeddingProvider } from "../providers/embedding.js";
 import { getLogger } from "../logger.js";
 import { ValidationError, FetchError } from "../errors.js";
+import { fetchWithRetry } from "./http-utils.js";
 import { indexDocument } from "../core/indexing.js";
 import { deleteDocument } from "../core/documents.js";
 
@@ -91,13 +92,10 @@ async function notionFetch<T>(
     fetchOptions.body = JSON.stringify(options.body);
   }
 
-  const response = await fetch(url, fetchOptions);
+  const response = await fetchWithRetry(url, fetchOptions);
 
   if (response.status === 401) {
     throw new ValidationError("Invalid Notion token or insufficient permissions");
-  }
-  if (response.status === 429) {
-    throw new FetchError("Notion API rate limit exceeded. Try again later.");
   }
   if (!response.ok) {
     const text = await response.text().catch(() => "unknown error");

--- a/src/connectors/slack.ts
+++ b/src/connectors/slack.ts
@@ -3,6 +3,7 @@ import type { EmbeddingProvider } from "../providers/embedding.js";
 import { indexDocument } from "../core/indexing.js";
 import { getLogger } from "../logger.js";
 import { LibScopeError, ValidationError } from "../errors.js";
+import { fetchWithRetry } from "./http-utils.js";
 
 export interface SlackConfig {
   token: string;
@@ -80,7 +81,7 @@ async function slackApi(
     url.searchParams.set(key, value);
   }
 
-  const response = await fetch(url.toString(), {
+  const response = await fetchWithRetry(url.toString(), {
     headers: { Authorization: `Bearer ${token}` },
   });
 

--- a/tests/unit/http-utils.test.ts
+++ b/tests/unit/http-utils.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { FetchError } from "../../src/errors.js";
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// Mock logger
+vi.mock("../../src/logger.js", () => ({
+  getLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+const { fetchWithRetry } = await import("../../src/connectors/http-utils.js");
+
+function jsonResponse(data: unknown, status = 200, headers?: Record<string, string>): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 429 ? "Too Many Requests" : "OK",
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
+    headers: new Headers(headers ?? {}),
+  } as unknown as Response;
+}
+
+describe("fetchWithRetry", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should return response on success", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
+    const res = await fetchWithRetry("https://example.com/api");
+    expect(res.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("should retry on 429 with Retry-After header", async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({}, 429, { "Retry-After": "1" }))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+    const promise = fetchWithRetry("https://example.com/api", undefined, {
+      maxRetries: 3,
+      baseDelay: 100,
+    });
+
+    // Advance past the Retry-After delay (1s)
+    await vi.advanceTimersByTimeAsync(1000);
+
+    const res = await promise;
+    expect(res.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("should retry on 500 with exponential backoff", async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({}, 500))
+      .mockResolvedValueOnce(jsonResponse({}, 502))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+    const promise = fetchWithRetry("https://example.com/api", undefined, {
+      maxRetries: 3,
+      baseDelay: 100,
+    });
+
+    // First retry: 100ms * 2^0 = 100ms
+    await vi.advanceTimersByTimeAsync(100);
+    // Second retry: 100ms * 2^1 = 200ms
+    await vi.advanceTimersByTimeAsync(200);
+
+    const res = await promise;
+    expect(res.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("should not retry on 400", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ error: "bad request" }, 400));
+    const res = await fetchWithRetry("https://example.com/api");
+    expect(res.status).toBe(400);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("should throw FetchError after max retries exceeded", async () => {
+    vi.useRealTimers();
+    mockFetch.mockResolvedValue(jsonResponse({}, 500));
+
+    await expect(
+      fetchWithRetry("https://example.com/api", undefined, {
+        maxRetries: 2,
+        baseDelay: 10,
+      }),
+    ).rejects.toThrow(FetchError);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    vi.useFakeTimers();
+  });
+
+  it("should pass through request options", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
+    await fetchWithRetry("https://example.com/api", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: "value" }),
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith("https://example.com/api", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: "value" }),
+    });
+  });
+});

--- a/tests/unit/notion.test.ts
+++ b/tests/unit/notion.test.ts
@@ -17,7 +17,8 @@ function jsonResponse(data: unknown, status = 200): Response {
     status,
     json: () => Promise.resolve(data),
     text: () => Promise.resolve(JSON.stringify(data)),
-  } as Response;
+    headers: new Headers(),
+  } as unknown as Response;
 }
 
 describe("convertNotionBlocks", () => {
@@ -387,10 +388,14 @@ describe("syncNotion", () => {
   });
 
   it("should handle rate limiting (429)", async () => {
-    mockFetch.mockResolvedValueOnce(jsonResponse({ message: "Rate limited" }, 429));
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ message: "Rate limited" }, 429))
+      .mockResolvedValueOnce(jsonResponse({ message: "Rate limited" }, 429))
+      .mockResolvedValueOnce(jsonResponse({ message: "Rate limited" }, 429))
+      .mockResolvedValueOnce(jsonResponse({ message: "Rate limited" }, 429));
 
     await expect(syncNotion(db, provider, { token: "secret_test123" })).rejects.toThrow(FetchError);
-  });
+  }, 15000);
 
   it("should collect errors for individual pages", async () => {
     // Search returns one page


### PR DESCRIPTION
Closes #176

## Changes
- Added `src/connectors/http-utils.ts` with `fetchWithRetry()` utility:
  - Retries on 429 (rate limit) with `Retry-After` header support
  - Retries on 5xx with exponential backoff
  - Configurable `maxRetries` (default 3) and `baseDelay` (default 1000ms)
- Updated `notion.ts`, `slack.ts`, and `confluence.ts` to use `fetchWithRetry`
- Added comprehensive tests in `tests/unit/http-utils.test.ts`
- All 571 tests pass, coverage ≥ 75%