### PR TITLE
fix: error handling gaps — counters, silent failures, version pruning

### DIFF
--- a/src/core/indexing.ts
+++ b/src/core/indexing.ts
@@ -326,7 +326,12 @@ export async function indexDocument(
         insertEmbedding.run(chunkId, vecBuffer);
         insertMeta?.run(chunkId, provider.name, "unknown");
       } catch (err) {
-        log.debug({ chunkId, err }, "Skipped vector insertion (sqlite-vec may not be loaded)");
+        const message = err instanceof Error ? err.message : String(err);
+        if (message.includes("no such table")) {
+          log.debug({ chunkId, err }, "Skipped vector insertion (sqlite-vec may not be loaded)");
+        } else {
+          log.warn({ chunkId, err }, "Failed to insert vector embedding");
+        }
       }
     }
   });

--- a/src/core/reindex.ts
+++ b/src/core/reindex.ts
@@ -87,6 +87,7 @@ export async function reindex(
       const embeddings = await provider.embedBatch(texts);
 
       let batchFailed = 0;
+      let batchSucceeded = 0;
       const upsert = db.transaction(() => {
         for (let j = 0; j < ids.length; j++) {
           const chunkId = ids[j]!;
@@ -100,6 +101,7 @@ export async function reindex(
             deleteStmt.run(chunkId);
             const vecBuffer = Buffer.from(new Float32Array(embedding).buffer);
             insertStmt.run(chunkId, vecBuffer);
+            batchSucceeded++;
           } catch (err) {
             log.warn({ chunkId, err }, "Failed to update embedding for chunk");
             failedChunkIds.push(chunkId);
@@ -110,7 +112,7 @@ export async function reindex(
 
       upsert();
       failed += batchFailed;
-      completed += ids.length - batchFailed;
+      completed += batchSucceeded;
     } catch (err) {
       log.error({ err, batchStart: i }, "Batch embedding failed");
       for (const id of ids) {

--- a/src/core/versioning.ts
+++ b/src/core/versioning.ts
@@ -140,6 +140,14 @@ export function pruneVersions(
   documentId: string,
   maxVersions: number = MAX_VERSIONS_DEFAULT,
 ): number {
+  const countResult = db
+    .prepare(`SELECT COUNT(*) AS cnt FROM document_versions WHERE document_id = ?`)
+    .get(documentId) as { cnt: number } | undefined;
+
+  if (!countResult || countResult.cnt <= maxVersions) {
+    return 0;
+  }
+
   const result = db
     .prepare(
       `DELETE FROM document_versions

--- a/src/core/watcher.ts
+++ b/src/core/watcher.ts
@@ -75,7 +75,9 @@ export class FileWatcher {
 
     const timer = setTimeout(() => {
       this.debounceTimers.delete(fullPath);
-      void this.processFile(fullPath);
+      this.processFile(fullPath).catch((err: unknown) => {
+        this.log.error({ path: fullPath, err }, "Unhandled error processing file");
+      });
     }, this.debounceMs);
 
     this.debounceTimers.set(fullPath, timer);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -89,8 +89,8 @@ async function main(): Promise<void> {
 
   try {
     llmProvider = createLlmProvider(config);
-  } catch {
-    // LLM provider is optional; ask-question tool will report the error
+  } catch (err) {
+    getLogger().warn({ err }, "LLM provider unavailable — ask-question tool will not work");
   }
 
   process.on("SIGINT", () => {


### PR DESCRIPTION
Closes #255

- reindex.ts: fix completed counter to track actual successes
- versioning.ts: guard pruneVersions against empty subquery
- indexing.ts: distinguish expected vs unexpected vector errors
- server.ts: log warning when LLM provider unavailable
- watcher.ts: handle rejected promise from processFile