### PR TITLE
fix: pyproject.toml license field for hatchling compatibility

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -7,7 +7,7 @@ name = "pylibscope"
 version = "1.1.0"
 description = "Python SDK for the LibScope AI knowledge base"
 readme = "README.md"
-license = "SEE LICENSE IN LICENSE"
+license = { file = "../../LICENSE" }
 requires-python = ">=3.9"
 authors = [{ name = "RobertLD" }]
 classifiers = [


### PR DESCRIPTION
The `release-python.yml` workflow failed because hatchling rejects `license = "SEE LICENSE IN LICENSE"` — it requires a valid SPDX expression or a file reference.

**Error:** `ValueError: Error parsing field project.license - Invalid license expression: 'SEE LICENSE IN LICENSE'`

**Fix:** Use `license = { file = "../../LICENSE" }` to reference the repo root LICENSE file (BSL 1.1).

After merging, the `v1.2.1` tag needs to be re-pushed to trigger the release workflows.