### PR TITLE
fix: Python SDK publish — sync version from git tag and fix license

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -23,6 +23,13 @@ jobs:
       - name: Install build tools
         run: pip install build
 
+      - name: Sync version from git tag
+        working-directory: sdk/python
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          sed -i "s/^version = .*/version = \"${VERSION}\"/" pyproject.toml
+          echo "Publishing pylibscope ${VERSION}"
+
       - name: Build package
         working-directory: sdk/python
         run: python -m build

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,16 +4,16 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pylibscope"
-version = "0.1.0"
+version = "1.1.0"
 description = "Python SDK for the LibScope AI knowledge base"
 readme = "README.md"
-license = "MIT"
+license = "SEE LICENSE IN LICENSE"
 requires-python = ">=3.9"
 authors = [{ name = "RobertLD" }]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "License :: Other/Proprietary License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
## Problem
The Python SDK (`pylibscope`) was never published to PyPI because:

1. **Version hardcoded at `0.1.0`** — didn't match the main package version
2. **License still said MIT** — repo changed to BSL 1.1

Additionally, even when a release tag is pushed, the pyproject.toml version wouldn't match the tag.

## Fix

### `sdk/python/pyproject.toml`
- Version updated to `1.1.0` (matches current main package)
- License changed from `MIT` to `SEE LICENSE IN LICENSE`
- Classifier changed from `OSI Approved :: MIT License` to `Other/Proprietary License`

### `.github/workflows/release-python.yml`
- Added **Sync version from git tag** step that extracts the version from `GITHUB_REF_NAME` (e.g., `v1.2.0` → `1.2.0`) and patches `pyproject.toml` before building
- This ensures the PyPI package version always matches the git release tag, no manual sync needed