### PR TITLE
fix: Python SDK license and build for PyPI publish

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -23,11 +23,12 @@ jobs:
       - name: Install build tools
         run: pip install build
 
-      - name: Sync version from git tag
+      - name: Prepare SDK for release
         working-directory: sdk/python
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           sed -i "s/^version = .*/version = \"${VERSION}\"/" pyproject.toml
+          cp ../../LICENSE .
           echo "Publishing pylibscope ${VERSION}"
 
       - name: Build package

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -7,7 +7,7 @@ name = "pylibscope"
 version = "1.1.0"
 description = "Python SDK for the LibScope AI knowledge base"
 readme = "README.md"
-license = { file = "../../LICENSE" }
+license = { text = "BSL-1.1" }
 requires-python = ">=3.9"
 authors = [{ name = "RobertLD" }]
 classifiers = [


### PR DESCRIPTION
## Problem
`release-python.yml` fails with: `OSError: License file does not exist: ../../LICENSE`

Hatchling resolves file paths relative to `pyproject.toml`, and can't traverse outside the package root (`sdk/python/`).

## Fix
- Use `license = { text = "BSL-1.1" }` — valid SPDX identifier, no file reference needed
- Copy `../../LICENSE` into `sdk/python/` during CI before `python -m build`
- LICENSE gets included in the published package