### PR TITLE
fix: support indexing.allowPrivateUrls in config set command

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -727,6 +727,10 @@ configCmd
       }
       saveUserConfig({ embedding: { provider: value } });
       console.log(`✓ Embedding provider set to: ${value}`);
+    } else if (key === "indexing.allowPrivateUrls") {
+      const bool = value === "true";
+      saveUserConfig({ indexing: { ...loadConfig().indexing, allowPrivateUrls: bool } });
+      console.log(`✓ indexing.allowPrivateUrls set to: ${bool}`);
     } else {
       console.error(`Unknown config key: ${key}`);
       process.exit(1);


### PR DESCRIPTION
Closes #233

The `config set` command only recognized `embedding.provider`. This adds support for `indexing.allowPrivateUrls` so users can persist the private URL setting:

```bash
libscope config set indexing.allowPrivateUrls true
```

Release-As: 1.2.3