### PR TITLE
feat: add allowSelfSignedCerts config for corporate TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ export LIBSCOPE_LLM_MODEL=gpt-4o-mini # optional
 | `LIBSCOPE_OLLAMA_URL` | Ollama server URL | `http://localhost:11434` |
 | `LIBSCOPE_LLM_PROVIDER` | LLM for RAG (`openai` / `ollama`) | — |
 | `LIBSCOPE_LLM_MODEL` | LLM model override | — |
+| `LIBSCOPE_ALLOW_PRIVATE_URLS` | Allow fetching from private/internal IPs | `false` |
+| `LIBSCOPE_ALLOW_SELF_SIGNED_CERTS` | Accept self-signed TLS certificates | `false` |
 | `ONENOTE_CLIENT_ID` | Microsoft app registration client ID | — |
 | `ONENOTE_TENANT_ID` | Microsoft tenant ID | `common` |
 | `NOTION_TOKEN` | Notion integration token | — |
@@ -261,11 +263,34 @@ export LIBSCOPE_LLM_MODEL=gpt-4o-mini # optional
   },
   "logging": {
     "level": "info"
+  },
+  "indexing": {
+    "allowPrivateUrls": false,
+    "allowSelfSignedCerts": false
   }
 }
 ```
 
 </details>
+
+### Corporate / Internal Networks
+
+If you're indexing docs from internal servers (Confluence, wikis, etc.), you may need:
+
+```bash
+# Allow fetching from private/internal IP addresses
+libscope config set indexing.allowPrivateUrls true
+
+# Accept self-signed or corporate TLS certificates
+libscope config set indexing.allowSelfSignedCerts true
+```
+
+Or via environment variables:
+
+```bash
+export LIBSCOPE_ALLOW_PRIVATE_URLS=true
+export LIBSCOPE_ALLOW_SELF_SIGNED_CERTS=true
+```
 
 ## Other Tools
 

--- a/agents.md
+++ b/agents.md
@@ -7,7 +7,7 @@
 LibScope is an **AI-powered knowledge base with MCP (Model Context Protocol) integration**. It indexes documentation (library docs, internal wikis, topics) into a local SQLite + vector store and serves them to AI assistants via semantic search.
 
 - **Language:** TypeScript (strict mode, ESM-only)
-- **Runtime:** Node.js ≥ 18
+- **Runtime:** Node.js ≥ 20
 - **Package manager:** npm
 - **Module system:** ES Modules (`"type": "module"` in package.json)
 
@@ -143,7 +143,7 @@ The factory in `src/providers/index.ts` selects the provider based on config. De
 
 Environment variables > project `.libscope.json` > user `~/.libscope/config.json` > hardcoded defaults.
 
-Env vars: `LIBSCOPE_EMBEDDING_PROVIDER`, `LIBSCOPE_OPENAI_API_KEY`, `LIBSCOPE_OLLAMA_URL`.
+Env vars: `LIBSCOPE_EMBEDDING_PROVIDER`, `LIBSCOPE_OPENAI_API_KEY`, `LIBSCOPE_OLLAMA_URL`, `LIBSCOPE_ALLOW_PRIVATE_URLS`, `LIBSCOPE_ALLOW_SELF_SIGNED_CERTS`.
 
 ## Testing
 
@@ -253,4 +253,25 @@ git worktree remove ../libscope-<branch-name>
 4. Write unit tests in `tests/unit/` using `MockEmbeddingProvider` and `createTestDb()`.
 5. Add integration coverage in `tests/integration/workflow.test.ts` if it's a core flow.
 6. Run `npm run typecheck && npm test && npm run lint` — all must pass.
-7. Update `README.md` if the feature is user-facing.
+7. **Update documentation** — see the Documentation section below.
+
+## Documentation
+
+Every user-facing change **must** update all relevant documentation. Documentation lives in multiple places — check each one:
+
+| Location | What it covers |
+|----------|---------------|
+| `README.md` | Top-level overview, quickstart, config tables, CLI summary |
+| `docs/guide/getting-started.md` | First-run walkthrough |
+| `docs/guide/configuration.md` | Config guide with env var table and examples |
+| `docs/reference/cli.md` | Full CLI command reference |
+| `docs/reference/configuration.md` | Complete config key reference, env vars, example config |
+| `agents.md` | Agent/Copilot guide — architecture, conventions, config precedence |
+
+**What to update for common change types:**
+
+- **New config key:** `src/config.ts` (interface + defaults + env override) → `README.md` (env var table, example config) → `docs/guide/configuration.md` (env var table) → `docs/reference/configuration.md` (config keys table, env vars table, example config) → `agents.md` (config precedence env var list)
+- **New CLI command:** `src/cli/index.ts` → `README.md` (CLI table) → `docs/reference/cli.md` (command reference)
+- **New MCP tool:** `src/mcp/server.ts` → `README.md` (MCP tools list) → `agents.md` (MCP Server section)
+- **New connector:** `src/connectors/` → `README.md` (connectors section) → `docs/guide/` (new guide page) → `docs/reference/cli.md` (sync/disconnect commands)
+- **New env var:** All env var tables: `README.md`, `docs/guide/configuration.md`, `docs/reference/configuration.md`

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -87,6 +87,8 @@ Supported providers: `openai`, `ollama`.
 | `LIBSCOPE_OLLAMA_URL` | Ollama server URL | `http://localhost:11434` |
 | `LIBSCOPE_LLM_PROVIDER` | LLM provider for RAG (`openai` / `ollama`) | — |
 | `LIBSCOPE_LLM_MODEL` | LLM model override | — |
