### PR TITLE
fix: use OS DNS resolver fallback for internal hostnames

### DIFF
--- a/src/core/url-fetcher.ts
+++ b/src/core/url-fetcher.ts
@@ -1,7 +1,10 @@
-import { promises as dns } from "node:dns";
+import { promises as dns, lookup as dnsLookup } from "node:dns";
+import { promisify } from "node:util";
 import { NodeHtmlMarkdown } from "node-html-markdown";
 import { FetchError } from "../errors.js";
 import { getLogger } from "../logger.js";
+
+const lookupAsync = promisify(dnsLookup);
 
 export interface FetchedDocument {
   title: string;
@@ -78,6 +81,17 @@ async function validateUrl(url: string, allowPrivateUrls = false): Promise<strin
   const addresses: string[] = [];
   for (const r of results) {
     if (r.status === "fulfilled") addresses.push(...r.value);
+  }
+
+  // Fall back to OS resolver (respects /etc/resolv.conf search domains)
+  // when dns.resolve4/resolve6 fail — common with short internal hostnames.
+  if (addresses.length === 0) {
+    try {
+      const result = await lookupAsync(hostname);
+      if (result.address) addresses.push(result.address);
+    } catch {
+      // lookup also failed
+    }
   }
 
   if (addresses.length === 0) {

--- a/tests/unit/repo.test.ts
+++ b/tests/unit/repo.test.ts
@@ -9,6 +9,11 @@ vi.mock("node:dns", () => ({
     resolve4: vi.fn().mockResolvedValue(["140.82.121.3"]),
     resolve6: vi.fn().mockRejectedValue(new Error("no AAAA")),
   },
+  lookup: vi.fn(
+    (_hostname: unknown, cb: (err: Error | null, address?: string, family?: number) => void) => {
+      cb(new Error("ENOTFOUND"));
+    },
+  ),
 }));
 
 const { parseRepoUrl, shouldIncludeFile, fetchRepoContents, indexRepository } =

--- a/tests/unit/url-fetcher.test.ts
+++ b/tests/unit/url-fetcher.test.ts
@@ -7,10 +7,14 @@ globalThis.fetch = mockFetch;
 // Mock dns.promises so we can control IP resolution
 const mockResolve4 = vi.fn();
 const mockResolve6 = vi.fn();
+const mockLookup = vi.fn();
 vi.mock("node:dns", () => ({
   promises: {
     resolve4: (...args: unknown[]): Promise<string[]> => mockResolve4(...args) as Promise<string[]>,
     resolve6: (...args: unknown[]): Promise<string[]> => mockResolve6(...args) as Promise<string[]>,
+  },
+  lookup: (...args: unknown[]): void => {
+    mockLookup(...args);
   },
 }));
 
@@ -62,9 +66,16 @@ describe("fetchAndConvert", () => {
     mockFetch.mockReset();
     mockResolve4.mockReset();
     mockResolve6.mockReset();
+    mockLookup.mockReset();
     // Default: resolve to a public IP
     mockResolve4.mockResolvedValue(["93.184.216.34"]);
     mockResolve6.mockRejectedValue(new Error("no AAAA"));
+    // Default: lookup also fails (callback style)
+    mockLookup.mockImplementation(
+      (_hostname: unknown, cb: (err: Error | null, address?: string, family?: number) => void) => {
+        cb(new Error("ENOTFOUND"));
+      },
+    );
   });
 
   it("should fetch HTML and convert to text with title from <title> tag", async () => {
@@ -184,6 +195,12 @@ describe("SSRF protection", () => {
     mockFetch.mockReset();
     mockResolve4.mockReset();
     mockResolve6.mockReset();
+    mockLookup.mockReset();
+    mockLookup.mockImplementation(
+      (_hostname: unknown, cb: (err: Error | null, address?: string, family?: number) => void) => {
+        cb(new Error("ENOTFOUND"));
+      },
+    );
   });
 
   it("should block file:// URLs", async () => {
@@ -254,8 +271,14 @@ describe("streaming body size limit", () => {
     mockFetch.mockReset();
     mockResolve4.mockReset();
     mockResolve6.mockReset();
+    mockLookup.mockReset();
     mockResolve4.mockResolvedValue(["93.184.216.34"]);
     mockResolve6.mockRejectedValue(new Error("no AAAA"));
+    mockLookup.mockImplementation(
+      (_hostname: unknown, cb: (err: Error | null, address?: string, family?: number) => void) => {
+        cb(new Error("ENOTFOUND"));
+      },
+    );
   });
 
   it("should abort when streamed body exceeds 10 MB regardless of Content-Length header", async () => {
@@ -298,8 +321,14 @@ describe("FetchOptions configuration", () => {
     mockFetch.mockReset();
     mockResolve4.mockReset();
     mockResolve6.mockReset();
+    mockLookup.mockReset();
     mockResolve4.mockResolvedValue(["93.184.216.34"]);
     mockResolve6.mockRejectedValue(new Error("no AAAA"));
+    mockLookup.mockImplementation(
+      (_hostname: unknown, cb: (err: Error | null, address?: string, family?: number) => void) => {
+        cb(new Error("ENOTFOUND"));
+      },
+    );
   });
 
   it("should expose sensible DEFAULT_FETCH_OPTIONS", () => {


### PR DESCRIPTION
Fixes DNS resolution for short internal hostnames like `confluence` that rely on `/etc/resolv.conf` search domains.

**Problem:** `dns.resolve4`/`resolve6` use the DNS protocol directly and don't respect OS search domains. A hostname like `confluence` that resolves via search domain `domain.voloridge.com` → `confluence.domain.voloridge.com` fails with `DNS resolution failed`.

**Fix:** Falls back to `dns.lookup()` (which uses the OS resolver, including search domains) when `resolve4`/`resolve6` return no results. The SSRF private IP check still applies to the resolved address.