### PR TITLE
docs: add libscope.com website to README and package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![CI](https://github.com/RobertLD/libscope/actions/workflows/ci.yml/badge.svg)](https://github.com/RobertLD/libscope/actions/workflows/ci.yml)
 [![License: Source Available](https://img.shields.io/badge/License-Source%20Available-orange.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](https://nodejs.org)
+[![Website](https://img.shields.io/badge/docs-libscope.com-blue)](https://libscope.com)
 
 LibScope is a local knowledge base that makes your documentation searchable by AI assistants. Point it at markdown files, URLs, or connect it to Obsidian/Notion/Confluence/Slack, and it chunks, embeds, and indexes everything into a local SQLite database. Your AI tools query it through [MCP](https://modelcontextprotocol.io/) (Model Context Protocol) or a REST API.
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "libscope",
   "version": "1.1.0",
   "description": "AI-powered knowledge base with MCP integration — query library docs, internal wikis, and topics with semantic search",
+  "homepage": "https://libscope.com",
   "type": "module",
   "bin": {
     "libscope": "./dist/cli/index.js"


### PR DESCRIPTION
- Added docs badge linking to https://libscope.com in README
- Added `homepage` field to package.json (shows on npmjs.com)