+| `LIBSCOPE_ALLOW_PRIVATE_URLS` | Allow fetching from private/internal IPs | `false` |
+| `LIBSCOPE_ALLOW_SELF_SIGNED_CERTS` | Accept self-signed TLS certificates | `false` |
 | `ONENOTE_CLIENT_ID` | Microsoft app registration client ID | — |
 | `ONENOTE_TENANT_ID` | Microsoft tenant ID | `common` |
 | `NOTION_TOKEN` | Notion integration token | — |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -173,6 +173,8 @@ libscope serve --api --port 3378
 | `libscope config set <key> <value>` | Set a configuration value |
 | `libscope config show` | Show current configuration |
 
+Supported config keys for `set`: `embedding.provider`, `indexing.allowPrivateUrls`, `indexing.allowSelfSignedCerts`.
+
 ## Global Options
 
 These work with any command:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -41,6 +41,13 @@ Complete reference for all configuration options.
 |-----|------|---------|-------------|
 | `logging.level` | string | `"info"` | `debug`, `info`, `warn`, `error`, or `silent` |
 
+### Indexing
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `indexing.allowPrivateUrls` | boolean | `false` | Allow fetching from private/internal IP addresses |
+| `indexing.allowSelfSignedCerts` | boolean | `false` | Accept self-signed or untrusted TLS certificates |
+
 ## Environment Variables
 
 | Variable | Maps to | Default |
@@ -50,6 +57,8 @@ Complete reference for all configuration options.
 | `LIBSCOPE_OLLAMA_URL` | `embedding.ollamaUrl` | `http://localhost:11434` |
 | `LIBSCOPE_LLM_PROVIDER` | `llm.provider` | — |
 | `LIBSCOPE_LLM_MODEL` | `llm.model` | — |
+| `LIBSCOPE_ALLOW_PRIVATE_URLS` | `indexing.allowPrivateUrls` | `false` |
+| `LIBSCOPE_ALLOW_SELF_SIGNED_CERTS` | `indexing.allowSelfSignedCerts` | `false` |
 | `ONENOTE_CLIENT_ID` | OneNote app client ID | — |
 | `ONENOTE_TENANT_ID` | OneNote tenant ID | `common` |
 | `NOTION_TOKEN` | Notion integration token | — |
@@ -63,9 +72,22 @@ Complete reference for all configuration options.
 # Via CLI
 libscope config set embedding.provider ollama
 libscope config set llm.provider openai
+libscope config set indexing.allowSelfSignedCerts true
 
 # View current config
 libscope config show
