### PR TITLE
feat(confluence): add --type flag for cloud vs server auth

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1656,14 +1656,16 @@ connectCmd
   .command("confluence")
   .description("Sync Confluence spaces and pages")
   .option("--url <url>", "Confluence base URL (e.g. https://acme.atlassian.net)")
-  .option("--email <email>", "Confluence user email")
-  .option("--token <token>", "API token or PAT")
+  .option("--type <type>", "Confluence type: cloud or server (Data Center)", "cloud")
+  .option("--email <email>", "Confluence user email (Cloud only)")
+  .option("--token <token>", "API token (Cloud) or Personal Access Token (Server/Data Center)")
   .option("--spaces <keys>", "Comma-separated space keys, or 'all'", "all")
   .option("--exclude-spaces <keys>", "Comma-separated space keys to exclude")
   .option("--sync", "Sync using previously saved config")
   .action(
     async (opts: {
       url?: string;
+      type?: string;
       email?: string;
       token?: string;
       spaces?: string;
@@ -1674,7 +1676,8 @@ connectCmd
       const { db, provider } = initializeAppWithEmbedding();
       try {
         const url = opts.url ?? process.env["CONFLUENCE_URL"] ?? "";
-        const email = opts.email ?? process.env["CONFLUENCE_EMAIL"] ?? "";
+        const confluenceType = opts.type === "server" ? "server" : ("cloud" as "cloud" | "server");
+        const email = opts.email ?? process.env["CONFLUENCE_EMAIL"] ?? undefined;
         const token = opts.token ?? process.env["CONFLUENCE_TOKEN"] ?? "";
 
         const spaces = (opts.spaces ?? "all").split(",").map((s) => s.trim());
@@ -1684,7 +1687,8 @@ connectCmd
 
         const result = await syncConfluence(db, provider, {
           baseUrl: url,
-          email,
+          type: confluenceType,
+          ...(email ? { email } : {}),
           token,
           spaces,
           excludeSpaces,

--- a/src/connectors/confluence.ts
+++ b/src/connectors/confluence.ts
@@ -12,7 +12,10 @@ import { startSync, completeSync, failSync } from "./sync-tracker.js";
 
 export interface ConfluenceConfig {
   baseUrl: string;
-  email: string;
+  /** "cloud" uses Basic auth (email:token). "server" uses Bearer PAT. Default: "cloud". */
+  type?: "cloud" | "server" | undefined;
+  /** Email for Confluence Cloud (Basic auth). Required when type is "cloud". */
+  email?: string | undefined;
   token: string;
   spaces: string[];
   lastSync?: string | undefined;
@@ -47,8 +50,15 @@ interface PaginatedResponse<T> {
   _links?: { next?: string };
 }
 
-function buildAuthHeader(email: string, token: string): string {
-  const encoded = Buffer.from(`${email}:${token}`).toString("base64");
+function buildAuthHeader(
+  type: "cloud" | "server",
+  email: string | undefined,
+  token: string,
+): string {
+  if (type === "server") {
+    return `Bearer ${token}`;
+  }
+  const encoded = Buffer.from(`${email ?? ""}:${token}`).toString("base64");
   return `Basic ${encoded}`;
 }
 
@@ -224,14 +234,18 @@ export async function syncConfluence(
   if (!config.baseUrl.trim()) {
     throw new ValidationError("Confluence baseUrl is required");
   }
-  if (!config.email.trim()) {
-    throw new ValidationError("Confluence email is required");
-  }
   if (!config.token.trim()) {
     throw new ValidationError("Confluence token is required");
   }
 
-  const auth = buildAuthHeader(config.email, config.token);
+  const confluenceType = config.type ?? "cloud";
+  if (confluenceType === "cloud" && !config.email?.trim()) {
+    throw new ValidationError(
+      "Confluence email is required for Cloud. For Server/Data Center, use --type server",
+    );
+  }
+
+  const auth = buildAuthHeader(confluenceType, config.email, config.token);
   let base = config.baseUrl;
   while (base.endsWith("/")) base = base.slice(0, -1);
   const syncId = startSync(db, "confluence", base);

--- a/tests/unit/confluence.test.ts
+++ b/tests/unit/confluence.test.ts
@@ -90,10 +90,15 @@ describe("Confluence connector", () => {
   };
 
   describe("buildAuthHeader", () => {
-    it("should encode email:token as base64", () => {
-      const header = buildAuthHeader("user@co.com", "mytoken");
+    it("should encode email:token as base64 for Cloud", () => {
+      const header = buildAuthHeader("cloud", "user@co.com", "mytoken");
       const expected = Buffer.from("user@co.com:mytoken").toString("base64");
       expect(header).toBe(`Basic ${expected}`);
+    });
+
+    it("should use Bearer token for Server/Data Center", () => {
+      const header = buildAuthHeader("server", undefined, "my-pat-token");
+      expect(header).toBe("Bearer my-pat-token");
     });
   });
 
@@ -190,12 +195,28 @@ describe("Confluence connector", () => {
       await expect(syncConfluence(db, provider, { ...baseConfig, baseUrl: "" })).rejects.toThrow(
         "baseUrl is required",
       );
-      await expect(syncConfluence(db, provider, { ...baseConfig, email: "" })).rejects.toThrow(
-        "email is required",
-      );
+      await expect(
+        syncConfluence(db, provider, { ...baseConfig, type: "cloud", email: "" }),
+      ).rejects.toThrow("email is required for Cloud");
       await expect(syncConfluence(db, provider, { ...baseConfig, token: "" })).rejects.toThrow(
         "token is required",
       );
+    });
+
+    it("should not require email for Server/Data Center", async () => {
+      fetchMock.mockResolvedValueOnce(mockFetchResponse(makeSpacesResponse([])));
+
+      const result = await syncConfluence(db, provider, {
+        baseUrl: "https://confluence.internal",
+        type: "server",
+        token: "my-pat",
+        spaces: ["ENG"],
+      });
+
+      expect(result.spaces).toBe(0);
+      const firstCall = fetchMock.mock.calls[0] as [string, RequestInit];
+      const headers = firstCall[1].headers as Record<string, string>;
+      expect(headers["Authorization"]).toBe("Bearer my-pat");
     });
 
     it("should list spaces and index pages", async () => {
@@ -451,7 +472,7 @@ describe("Confluence connector", () => {
 
       await syncConfluence(db, provider, baseConfig);
 
-      const expectedAuth = buildAuthHeader(baseConfig.email, baseConfig.token);
+      const expectedAuth = buildAuthHeader("cloud", baseConfig.email, baseConfig.token);
       const firstCall = fetchMock.mock.calls[0] as [string, RequestInit];
       const headers = firstCall[1].headers as Record<string, string>;
       expect(headers["Authorization"]).toBe(expectedAuth);


### PR DESCRIPTION
Adds an explicit `--type` flag (`cloud` or `server`) to the Confluence connector CLI.

**Cloud** (default): Uses Basic auth (`email:token`). Requires `--email`.
**Server/Data Center**: Uses Bearer PAT auth. No email needed.

### Usage

```bash
# Confluence Cloud (default)
libscope connect confluence --url https://acme.atlassian.net --email user@acme.com --token <API_TOKEN> --spaces ENG

# Confluence Server / Data Center
libscope connect confluence --url https://confluence.internal --type server --token <PAT> --spaces ENG
```

Closes #241