### PR TITLE
fix(mcp): expose relevance scores in search results

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -147,7 +147,7 @@ async function main(): Promise<void> {
         results
           .map(
             (r, i) =>
-              `## Result ${i + 1}: ${r.title}\n` +
+              `## Result ${i + 1}: ${r.title} (score: ${r.score.toFixed(2)})\n` +
               (r.library ? `**Library:** ${r.library}${r.version ? ` v${r.version}` : ""}\n` : "") +
               (r.url ? `**Source:** ${r.url}\n` : "") +
               (r.avgRating ? `**Rating:** ${r.avgRating.toFixed(1)}/5\n` : "") +


### PR DESCRIPTION
Adds similarity score to each search result heading in MCP output so consumers can gauge relevance and decide when to stop reading.