### PR TITLE
feat: context chunk expansion for search results

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -61,6 +61,7 @@ libscope import-batch ./docs/ --concurrency 10 --filter "**/*.md" --library my-l
 
 ```bash
 libscope search "authentication best practices" --library my-lib --limit 10
+libscope search "deploy process" --context 1    # include neighboring chunks
 ```
 
 | Option | Description |
@@ -69,6 +70,7 @@ libscope search "authentication best practices" --library my-lib --limit 10
 | `--topic <name>` | Filter by topic |
 | `--limit <n>` | Max results (default: 10) |
 | `--min-rating <n>` | Minimum average rating |
+| `--context <n>` | Include N neighboring chunks before/after each result (0-2, default: 0) |
 
 ### `libscope ask`
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -330,19 +330,28 @@ program
   .option("--library <name>", "Filter by library")
   .option("--limit <n>", "Max results", "5")
   .option("--offset <n>", "Offset for pagination", "0")
+  .option("--context <n>", "Include N neighboring chunks before/after each result (0-2)", "0")
   .action(
     async (
       query: string,
-      opts: { topic?: string; library?: string; limit: string; offset: string },
+      opts: {
+        topic?: string;
+        library?: string;
+        limit: string;
+        offset: string;
+        context: string;
+      },
     ) => {
       const { db, provider } = initializeAppWithEmbedding();
       try {
+        const contextChunks = parseIntOption(opts.context, "--context");
         const { results, totalCount } = await searchDocuments(db, provider, {
           query,
           topic: opts.topic,
           library: opts.library,
           limit: parseIntOption(opts.limit, "--limit"),
           offset: parseIntOption(opts.offset, "--offset"),
+          contextChunks: contextChunks > 0 ? contextChunks : undefined,
         });
 
         if (results.length === 0) {
@@ -353,7 +362,24 @@ program
             console.log(`\n── ${r.title} (score: ${r.score.toFixed(2)}) ──`);
             if (r.library) console.log(`  Library: ${r.library}`);
             if (r.url) console.log(`  Source: ${r.url}`);
+
+            if (r.contextBefore && r.contextBefore.length > 0) {
+              for (const c of r.contextBefore) {
+                const preview = c.content.slice(0, 120);
+                console.log(`  ↑ ${preview}${c.content.length > 120 ? "..." : ""}`);
+              }
+              console.log("  ─ ─ ─");
+            }
+
             console.log(`  ${r.content.slice(0, 200)}${r.content.length > 200 ? "..." : ""}`);
+
+            if (r.contextAfter && r.contextAfter.length > 0) {
+              console.log("  ─ ─ ─");
+              for (const c of r.contextAfter) {
+                const preview = c.content.slice(0, 120);
+                console.log(`  ↓ ${preview}${c.content.length > 120 ? "..." : ""}`);
+              }
+            }
           }
         }
       } finally {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -5,7 +5,13 @@ export { checkDuplicate, findDuplicates } from "./dedup.js";
 export type { DedupResult, DedupOptions, DuplicateGroup } from "./dedup.js";
 
 export { searchDocuments } from "./search.js";
-export type { SearchOptions, SearchResult, SearchMethod, ScoreExplanation } from "./search.js";
+export type {
+  SearchOptions,
+  SearchResult,
+  SearchMethod,
+  ScoreExplanation,
+  ContextChunk,
+} from "./search.js";
 
 export {
   logSearch,

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -56,6 +56,7 @@ export interface SearchOptions {
   tags?: string[] | undefined;
   limit?: number | undefined;
   offset?: number | undefined;
+  contextChunks?: number | undefined;
   analyticsEnabled?: boolean | undefined;
 }
 
@@ -73,6 +74,12 @@ export interface ScoreExplanation {
   details: string;
 }
 
+export interface ContextChunk {
+  chunkId: string;
+  content: string;
+  chunkIndex: number;
+}
+
 export interface SearchResult {
   documentId: string;
   chunkId: string;
@@ -86,6 +93,70 @@ export interface SearchResult {
   score: number;
   avgRating: number | null;
   scoreExplanation: ScoreExplanation;
+  contextBefore?: ContextChunk[] | undefined;
+  contextAfter?: ContextChunk[] | undefined;
+}
+
+interface ChunkRow {
+  id: string;
+  content: string;
+  chunk_index: number;
+}
+
+/** Fetch neighboring chunks for a given chunk within its document. */
+function fetchContextChunks(
+  db: Database.Database,
+  chunkId: string,
+  documentId: string,
+  contextSize: number,
+): { before: ContextChunk[]; after: ContextChunk[] } {
+  const currentRow = db
+    .prepare(`SELECT chunk_index FROM chunks WHERE id = ? AND document_id = ?`)
+    .get(chunkId, documentId) as { chunk_index: number } | undefined;
+
+  if (!currentRow) return { before: [], after: [] };
+
+  const idx = currentRow.chunk_index;
+
+  const beforeRows = db
+    .prepare(
+      `SELECT id, content, chunk_index FROM chunks
+       WHERE document_id = ? AND chunk_index >= ? AND chunk_index < ?
+       ORDER BY chunk_index ASC`,
+    )
+    .all(documentId, Math.max(0, idx - contextSize), idx) as ChunkRow[];
+
+  const afterRows = db
+    .prepare(
+      `SELECT id, content, chunk_index FROM chunks
+       WHERE document_id = ? AND chunk_index > ? AND chunk_index <= ?
+       ORDER BY chunk_index ASC`,
+    )
+    .all(documentId, idx, idx + contextSize) as ChunkRow[];
+
+  return {
+    before: beforeRows.map((r) => ({
+      chunkId: r.id,
+      content: r.content,
+      chunkIndex: r.chunk_index,
+    })),
+    after: afterRows.map((r) => ({ chunkId: r.id, content: r.content, chunkIndex: r.chunk_index })),
+  };
+}
+
+/** Attach context chunks to search results when requested. */
+function attachContext(
+  db: Database.Database,
+  results: SearchResult[],
+  contextSize: number,
+): SearchResult[] {
+  if (contextSize <= 0) return results;
+  const capped = Math.min(contextSize, 2);
+
+  return results.map((r) => {
+    const { before, after } = fetchContextChunks(db, r.chunkId, r.documentId, capped);
+    return { ...r, contextBefore: before, contextAfter: after };
+  });
 }
 
 /** Perform semantic search across indexed documents. */
@@ -242,6 +313,10 @@ export async function searchDocuments(
       });
     }
 
+    if (options.contextChunks) {
+      response.results = attachContext(db, response.results, options.contextChunks);
+    }
+
     return response;
   } catch (err) {
     if (!isVectorTableError(err)) {
@@ -265,6 +340,10 @@ export async function searchDocuments(
         topScore: response.results[0]?.score ?? null,
         searchType: method,
       });
+    }
+
+    if (options.contextChunks) {
+      response.results = attachContext(db, response.results, options.contextChunks);
     }
 
     return response;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -124,6 +124,14 @@ async function main(): Promise<void> {
         .max(50)
         .optional()
         .describe("Maximum results to return (default: 10)"),
+      contextChunks: z
+        .number()
+        .min(0)
+        .max(2)
+        .optional()
+        .describe(
+          "Number of neighboring chunks to include before/after each result for context (0-2, default: 0)",
+        ),
     },
     withErrorHandling(async (params) => {
       const { results, totalCount } = await searchDocuments(db, provider, {
@@ -134,6 +142,7 @@ async function main(): Promise<void> {
         minRating: params.minRating,
         limit: params.limit,
         offset: params.offset,
+        contextChunks: params.contextChunks,
       });
 
       if (results.length === 0) {
@@ -145,14 +154,25 @@ async function main(): Promise<void> {
       const text =
         `**Total results: ${totalCount}**\n\n` +
         results
-          .map(
-            (r, i) =>
+          .map((r, i) => {
+            let entry =
               `## Result ${i + 1}: ${r.title} (score: ${r.score.toFixed(2)})\n` +
               (r.library ? `**Library:** ${r.library}${r.version ? ` v${r.version}` : ""}\n` : "") +
               (r.url ? `**Source:** ${r.url}\n` : "") +
-              (r.avgRating ? `**Rating:** ${r.avgRating.toFixed(1)}/5\n` : "") +
-              `\n${r.content}\n`,
-          )
+              (r.avgRating ? `**Rating:** ${r.avgRating.toFixed(1)}/5\n` : "");
+
+            if (r.contextBefore && r.contextBefore.length > 0) {
+              entry += `\n**Context (before):**\n${r.contextBefore.map((c) => c.content).join("\n\n")}\n`;
+            }
+
+            entry += `\n${r.content}\n`;
+
+            if (r.contextAfter && r.contextAfter.length > 0) {
+              entry += `\n**Context (after):**\n${r.contextAfter.map((c) => c.content).join("\n\n")}\n`;
+            }
+
+            return entry;
+          })
           .join("\n---\n\n");
 
       return { content: [{ type: "text" as const, text }] };

--- a/tests/fixtures/helpers.ts
+++ b/tests/fixtures/helpers.ts
@@ -33,11 +33,13 @@ export function insertChunk(
   id: string,
   documentId: string,
   content: string,
+  chunkIndex = 0,
 ): void {
-  db.prepare(`INSERT INTO chunks (id, document_id, content, chunk_index) VALUES (?, ?, ?, 0)`).run(
+  db.prepare(`INSERT INTO chunks (id, document_id, content, chunk_index) VALUES (?, ?, ?, ?)`).run(
     id,
     documentId,
     content,
+    chunkIndex,
   );
 }
 

--- a/tests/unit/search.test.ts
+++ b/tests/unit/search.test.ts
@@ -328,3 +328,145 @@ describe("search result scoring explanation (issue #89)", () => {
     expect(result.score).toBe(-result.scoreExplanation.rawScore);
   });
 });
+
+describe("context chunk expansion (issue #247)", () => {
+  let db: Database.Database;
+  let provider: MockEmbeddingProvider;
+
+  beforeEach(() => {
+    db = createTestDb();
+    provider = new MockEmbeddingProvider();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("should return contextBefore and contextAfter when contextChunks is set", async () => {
+    insertDoc(db, "doc1", "Multi-chunk Doc");
+    insertChunk(db, "c1-0", "doc1", "Chapter 1: Introduction", 0);
+    insertChunk(db, "c1-1", "doc1", "Chapter 2: Core concepts explained", 1);
+    insertChunk(db, "c1-2", "doc1", "Chapter 3: Advanced patterns", 2);
+    insertChunk(db, "c1-3", "doc1", "Chapter 4: Conclusion and summary", 3);
+
+    const { results } = await searchDocuments(db, provider, {
+      query: "Core concepts",
+      contextChunks: 1,
+    });
+
+    expect(results.length).toBe(1);
+    const result = results[0]!;
+    expect(result.content).toContain("Core concepts");
+    expect(result.contextBefore).toBeDefined();
+    expect(result.contextBefore!.length).toBe(1);
+    expect(result.contextBefore![0]!.content).toContain("Introduction");
+    expect(result.contextAfter).toBeDefined();
+    expect(result.contextAfter!.length).toBe(1);
+    expect(result.contextAfter![0]!.content).toContain("Advanced patterns");
+  });
+
+  it("should return up to 2 context chunks per side", async () => {
+    insertDoc(db, "doc1", "Big Doc");
+    insertChunk(db, "c0", "doc1", "Section zero", 0);
+    insertChunk(db, "c1", "doc1", "Section one", 1);
+    insertChunk(db, "c2", "doc1", "Section two target keyword", 2);
+    insertChunk(db, "c3", "doc1", "Section three", 3);
+    insertChunk(db, "c4", "doc1", "Section four", 4);
+
+    const { results } = await searchDocuments(db, provider, {
+      query: "target keyword",
+      contextChunks: 2,
+    });
+
+    expect(results.length).toBe(1);
+    const result = results[0]!;
+    expect(result.contextBefore!.length).toBe(2);
+    expect(result.contextBefore![0]!.content).toContain("Section zero");
+    expect(result.contextBefore![1]!.content).toContain("Section one");
+    expect(result.contextAfter!.length).toBe(2);
+    expect(result.contextAfter![0]!.content).toContain("Section three");
+    expect(result.contextAfter![1]!.content).toContain("Section four");
+  });
+
+  it("should handle first chunk with no context before", async () => {
+    insertDoc(db, "doc1", "Edge Doc");
+    insertChunk(db, "c0", "doc1", "First chunk searchable content", 0);
+    insertChunk(db, "c1", "doc1", "Second chunk", 1);
+
+    const { results } = await searchDocuments(db, provider, {
+      query: "searchable content",
+      contextChunks: 1,
+    });
+
+    expect(results.length).toBe(1);
+    expect(results[0]!.contextBefore!.length).toBe(0);
+    expect(results[0]!.contextAfter!.length).toBe(1);
+  });
+
+  it("should handle last chunk with no context after", async () => {
+    insertDoc(db, "doc1", "Edge Doc");
+    insertChunk(db, "c0", "doc1", "First chunk", 0);
+    insertChunk(db, "c1", "doc1", "Last chunk searchable end", 1);
+
+    const { results } = await searchDocuments(db, provider, {
+      query: "searchable end",
+      contextChunks: 1,
+    });
+
+    expect(results.length).toBe(1);
+    expect(results[0]!.contextBefore!.length).toBe(1);
+    expect(results[0]!.contextAfter!.length).toBe(0);
+  });
+
+  it("should not include context when contextChunks is 0 or unset", async () => {
+    insertDoc(db, "doc1", "No Context Doc");
+    insertChunk(db, "c0", "doc1", "Chunk zero", 0);
+    insertChunk(db, "c1", "doc1", "Chunk one with keyword", 1);
+    insertChunk(db, "c2", "doc1", "Chunk two", 2);
+
+    const { results } = await searchDocuments(db, provider, {
+      query: "keyword",
+    });
+
+    expect(results.length).toBe(1);
+    expect(results[0]!.contextBefore).toBeUndefined();
+    expect(results[0]!.contextAfter).toBeUndefined();
+  });
+
+  it("should cap contextChunks at 2 even if higher value is passed", async () => {
+    insertDoc(db, "doc1", "Cap Doc");
+    insertChunk(db, "c0", "doc1", "Section A", 0);
+    insertChunk(db, "c1", "doc1", "Section B", 1);
+    insertChunk(db, "c2", "doc1", "Section C", 2);
+    insertChunk(db, "c3", "doc1", "Section D target text", 3);
+    insertChunk(db, "c4", "doc1", "Section E", 4);
+    insertChunk(db, "c5", "doc1", "Section F", 5);
+    insertChunk(db, "c6", "doc1", "Section G", 6);
+
+    const { results } = await searchDocuments(db, provider, {
+      query: "target text",
+      contextChunks: 5,
+    });
+
+    expect(results.length).toBe(1);
+    // Capped at 2
+    expect(results[0]!.contextBefore!.length).toBe(2);
+    expect(results[0]!.contextAfter!.length).toBe(2);
+  });
+
+  it("should include chunkIndex in context chunks", async () => {
+    insertDoc(db, "doc1", "Index Doc");
+    insertChunk(db, "c0", "doc1", "Prologue", 0);
+    insertChunk(db, "c1", "doc1", "Main searchable section", 1);
+    insertChunk(db, "c2", "doc1", "Epilogue", 2);
+
+    const { results } = await searchDocuments(db, provider, {
+      query: "searchable section",
+      contextChunks: 1,
+    });
+
+    expect(results.length).toBe(1);
+    expect(results[0]!.contextBefore![0]!.chunkIndex).toBe(0);
+    expect(results[0]!.contextAfter![0]!.chunkIndex).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `contextChunks` option to search that returns neighboring chunks alongside each result. This solves the problem where chunk boundaries cut context mid-thought — users no longer need to fall back to `get-document` and read the entire document.

## Changes

### Core (`src/core/search.ts`)
- New `ContextChunk` type: `{ chunkId, content, chunkIndex }`
- `SearchResult` gains optional `contextBefore` / `contextAfter` arrays
- `fetchContextChunks()` queries neighbors by `chunk_index` windowing
- Capped at max **2 chunks per side** to avoid returning entire documents
- Works with all search methods (vector, FTS5, LIKE fallback)

### MCP Tool (`src/mcp/server.ts`)
- `search-docs` gains optional `contextChunks` parameter (0-2, default: 0)
- Context rendered as labeled sections in the markdown output

### CLI (`src/cli/index.ts`)
- `libscope search` gains `--context <n>` flag
- Context chunks displayed with ↑/↓ arrows before/after the matched chunk

### Tests
- 7 new unit tests: basic expansion, cap at 2, first/last chunk edges, unset = no context, chunkIndex values

## Usage

```bash
# CLI
libscope search "deploy process" --context 1

# MCP tool
search-docs: { query: "deploy", contextChunks: 1 }
```

Closes #247