### PR TITLE
fix: remove unsafe non-null assertions and fix type casts

### DIFF
--- a/src/core/graph.ts
+++ b/src/core/graph.ts
@@ -237,11 +237,15 @@ export function buildKnowledgeGraph(
       // Pairwise similarity
       const docIdList = [...docEmbeddings.keys()];
       for (let i = 0; i < docIdList.length; i++) {
-        const idA = docIdList[i]!;
-        const vecA = docEmbeddings.get(idA)!;
+        const idA = docIdList[i];
+        if (!idA) continue;
+        const vecA = docEmbeddings.get(idA);
+        if (!vecA) continue;
         for (let j = i + 1; j < docIdList.length; j++) {
-          const idB = docIdList[j]!;
-          const vecB = docEmbeddings.get(idB)!;
+          const idB = docIdList[j];
+          if (!idB) continue;
+          const vecB = docEmbeddings.get(idB);
+          if (!vecB) continue;
           const sim = cosineSimilarity(vecA, vecB);
           if (sim >= threshold) {
             edges.push({

--- a/src/core/packs.ts
+++ b/src/core/packs.ts
@@ -346,7 +346,7 @@ export function createPack(db: Database.Database, options: CreatePackOptions): K
   }
 
   let query = "SELECT id, title, content, url, topic_id FROM documents";
-  const params: string[] = [];
+  const params: unknown[] = [];
 
   if (options.topic) {
     query += " WHERE topic_id = ?";

--- a/src/core/rag.ts
+++ b/src/core/rag.ts
@@ -138,12 +138,17 @@ function createOpenAiProvider(
       }
 
       const data = (await res.json()) as {
-        choices: Array<{ message: { content: string } }>;
+        choices?: Array<{ message: { content: string } }>;
         usage?: { total_tokens: number };
       };
 
+      const firstChoice = data.choices?.[0];
+      if (!firstChoice) {
+        throw new Error("OpenAI API error: LLM returned no choices in response");
+      }
+
       return {
-        text: data.choices[0]?.message.content ?? "",
+        text: firstChoice.message.content,
         tokensUsed: data.usage?.total_tokens,
       };
     },


### PR DESCRIPTION
Closes #253

- graph.ts: replace non-null assertions with proper null checks on Map.get()
- rag.ts: validate LLM response choices array before access
- packs.ts: fix params type from string[] to unknown[]