### PR TITLE
fix: add input validation for search params, CLI options, and API responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "libscope",
       "version": "1.2.3",
-      "license": "MIT",
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@xenova/transformers": "^2.17.2",
@@ -38,7 +38,7 @@
         "vitest": "^4.0.18"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@algolia/abtesting": {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -84,6 +84,16 @@ process.on("SIGTERM", () => {
 const _require = createRequire(import.meta.url);
 const _pkg = _require("../../package.json") as { version: string };
 
+/** Parse a CLI option string as an integer, exiting with an error if the value is not a valid number. */
+function parseIntOption(value: string, name: string): number {
+  const n = parseInt(value, 10);
+  if (Number.isNaN(n)) {
+    console.error(`Error: "${value}" is not a valid number for ${name}`);
+    process.exit(1);
+  }
+  return n;
+}
+
 const program = new Command();
 
 program
@@ -284,7 +294,7 @@ program
         const startTime = Date.now();
 
         const result = await batchImport(db, provider, files, {
-          concurrency: parseInt(opts.concurrency, 10),
+          concurrency: parseIntOption(opts.concurrency, "--concurrency"),
           library: opts.library,
           version: opts.version,
           topicId: opts.topic,
@@ -331,8 +341,8 @@ program
           query,
           topic: opts.topic,
           library: opts.library,
-          limit: parseInt(opts.limit, 10),
-          offset: parseInt(opts.offset, 10),
+          limit: parseIntOption(opts.limit, "--limit"),
+          offset: parseIntOption(opts.offset, "--offset"),
         });
 
         if (results.length === 0) {
@@ -385,7 +395,7 @@ program
 
         const result = await askQuestion(db, provider, llmProvider, {
           question,
-          topK: parseInt(opts.topK, 10),
+          topK: parseIntOption(opts.topK, "--top-k"),
           topic: opts.topic,
           library: opts.library,
         });
@@ -498,7 +508,7 @@ docsCmd
         library: opts.library,
         topicId: opts.topic,
         sourceType: opts.sourceType,
-        limit: parseInt(opts.limit, 10),
+        limit: parseIntOption(opts.limit, "--limit"),
       });
 
       if (docs.length === 0) {
@@ -657,7 +667,12 @@ docsCmd
   .action(async (documentId: string, version: string) => {
     const { db, provider } = initializeAppWithEmbedding();
     try {
-      const restored = await rollbackToVersion(db, provider, documentId, parseInt(version, 10));
+      const restored = await rollbackToVersion(
+        db,
+        provider,
+        documentId,
+        parseIntOption(version, "<version>"),
+      );
       console.log(`✓ Rolled back to version ${version}, saved as v${restored.version}`);
     } finally {
       closeDatabase();
@@ -704,7 +719,7 @@ program
       const { db, provider } = initializeAppWithEmbedding();
       const { startApiServer } = await import("../api/server.js");
       const { port } = await startApiServer(db, provider, {
-        port: parseInt(opts.port, 10),
+        port: parseIntOption(opts.port, "--port"),
         host: opts.host,
       });
       console.log(`LibScope API server listening on http://${opts.host}:${port}`);
@@ -830,7 +845,7 @@ program
   .action(async (directory: string, opts: { extensions: string; debounce: string }) => {
     const { db, provider } = initializeAppWithEmbedding();
     const extensions = opts.extensions.split(",").map((e) => e.trim().toLowerCase());
-    const debounceMs = parseInt(opts.debounce, 10);
+    const debounceMs = parseIntOption(opts.debounce, "--debounce");
 
     // Initial scan
     const extensionSet = new Set(extensions);
@@ -910,7 +925,7 @@ program
         documentIds: opts.doc,
         since: opts.since,
         before: opts.before,
-        batchSize: parseInt(opts.batchSize, 10),
+        batchSize: parseIntOption(opts.batchSize, "--batch-size"),
         onProgress: (progress) => {
           const done = progress.completed + progress.failed;
           console.log(`  [${done}/${progress.total}] chunks processed`);
@@ -941,7 +956,7 @@ program
   .action(async (opts: { limit: string }) => {
     const { db, provider } = initializeAppWithEmbedding();
     try {
-      await startRepl({ db, provider, limit: parseInt(opts.limit, 10) });
+      await startRepl({ db, provider, limit: parseIntOption(opts.limit, "--limit") });
     } finally {
       closeDatabase();
     }
@@ -1039,7 +1054,7 @@ statsCmd
   .action((opts: { limit: string }) => {
     const { db } = initializeApp();
     try {
-      const docs = getPopularDocuments(db, parseInt(opts.limit, 10));
+      const docs = getPopularDocuments(db, parseIntOption(opts.limit, "--limit"));
       if (docs.length === 0) {
         console.log("No search data yet.");
         return;
@@ -1065,7 +1080,7 @@ statsCmd
   .action((opts: { days: string }) => {
     const { db } = initializeApp();
     try {
-      const docs = getStaleDocuments(db, parseInt(opts.days, 10));
+      const docs = getStaleDocuments(db, parseIntOption(opts.days, "--days"));
       if (docs.length === 0) {
         console.log("No stale documents found.");
         return;
@@ -1090,7 +1105,7 @@ statsCmd
   .action((opts: { limit: string }) => {
     const { db } = initializeApp();
     try {
-      const queries = getTopQueries(db, parseInt(opts.limit, 10));
+      const queries = getTopQueries(db, parseIntOption(opts.limit, "--limit"));
       if (queries.length === 0) {
         console.log("No search data yet.");
         return;
@@ -1116,7 +1131,7 @@ statsCmd
   .action((opts: { days: string }) => {
     const { db } = initializeApp();
     try {
-      const days = parseInt(opts.days, 10);
+      const days = parseIntOption(opts.days, "--days");
       const analytics = getSearchAnalytics(db, days);
       const gaps = getKnowledgeGaps(db, days);
 

--- a/src/connectors/onenote.ts
+++ b/src/connectors/onenote.ts
@@ -259,7 +259,20 @@ export async function authenticateDeviceCode(
     throw new LibScopeError(`Device code request failed: ${text}`, "ONENOTE_AUTH_ERROR");
   }
 
-  const dcData = (await dcRes.json()) as {
+  const dcJson: unknown = await dcRes.json();
+  if (
+    dcJson == null ||
+    typeof dcJson !== "object" ||
+    typeof (dcJson as Record<string, unknown>)["device_code"] !== "string" ||
+    typeof (dcJson as Record<string, unknown>)["user_code"] !== "string" ||
+    typeof (dcJson as Record<string, unknown>)["verification_uri"] !== "string"
+  ) {
+    throw new LibScopeError(
+      "Invalid device code response: missing device_code, user_code, or verification_uri",
+      "ONENOTE_AUTH_ERROR",
+    );
+  }
+  const dcData = dcJson as {
     device_code: string;
     user_code: string;
     verification_uri: string;

--- a/src/core/export.ts
+++ b/src/core/export.ts
@@ -1,7 +1,7 @@
 import type Database from "better-sqlite3";
 import { readFileSync, writeFileSync } from "node:fs";
 import { getLogger } from "../logger.js";
-import { DatabaseError } from "../errors.js";
+import { DatabaseError, ValidationError } from "../errors.js";
 
 const EXPORT_VERSION = "1.0";
 
@@ -77,6 +77,22 @@ export function importFromBackup(db: Database.Database, backupPath: string): Exp
         throw new DatabaseError(`Invalid backup file: missing ${key}`);
       }
     }
+    if (!Array.isArray(record["documents"])) {
+      throw new ValidationError("Invalid backup file: documents must be an array");
+    }
+    for (const doc of record["documents"] as unknown[]) {
+      if (
+        doc == null ||
+        typeof doc !== "object" ||
+        typeof (doc as Record<string, unknown>)["id"] !== "string" ||
+        typeof (doc as Record<string, unknown>)["title"] !== "string"
+      ) {
+        throw new ValidationError(
+          "Invalid backup file: each document must have an id (string) and title (string)",
+        );
+      }
+    }
+
     const parsed = data as ExportData;
 
     if (!parsed.metadata?.version) {

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -95,8 +95,8 @@ export async function searchDocuments(
   options: SearchOptions,
 ): Promise<SearchResponse> {
   const log = withCorrelationId({ operation: "searchDocuments" });
-  const limit = options.limit ?? 10;
-  const offset = options.offset ?? 0;
+  const limit = Math.max(1, Math.min(options.limit ?? 10, 1000));
+  const offset = Math.max(0, options.offset ?? 0);
 
   const analyticsEnabled = options.analyticsEnabled ?? true;
   const startTime = performance.now();

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -36,13 +36,13 @@ export class OllamaEmbeddingProvider implements EmbeddingProvider {
           throw new Error(`Ollama API returned ${response.status}: ${await response.text()}`);
         }
 
-        const data = (await response.json()) as { embeddings: number[][] };
+        const data = (await response.json()) as Record<string, unknown>;
         if (!data.embeddings || !Array.isArray(data.embeddings)) {
           throw new EmbeddingError(
             `Unexpected Ollama response shape: ${JSON.stringify(Object.keys(data))}`,
           );
         }
-        const embedding = data.embeddings[0];
+        const embedding = data.embeddings[0] as number[] | undefined;
         if (!embedding) {
           throw new Error("Ollama returned empty embeddings");
         }
@@ -85,25 +85,26 @@ export class OllamaEmbeddingProvider implements EmbeddingProvider {
           throw new Error(`Ollama API returned ${response.status}: ${await response.text()}`);
         }
 
-        const data = (await response.json()) as { embeddings: number[][] };
+        const data = (await response.json()) as Record<string, unknown>;
         if (!data.embeddings || !Array.isArray(data.embeddings)) {
           throw new EmbeddingError(
             `Unexpected Ollama response shape: ${JSON.stringify(Object.keys(data))}`,
           );
         }
-        if (data.embeddings.length !== texts.length) {
+        const embeddings = data.embeddings as number[][];
+        if (embeddings.length !== texts.length) {
           throw new EmbeddingError(
-            `Ollama returned ${data.embeddings.length} embeddings for ${texts.length} inputs`,
+            `Ollama returned ${embeddings.length} embeddings for ${texts.length} inputs`,
           );
         }
-        for (const emb of data.embeddings) {
+        for (const emb of embeddings) {
           if (emb.length !== this.dimensions) {
             throw new EmbeddingError(
               `Expected embedding dimension ${this.dimensions}, got ${emb.length}`,
             );
           }
         }
-        return data.embeddings;
+        return embeddings;
       });
     } catch (err) {
       if (err instanceof EmbeddingError) throw err;


### PR DESCRIPTION
Closes #252

- Clamp search limit/offset to valid ranges
- Validate Ollama API response structure before type assertion
- Validate backup import document structure
- Validate OneNote device code auth response fields
- Check parseInt results for NaN in CLI option parsing