### PR TITLE
feat: add API key authentication (#173)

### DIFF
--- a/src/api/middleware.ts
+++ b/src/api/middleware.ts
@@ -100,6 +100,26 @@ setInterval(() => {
   }
 }, 5 * 60_000).unref();
 
+/** Check API key authentication. Returns true if request is authorized. */
+export function checkApiKey(req: IncomingMessage, res: ServerResponse): boolean {
+  const apiKey = process.env.LIBSCOPE_API_KEY;
+  if (!apiKey) return true;
+
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith("Bearer ")) {
+    sendError(res, 401, "UNAUTHORIZED", "Missing or invalid Authorization header");
+    return false;
+  }
+
+  const token = authHeader.slice(7);
+  if (token !== apiKey) {
+    sendError(res, 401, "UNAUTHORIZED", "Invalid API key");
+    return false;
+  }
+
+  return true;
+}
+
 /** Parse the request body as JSON. Returns the parsed object or null on failure. */
 export async function parseJsonBody(
   req: IncomingMessage,

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -2,7 +2,7 @@ import { createServer } from "node:http";
 import type Database from "better-sqlite3";
 import type { EmbeddingProvider } from "../providers/embedding.js";
 import { getLogger } from "../logger.js";
-import { corsMiddleware, checkRateLimit } from "./middleware.js";
+import { corsMiddleware, checkRateLimit, checkApiKey } from "./middleware.js";
 import { handleRequest } from "./routes.js";
 
 export interface ApiServerOptions {
@@ -31,6 +31,7 @@ export async function startApiServer(
     }
 
     if (corsMiddleware(req, res, corsOrigins)) return;
+    if (!checkApiKey(req, res)) return;
     handleRequest(req, res, db, provider).catch((err: unknown) => {
       log.error({ err }, "Unhandled error in request handler");
       if (!res.headersSent) {

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { IncomingMessage, ServerResponse } from "node:http";
 import { Socket } from "node:net";
 import type Database from "better-sqlite3";
@@ -11,6 +11,7 @@ import {
   sendJson,
   sendError,
   checkRateLimit,
+  checkApiKey,
   getRateLimitMapSize,
   MAX_RATE_LIMIT_ENTRIES,
 } from "../../src/api/middleware.js";
@@ -558,6 +559,63 @@ describe("middleware — security", () => {
     expect(res.getHeader("X-XSS-Protection")).toBe("1; mode=block");
     expect(res.getHeader("Referrer-Policy")).toBe("strict-origin-when-cross-origin");
     expect(res.getHeader("Content-Security-Policy")).toBeDefined();
+  });
+});
+
+describe("middleware — API key authentication", () => {
+  const ORIGINAL_KEY = process.env.LIBSCOPE_API_KEY;
+
+  afterEach(() => {
+    if (ORIGINAL_KEY === undefined) {
+      delete process.env.LIBSCOPE_API_KEY;
+    } else {
+      process.env.LIBSCOPE_API_KEY = ORIGINAL_KEY;
+    }
+  });
+
+  it("should allow requests when no API key is configured", () => {
+    delete process.env.LIBSCOPE_API_KEY;
+    const req = createMockReq("GET", "/api/v1/health");
+    const { res } = createMockRes();
+    expect(checkApiKey(req, res)).toBe(true);
+  });
+
+  it("should reject requests without Authorization header", () => {
+    process.env.LIBSCOPE_API_KEY = "test-key";
+    const req = createMockReq("GET", "/api/v1/health");
+    const { res, getStatus, getBody } = createMockRes();
+    expect(checkApiKey(req, res)).toBe(false);
+    expect(getStatus()).toBe(401);
+    const parsed = parseResponse(getBody());
+    expect(parsed.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should reject requests with wrong API key", () => {
+    process.env.LIBSCOPE_API_KEY = "test-key";
+    const req = createMockReq("GET", "/api/v1/health");
+    req.headers.authorization = "Bearer wrong-key";
+    const { res, getStatus, getBody } = createMockRes();
+    expect(checkApiKey(req, res)).toBe(false);
+    expect(getStatus()).toBe(401);
+    const parsed = parseResponse(getBody());
+    expect(parsed.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should allow requests with correct API key", () => {
+    process.env.LIBSCOPE_API_KEY = "test-key";
+    const req = createMockReq("GET", "/api/v1/health");
+    req.headers.authorization = "Bearer test-key";
+    const { res } = createMockRes();
+    expect(checkApiKey(req, res)).toBe(true);
+  });
+
+  it("should reject non-Bearer authorization schemes", () => {
+    process.env.LIBSCOPE_API_KEY = "test-key";
+    const req = createMockReq("GET", "/api/v1/health");
+    req.headers.authorization = "Basic dGVzdC1rZXk=";
+    const { res, getStatus } = createMockRes();
+    expect(checkApiKey(req, res)).toBe(false);
+    expect(getStatus()).toBe(401);
   });
 });
 


### PR DESCRIPTION
## Summary
Add Bearer token authentication via `LIBSCOPE_API_KEY` environment variable.

When the env var is set, all API requests must include a valid `Authorization: Bearer <key>` header. When unset, access remains open for backward compatibility.

### Changes
- Add `checkApiKey()` middleware in `src/api/middleware.ts`
- Integrate auth check in `src/api/server.ts` after rate limiting, before routes
- Add 5 unit tests covering all auth scenarios

Closes #173