### PR TITLE
fix: update engines to node >=20

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "url": "https://github.com/RobertLD/libscope.git"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",


### PR DESCRIPTION
commander@14 and pino@10 (thread-stream@4) both require Node >=20. Node 18 reached EOL April 2025. CI already only tests 20 and 22.

Found during pre-release audit.