### PR TITLE
fix: Docker build failing due to husky in prepare script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ RUN apk add --no-cache python3 make g++ && \
     addgroup -g 1001 libscope && \
     adduser -u 1001 -G libscope -s /bin/sh -D libscope
 COPY package*.json ./
-RUN npm ci --omit=dev && apk del python3 make g++
+RUN npm ci --omit=dev --ignore-scripts && \
+    npm rebuild better-sqlite3 && \
+    apk del python3 make g++
 COPY --from=builder /app/dist ./dist
 USER libscope
 EXPOSE 3420 3421


### PR DESCRIPTION
The `prepare` script runs `husky`, which is a devDependency. In the production Docker stage, `npm ci --omit=dev` skips devDeps but still runs lifecycle scripts, causing `sh: husky: not found` (exit 127).

**Fix:** Use `--ignore-scripts` to skip lifecycle scripts, then explicitly `npm rebuild better-sqlite3` for the native bindings.

Verified: Docker build succeeds locally.