### PR TITLE
fix(mcp): use workspace-aware database path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage/
 .env.local
 docs/.vitepress/dist
 docs/.vitepress/cache
+.vscode/

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -3,6 +3,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import { loadConfig } from "../config.js";
 import { getDatabase, runMigrations, createVectorTable } from "../db/index.js";
+import { getActiveWorkspace, getWorkspacePath } from "../core/workspace.js";
 import { createEmbeddingProvider } from "../providers/index.js";
 import { searchDocuments } from "../core/search.js";
 import { askQuestion, createLlmProvider, type LlmProvider } from "../core/rag.js";
@@ -65,7 +66,7 @@ async function main(): Promise<void> {
 
   let db;
   try {
-    db = getDatabase(config.database.path);
+    db = getDatabase(getWorkspacePath(getActiveWorkspace()));
     runMigrations(db);
   } catch (err) {
     console.error("Failed to initialize database:", err instanceof Error ? err.message : err);


### PR DESCRIPTION
MCP server was hardcoded to `config.database.path` (~/.libscope/libscope.db) instead of the active workspace DB. This caused empty results when documents were indexed via CLI into a workspace.

Now uses `getActiveWorkspace()` + `getWorkspacePath()` — same resolution as the CLI.