### PR TITLE
fix: add vercel.json to install devDependencies for vitepress build

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "installCommand": "npm install --include=dev",
+  "buildCommand": "npm run docs:build",
+  "outputDirectory": "docs/.vitepress/dist"
+}


### PR DESCRIPTION
Vercel skips devDependencies by default, causing 'vitepress: command not found' during docs builds. This config ensures devDependencies are installed.