+```
+
+## Corporate / Internal Networks
+
+If you're indexing docs from internal servers (Confluence, wikis, etc.):
+
+```bash
+# Allow fetching from private/internal IP addresses
+libscope config set indexing.allowPrivateUrls true
+
+# Accept self-signed or corporate TLS certificates
+libscope config set indexing.allowSelfSignedCerts true
 ```
 
 ## Example Config File
@@ -86,6 +108,10 @@ libscope config show
   },
   "logging": {
     "level": "info"
+  },
+  "indexing": {
+    "allowPrivateUrls": false,
+    "allowSelfSignedCerts": false
   }
 }
 ```

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -200,6 +200,7 @@ export async function handleRequest(
       }
       const fetched = await fetchAndConvert(b["url"], {
         allowPrivateUrls: loadConfig().indexing.allowPrivateUrls,
+        allowSelfSignedCerts: loadConfig().indexing.allowSelfSignedCerts,
       });
       const topicId = typeof b["topic"] === "string" ? b["topic"] : undefined;
       const doc = await indexDocument(db, provider, {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -138,6 +138,7 @@ program
           console.log(`Fetching ${fileOrUrl}...`);
           const fetched = await fetchAndConvert(fileOrUrl, {
             allowPrivateUrls: config.indexing.allowPrivateUrls,
+            allowSelfSignedCerts: config.indexing.allowSelfSignedCerts,
           });
           content = fetched.content;
           title = opts.title ?? fetched.title;
@@ -731,6 +732,10 @@ configCmd
       const bool = value === "true";
       saveUserConfig({ indexing: { ...loadConfig().indexing, allowPrivateUrls: bool } });
       console.log(`✓ indexing.allowPrivateUrls set to: ${bool}`);
+    } else if (key === "indexing.allowSelfSignedCerts") {
+      const bool = value === "true";
+      saveUserConfig({ indexing: { ...loadConfig().indexing, allowSelfSignedCerts: bool } });
+      console.log(`✓ indexing.allowSelfSignedCerts set to: ${bool}`);
     } else {
       console.error(`Unknown config key: ${key}`);
       process.exit(1);

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,7 @@ export interface LibScopeConfig {
   indexing: {
     maxDocumentSize: number;
     allowPrivateUrls: boolean;
+    allowSelfSignedCerts: boolean;
   };
   logging: {
     level: "debug" | "info" | "warn" | "error" | "silent";
@@ -43,6 +44,7 @@ const DEFAULT_CONFIG: LibScopeConfig = {
   indexing: {
     maxDocumentSize: 100 * 1024 * 1024, // 100MB
     allowPrivateUrls: false,
+    allowSelfSignedCerts: false,
   },
   logging: {
     level: "info",
@@ -93,11 +95,20 @@ function getEnvOverrides(): Partial<LibScopeConfig> {
   const llmProvider = process.env["LIBSCOPE_LLM_PROVIDER"];
   const llmModel = process.env["LIBSCOPE_LLM_MODEL"];
   const allowPrivate = process.env["LIBSCOPE_ALLOW_PRIVATE_URLS"];
+  const allowSelfSigned = process.env["LIBSCOPE_ALLOW_SELF_SIGNED_CERTS"];
 
-  if (allowPrivate === "true" || allowPrivate === "1") {
+  if (
+    allowPrivate === "true" ||
+    allowPrivate === "1" ||
+    allowSelfSigned === "true" ||
+    allowSelfSigned === "1"
+  ) {
     overrides.indexing = {
       ...DEFAULT_CONFIG.indexing,
-      allowPrivateUrls: true,
+      ...(allowPrivate === "true" || allowPrivate === "1" ? { allowPrivateUrls: true } : {}),
+      ...(allowSelfSigned === "true" || allowSelfSigned === "1"
+        ? { allowSelfSignedCerts: true }
+        : {}),
     };
   }
 

--- a/src/core/url-fetcher.ts
+++ b/src/core/url-fetcher.ts
@@ -21,6 +21,8 @@ export interface FetchOptions {
   maxBodySize?: number;
   /** Allow fetching from private/internal IP addresses (default: false). */
   allowPrivateUrls?: boolean;
+  /** Accept self-signed or untrusted TLS certificates (default: false). */
+  allowSelfSignedCerts?: boolean;
 }
 
 export const DEFAULT_FETCH_OPTIONS: Required<FetchOptions> = {
@@ -28,6 +30,7 @@ export const DEFAULT_FETCH_OPTIONS: Required<FetchOptions> = {
   maxRedirects: 5,
   maxBodySize: 10 * 1024 * 1024, // 10 MB
   allowPrivateUrls: false,
+  allowSelfSignedCerts: false,
 } as const;
 
 /** Check whether an IP address belongs to a private/reserved range. */
@@ -151,6 +154,32 @@ async function fetchWithRedirects(
   timeout: number,
   maxRedirects: number,
   allowPrivateUrls: boolean,
+  allowSelfSignedCerts: boolean,
+): Promise<Response> {
+  // Temporarily disable TLS verification when self-signed certs are allowed.
+  // Node's native fetch (undici) reads this env var at connection time.
+  const prevTls = process.env["NODE_TLS_REJECT_UNAUTHORIZED"];
+  if (allowSelfSignedCerts) {
+    process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = "0";
+  }
+  try {
+    return await _fetchWithRedirects(url, timeout, maxRedirects, allowPrivateUrls);
+  } finally {
+    if (allowSelfSignedCerts) {
+      if (prevTls === undefined) {
+        delete process.env["NODE_TLS_REJECT_UNAUTHORIZED"];
+      } else {
+        process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = prevTls;
+      }
+    }
+  }
+}
+
+async function _fetchWithRedirects(
+  url: string,
+  timeout: number,
+  maxRedirects: number,
+  allowPrivateUrls: boolean,
 ): Promise<Response> {
   let current = url;
   for (let i = 0; i <= maxRedirects; i++) {
@@ -212,7 +241,7 @@ export async function fetchAndConvert(
   const log = getLogger();
   log.info({ url }, "Fetching URL");
 
-  const { timeout, maxRedirects, maxBodySize, allowPrivateUrls } = {
+  const { timeout, maxRedirects, maxBodySize, allowPrivateUrls, allowSelfSignedCerts } = {
     ...DEFAULT_FETCH_OPTIONS,
     ...options,
   };
@@ -220,7 +249,13 @@ export async function fetchAndConvert(
   try {
     await validateUrl(url, allowPrivateUrls);
 
-    const response = await fetchWithRedirects(url, timeout, maxRedirects, allowPrivateUrls);
+    const response = await fetchWithRedirects(
+      url,
+      timeout,
+      maxRedirects,
+      allowPrivateUrls,
+      allowSelfSignedCerts,
+    );
 
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -277,6 +277,7 @@ async function main(): Promise<void> {
       if (url && !content) {
         const fetched = await fetchAndConvert(url, {
           allowPrivateUrls: config.indexing.allowPrivateUrls,
+          allowSelfSignedCerts: config.indexing.allowSelfSignedCerts,
         });
         content = fetched.content;
         title ??= fetched.title;

--- a/tests/unit/url-fetcher.test.ts
+++ b/tests/unit/url-fetcher.test.ts
@@ -337,6 +337,7 @@ describe("FetchOptions configuration", () => {
       maxRedirects: 5,
       maxBodySize: 10 * 1024 * 1024,
       allowPrivateUrls: false,
+      allowSelfSignedCerts: false,
     });
   });
 


### PR DESCRIPTION
Adds `indexing.allowSelfSignedCerts` config option to accept self-signed or untrusted TLS certificates when fetching URLs from internal servers.

**Problem:** Fetching from internal services (e.g. Confluence) behind corporate CAs with self-signed certificates fails with `SELF_SIGNED_CERT_IN_CHAIN`.

**Fix:**
- New config key: `indexing.allowSelfSignedCerts` (default: `false`)
- New env var: `LIBSCOPE_ALLOW_SELF_SIGNED_CERTS`
- CLI: `libscope config set indexing.allowSelfSignedCerts true`
- Temporarily sets `NODE_TLS_REJECT_UNAUTHORIZED=0` during fetch, restores after
- Wired through CLI, MCP server, and API routes

**Docs updated:** README, docs site (configuration guide, reference, CLI reference), agents.md (added full Documentation section with checklist for future changes).