### PR TITLE
feat: document cross-references and relationship links

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -112,6 +112,26 @@ libscope serve --dashboard --port 8080
 | `libscope docs history <id>` | View version history |
 | `libscope docs rollback <id> <version>` | Rollback to a previous version |
 
+## Document Links (Cross-references)
+
+| Command | Description |
+|---------|-------------|
+| `libscope link <sourceId> <targetId>` | Create a cross-reference link |
+| `libscope links <documentId>` | Show all links for a document |
+| `libscope unlink <linkId>` | Remove a link |
+| `libscope prereqs <documentId>` | Show prerequisite reading chain |
+
+### `libscope link`
+
+```bash
+libscope link <sourceId> <targetId> --type see_also --label "Background context"
+```
+
+| Option | Description |
+|--------|-------------|
+| `--type <type>` | Link type: `see_also`, `prerequisite`, `supersedes`, `related` (default: `related`) |
+| `--label <text>` | Optional description of the relationship |
+
 ## Topics & Tags
 
 | Command | Description |

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -20,7 +20,11 @@ import {
   askQuestion,
   askQuestionStream,
   createLlmProvider,
+  createLink,
+  getDocumentLinks,
+  deleteLink,
 } from "../core/index.js";
+import type { LinkType } from "../core/index.js";
 import { loadConfig } from "../config.js";
 import { DocumentNotFoundError, LibScopeError } from "../errors.js";
 import { getLogger } from "../logger.js";
@@ -61,6 +65,33 @@ function matchDocumentTags(segments: string[]): string | null {
     segments[1] === "v1" &&
     segments[2] === "documents" &&
     segments[4] === "tags"
+  ) {
+    return segments[3] ?? null;
+  }
+  return null;
+}
+
+/** Match /api/v1/documents/:id/links */
+function matchDocumentLinks(segments: string[]): string | null {
+  if (
+    segments.length === 5 &&
+    segments[0] === "api" &&
+    segments[1] === "v1" &&
+    segments[2] === "documents" &&
+    segments[4] === "links"
+  ) {
+    return segments[3] ?? null;
+  }
+  return null;
+}
+
+/** Match /api/v1/links/:id */
+function matchLinkId(segments: string[]): string | null {
+  if (
+    segments.length === 4 &&
+    segments[0] === "api" &&
+    segments[1] === "v1" &&
+    segments[2] === "links"
   ) {
     return segments[3] ?? null;
   }
@@ -370,6 +401,39 @@ export async function handleRequest(
 
     if (docId && method === "DELETE") {
       deleteDocument(db, docId);
+      const took = Math.round(performance.now() - start);
+      sendJson(res, 200, { deleted: true }, took);
+      return;
+    }
+
+    // Document links: GET/POST /api/v1/documents/:id/links
+    const linksDocId = matchDocumentLinks(segments);
+    if (linksDocId && method === "GET") {
+      const links = getDocumentLinks(db, linksDocId);
+      const took = Math.round(performance.now() - start);
+      sendJson(res, 200, links, took);
+      return;
+    }
+    if (linksDocId && method === "POST") {
+      const body = (await parseJsonBody(req)) as {
+        targetId?: string;
+        linkType?: string;
+        label?: string;
+      };
+      if (!body.targetId || !body.linkType) {
+        sendError(res, 400, "VALIDATION_ERROR", "targetId and linkType are required");
+        return;
+      }
+      const link = createLink(db, linksDocId, body.targetId, body.linkType as LinkType, body.label);
+      const took = Math.round(performance.now() - start);
+      sendJson(res, 201, link, took);
+      return;
+    }
+
+    // Delete link: DELETE /api/v1/links/:id
+    const linkId = matchLinkId(segments);
+    if (linkId && method === "DELETE") {
+      deleteLink(db, linkId);
       const took = Math.round(performance.now() - start);
       sendJson(res, 200, { deleted: true }, took);
       return;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,6 +10,8 @@ import { askQuestion, createLlmProvider } from "../core/rag.js";
 import { getDocumentRatings, listRatings } from "../core/ratings.js";
 import { createTopic, listTopics } from "../core/topics.js";
 import { getDocument, listDocuments, deleteDocument } from "../core/documents.js";
+import { createLink, getDocumentLinks, deleteLink, getPrerequisiteChain } from "../core/links.js";
+import type { LinkType } from "../core/links.js";
 import { getVersionHistory, rollbackToVersion } from "../core/versioning.js";
 import { initLogger, type LogLevel } from "../logger.js";
 import { readFileSync, readdirSync, statSync } from "node:fs";
@@ -512,6 +514,92 @@ ratingsCmd
           console.log(`  ${r.rating}/5 by ${r.ratedBy} — ${r.feedback ?? "(no feedback)"}`);
         }
       }
+    } finally {
+      closeDatabase();
+    }
+  });
+
+// links (document cross-references)
+program
+  .command("link <sourceId> <targetId>")
+  .description("Create a cross-reference link between two documents")
+  .option("--type <type>", "Link type: see_also, prerequisite, supersedes, related", "related")
+  .option("--label <text>", "Human-readable description of the link")
+  .action((sourceId: string, targetId: string, opts: { type: string; label?: string }) => {
+    const validTypes = ["see_also", "prerequisite", "supersedes", "related"];
+    if (!validTypes.includes(opts.type)) {
+      console.error(`Invalid link type: ${opts.type}. Must be one of: ${validTypes.join(", ")}`);
+      process.exit(1);
+    }
+    const { db } = initializeApp();
+    try {
+      const link = createLink(db, sourceId, targetId, opts.type as LinkType, opts.label);
+      console.log(`✓ Link created: ${link.linkType} (${link.id})`);
+    } finally {
+      closeDatabase();
+    }
+  });
+
+program
+  .command("links <documentId>")
+  .description("Show all cross-reference links for a document")
+  .action((documentId: string) => {
+    const { db } = initializeApp();
+    try {
+      const { outgoing, incoming } = getDocumentLinks(db, documentId);
+      if (outgoing.length === 0 && incoming.length === 0) {
+        console.log("No links found for this document.");
+        return;
+      }
+      if (outgoing.length > 0) {
+        console.log("\nOutgoing links:");
+        for (const l of outgoing) {
+          console.log(`  → [${l.linkType}] ${l.targetTitle}${l.label ? ` — ${l.label}` : ""}`);
+          console.log(`    ID: ${l.id}  Target: ${l.targetId}`);
+        }
+      }
+      if (incoming.length > 0) {
+        console.log("\nIncoming links:");
+        for (const l of incoming) {
+          console.log(`  ← [${l.linkType}] ${l.sourceTitle}${l.label ? ` — ${l.label}` : ""}`);
+          console.log(`    ID: ${l.id}  Source: ${l.sourceId}`);
+        }
+      }
+    } finally {
+      closeDatabase();
+    }
+  });
+
+program
+  .command("unlink <linkId>")
+  .description("Remove a cross-reference link")
+  .action((linkId: string) => {
+    const { db } = initializeApp();
+    try {
+      deleteLink(db, linkId);
+      console.log(`✓ Link ${linkId} deleted.`);
+    } finally {
+      closeDatabase();
+    }
+  });
+
+program
+  .command("prereqs <documentId>")
+  .description("Show prerequisite reading chain for a document")
+  .action((documentId: string) => {
+    const { db } = initializeApp();
+    try {
+      const chain = getPrerequisiteChain(db, documentId);
+      if (chain.length === 0) {
+        console.log("No prerequisites found for this document.");
+        return;
+      }
+      console.log("\nPrerequisite reading order:");
+      for (let i = 0; i < chain.length; i++) {
+        const doc = chain[i]!;
+        console.log(`  ${i + 1}. ${doc.title} (${doc.id})`);
+      }
+      console.log(`  ${chain.length + 1}. [this document]`);
     } finally {
       closeDatabase();
     }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -156,6 +156,15 @@ export type { Workspace } from "./workspace.js";
 export { buildKnowledgeGraph, detectClusters } from "./graph.js";
 export type { KnowledgeGraph, GraphNode, GraphEdge, GraphOptions } from "./graph.js";
 
+export {
+  createLink,
+  getDocumentLinks,
+  deleteLink,
+  getPrerequisiteChain,
+  listLinks,
+} from "./links.js";
+export type { LinkType, DocumentLink, DocumentLinkWithTitle, DocumentLinks } from "./links.js";
+
 export { startApiServer } from "../api/server.js";
 export type { ApiServerOptions } from "../api/server.js";
 

--- a/src/core/links.ts
+++ b/src/core/links.ts
@@ -1,0 +1,226 @@
+import type Database from "better-sqlite3";
+import { randomUUID } from "node:crypto";
+import { ValidationError, DocumentNotFoundError } from "../errors.js";
+import { createChildLogger } from "../logger.js";
+
+export type LinkType = "see_also" | "prerequisite" | "supersedes" | "related";
+
+const VALID_LINK_TYPES: ReadonlySet<string> = new Set<LinkType>([
+  "see_also",
+  "prerequisite",
+  "supersedes",
+  "related",
+]);
+
+export interface DocumentLink {
+  id: string;
+  sourceId: string;
+  targetId: string;
+  linkType: LinkType;
+  label: string | null;
+  createdAt: string;
+}
+
+export interface DocumentLinkWithTitle extends DocumentLink {
+  sourceTitle: string;
+  targetTitle: string;
+}
+
+export interface DocumentLinks {
+  outgoing: DocumentLinkWithTitle[];
+  incoming: DocumentLinkWithTitle[];
+}
+
+interface LinkRow {
+  id: string;
+  source_id: string;
+  target_id: string;
+  link_type: string;
+  label: string | null;
+  created_at: string;
+}
+
+interface LinkRowWithTitles extends LinkRow {
+  source_title: string;
+  target_title: string;
+}
+
+function rowToLink(row: LinkRow): DocumentLink {
+  return {
+    id: row.id,
+    sourceId: row.source_id,
+    targetId: row.target_id,
+    linkType: row.link_type as LinkType,
+    label: row.label,
+    createdAt: row.created_at,
+  };
+}
+
+function rowToLinkWithTitle(row: LinkRowWithTitles): DocumentLinkWithTitle {
+  return {
+    ...rowToLink(row),
+    sourceTitle: row.source_title,
+    targetTitle: row.target_title,
+  };
+}
+
+function assertDocumentExists(db: Database.Database, docId: string, role: string): void {
+  const row = db.prepare("SELECT id FROM documents WHERE id = ?").get(docId) as
+    | { id: string }
+    | undefined;
+  if (!row) {
+    throw new DocumentNotFoundError(`${role} document not found: ${docId}`);
+  }
+}
+
+/** Create a link between two documents. Returns existing link if duplicate. */
+export function createLink(
+  db: Database.Database,
+  sourceId: string,
+  targetId: string,
+  linkType: LinkType,
+  label?: string,
+): DocumentLink {
+  const log = createChildLogger({ operation: "createLink" });
+
+  if (!VALID_LINK_TYPES.has(linkType)) {
+    throw new ValidationError(
+      `Invalid link type: ${linkType}. Must be one of: ${[...VALID_LINK_TYPES].join(", ")}`,
+    );
+  }
+  if (sourceId === targetId) {
+    throw new ValidationError("Cannot link a document to itself");
+  }
+
+  assertDocumentExists(db, sourceId, "Source");
+  assertDocumentExists(db, targetId, "Target");
+
+  const id = randomUUID();
+  const result = db
+    .prepare(
+      `INSERT INTO document_links (id, source_id, target_id, link_type, label)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(source_id, target_id, link_type) DO NOTHING`,
+    )
+    .run(id, sourceId, targetId, linkType, label ?? null);
+
+  if (result.changes > 0) {
+    log.info({ linkId: id, sourceId, targetId, linkType }, "Document link created");
+    return {
+      id,
+      sourceId,
+      targetId,
+      linkType,
+      label: label ?? null,
+      createdAt: new Date().toISOString(),
+    };
+  }
+
+  // Return existing
+  const existing = db
+    .prepare(
+      `SELECT id, source_id, target_id, link_type, label, created_at
+       FROM document_links WHERE source_id = ? AND target_id = ? AND link_type = ?`,
+    )
+    .get(sourceId, targetId, linkType) as LinkRow;
+
+  log.info({ sourceId, targetId, linkType }, "Link already exists, returning existing");
+  return rowToLink(existing);
+}
+
+/** Get all links for a document (both outgoing and incoming), with titles. */
+export function getDocumentLinks(db: Database.Database, documentId: string): DocumentLinks {
+  const outgoing = db
+    .prepare(
+      `SELECT l.id, l.source_id, l.target_id, l.link_type, l.label, l.created_at,
+              s.title AS source_title, t.title AS target_title
+       FROM document_links l
+       JOIN documents s ON s.id = l.source_id
+       JOIN documents t ON t.id = l.target_id
+       WHERE l.source_id = ?
+       ORDER BY l.created_at DESC`,
+    )
+    .all(documentId) as LinkRowWithTitles[];
+
+  const incoming = db
+    .prepare(
+      `SELECT l.id, l.source_id, l.target_id, l.link_type, l.label, l.created_at,
+              s.title AS source_title, t.title AS target_title
+       FROM document_links l
+       JOIN documents s ON s.id = l.source_id
+       JOIN documents t ON t.id = l.target_id
+       WHERE l.target_id = ?
+       ORDER BY l.created_at DESC`,
+    )
+    .all(documentId) as LinkRowWithTitles[];
+
+  return {
+    outgoing: outgoing.map(rowToLinkWithTitle),
+    incoming: incoming.map(rowToLinkWithTitle),
+  };
+}
+
+/** Delete a link by its ID. */
+export function deleteLink(db: Database.Database, linkId: string): void {
+  const log = createChildLogger({ operation: "deleteLink" });
+  const result = db.prepare("DELETE FROM document_links WHERE id = ?").run(linkId);
+  if (result.changes === 0) {
+    throw new ValidationError(`Link not found: ${linkId}`);
+  }
+  log.info({ linkId }, "Document link deleted");
+}
+
+/** Get the prerequisite chain for a document (ordered learning path). Detects cycles. */
+export function getPrerequisiteChain(
+  db: Database.Database,
+  documentId: string,
+): Array<{ id: string; title: string }> {
+  const chain: Array<{ id: string; title: string }> = [];
+  const visited = new Set<string>();
+  let currentId = documentId;
+
+  // Walk backwards through prerequisite links
+  while (true) {
+    if (visited.has(currentId)) break; // cycle detection
+    visited.add(currentId);
+
+    const prereq = db
+      .prepare(
+        `SELECT l.source_id, d.title
+         FROM document_links l
+         JOIN documents d ON d.id = l.source_id
+         WHERE l.target_id = ? AND l.link_type = 'prerequisite'
+         LIMIT 1`,
+      )
+      .get(currentId) as { source_id: string; title: string } | undefined;
+
+    if (!prereq) break;
+
+    chain.unshift({ id: prereq.source_id, title: prereq.title });
+    currentId = prereq.source_id;
+  }
+
+  return chain;
+}
+
+/** List all links in the database, optionally filtered by type. */
+export function listLinks(db: Database.Database, linkType?: LinkType): DocumentLinkWithTitle[] {
+  let sql = `
+    SELECT l.id, l.source_id, l.target_id, l.link_type, l.label, l.created_at,
+           s.title AS source_title, t.title AS target_title
+    FROM document_links l
+    JOIN documents s ON s.id = l.source_id
+    JOIN documents t ON t.id = l.target_id
+  `;
+  const params: unknown[] = [];
+
+  if (linkType) {
+    sql += " WHERE l.link_type = ?";
+    params.push(linkType);
+  }
+
+  sql += " ORDER BY l.created_at DESC";
+
+  const rows = db.prepare(sql).all(...params) as LinkRowWithTitles[];
+  return rows.map(rowToLinkWithTitle);
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -2,7 +2,7 @@ import type Database from "better-sqlite3";
 import { DatabaseError } from "../errors.js";
 import { getLogger } from "../logger.js";
 
-const SCHEMA_VERSION = 12;
+const SCHEMA_VERSION = 13;
 
 const MIGRATIONS: Record<number, string> = {
   1: `
@@ -214,6 +214,21 @@ const MIGRATIONS: Record<number, string> = {
     );
 
     INSERT INTO schema_version (version) VALUES (12);
+  `,
+  13: `
+    CREATE TABLE IF NOT EXISTS document_links (
+      id TEXT PRIMARY KEY,
+      source_id TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+      target_id TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+      link_type TEXT NOT NULL,
+      label TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE(source_id, target_id, link_type)
+    );
+    CREATE INDEX IF NOT EXISTS idx_links_source ON document_links(source_id);
+    CREATE INDEX IF NOT EXISTS idx_links_target ON document_links(target_id);
+
+    INSERT INTO schema_version (version) VALUES (13);
   `,
 };
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -11,6 +11,8 @@ import { getDocument, listDocuments, deleteDocument } from "../core/documents.js
 import { rateDocument, getDocumentRatings } from "../core/ratings.js";
 import { indexDocument } from "../core/indexing.js";
 import { listTopics } from "../core/topics.js";
+import { createLink, getDocumentLinks, deleteLink } from "../core/links.js";
+import type { LinkType } from "../core/links.js";
 import { fetchAndConvert } from "../core/url-fetcher.js";
 import { initLogger, getLogger } from "../logger.js";
 import { LibScopeError, ValidationError } from "../errors.js";
@@ -836,6 +838,84 @@ async function main(): Promise<void> {
         ...gaps.map((g) => `  ${g.count}x  ${g.query} (last: ${g.lastSearched})`),
       ];
       return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }),
+  );
+
+  // Tool: link-documents
+  server.tool(
+    "link-documents",
+    "Create a relationship between two documents (see_also, prerequisite, supersedes, related)",
+    {
+      sourceId: z.string().describe("The source document ID"),
+      targetId: z.string().describe("The target document ID"),
+      linkType: z
+        .enum(["see_also", "prerequisite", "supersedes", "related"])
+        .describe("Type of relationship"),
+      label: z.string().optional().describe("Optional human-readable description of the link"),
+    },
+    withErrorHandling((params) => {
+      const link = createLink(
+        db,
+        params.sourceId,
+        params.targetId,
+        params.linkType as LinkType,
+        params.label,
+      );
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `✓ Link created: ${link.sourceId} → ${link.targetId} (${link.linkType})${link.label ? ` — ${link.label}` : ""}`,
+          },
+        ],
+      };
+    }),
+  );
+
+  // Tool: get-document-links
+  server.tool(
+    "get-document-links",
+    "Get all cross-reference links for a document (both outgoing and incoming)",
+    {
+      documentId: z.string().describe("The document ID"),
+    },
+    withErrorHandling((params) => {
+      const { outgoing, incoming } = getDocumentLinks(db, params.documentId);
+      if (outgoing.length === 0 && incoming.length === 0) {
+        return { content: [{ type: "text" as const, text: "No links found for this document." }] };
+      }
+
+      const lines: string[] = [];
+      if (outgoing.length > 0) {
+        lines.push("**Outgoing links:**");
+        for (const l of outgoing) {
+          lines.push(
+            `  → [${l.linkType}] ${l.targetTitle} (${l.targetId})${l.label ? ` — ${l.label}` : ""}`,
+          );
+        }
+      }
+      if (incoming.length > 0) {
+        lines.push("**Incoming links:**");
+        for (const l of incoming) {
+          lines.push(
+            `  ← [${l.linkType}] ${l.sourceTitle} (${l.sourceId})${l.label ? ` — ${l.label}` : ""}`,
+          );
+        }
+      }
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }),
+  );
+
+  // Tool: delete-link
+  server.tool(
+    "delete-link",
+    "Remove a cross-reference link between documents",
+    {
+      linkId: z.string().describe("The link ID to delete"),
+    },
+    withErrorHandling((params) => {
+      deleteLink(db, params.linkId);
+      return { content: [{ type: "text" as const, text: `✓ Link ${params.linkId} deleted.` }] };
     }),
   );
 

--- a/tests/unit/links.test.ts
+++ b/tests/unit/links.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type Database from "better-sqlite3";
+import { createTestDb } from "../fixtures/test-db.js";
+import { insertDoc } from "../fixtures/helpers.js";
+import {
+  createLink,
+  getDocumentLinks,
+  deleteLink,
+  getPrerequisiteChain,
+  listLinks,
+} from "../../src/core/links.js";
+
+describe("document links", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+    insertDoc(db, "doc-a", "Document A");
+    insertDoc(db, "doc-b", "Document B");
+    insertDoc(db, "doc-c", "Document C");
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  describe("createLink", () => {
+    it("should create a link between two documents", () => {
+      const link = createLink(db, "doc-a", "doc-b", "see_also");
+      expect(link.sourceId).toBe("doc-a");
+      expect(link.targetId).toBe("doc-b");
+      expect(link.linkType).toBe("see_also");
+      expect(link.label).toBeNull();
+      expect(link.id).toBeDefined();
+    });
+
+    it("should create a link with a label", () => {
+      const link = createLink(db, "doc-a", "doc-b", "prerequisite", "Read this first");
+      expect(link.label).toBe("Read this first");
+    });
+
+    it("should return existing link on duplicate", () => {
+      const first = createLink(db, "doc-a", "doc-b", "related");
+      const second = createLink(db, "doc-a", "doc-b", "related");
+      expect(second.id).toBe(first.id);
+    });
+
+    it("should allow different link types between same documents", () => {
+      const link1 = createLink(db, "doc-a", "doc-b", "see_also");
+      const link2 = createLink(db, "doc-a", "doc-b", "prerequisite");
+      expect(link1.id).not.toBe(link2.id);
+    });
+
+    it("should reject self-links", () => {
+      expect(() => createLink(db, "doc-a", "doc-a", "related")).toThrow(
+        "Cannot link a document to itself",
+      );
+    });
+
+    it("should reject invalid link types", () => {
+      expect(() => createLink(db, "doc-a", "doc-b", "invalid" as never)).toThrow(
+        "Invalid link type",
+      );
+    });
+
+    it("should reject links to non-existent documents", () => {
+      expect(() => createLink(db, "doc-a", "nonexistent", "related")).toThrow(
+        "Target document not found",
+      );
+    });
+
+    it("should reject links from non-existent documents", () => {
+      expect(() => createLink(db, "nonexistent", "doc-b", "related")).toThrow(
+        "Source document not found",
+      );
+    });
+  });
+
+  describe("getDocumentLinks", () => {
+    it("should return outgoing and incoming links with titles", () => {
+      createLink(db, "doc-a", "doc-b", "see_also");
+      createLink(db, "doc-c", "doc-a", "prerequisite");
+
+      const { outgoing, incoming } = getDocumentLinks(db, "doc-a");
+
+      expect(outgoing.length).toBe(1);
+      expect(outgoing[0]!.targetId).toBe("doc-b");
+      expect(outgoing[0]!.targetTitle).toBe("Document B");
+      expect(outgoing[0]!.sourceTitle).toBe("Document A");
+
+      expect(incoming.length).toBe(1);
+      expect(incoming[0]!.sourceId).toBe("doc-c");
+      expect(incoming[0]!.sourceTitle).toBe("Document C");
+    });
+
+    it("should return empty arrays for document with no links", () => {
+      const { outgoing, incoming } = getDocumentLinks(db, "doc-a");
+      expect(outgoing).toEqual([]);
+      expect(incoming).toEqual([]);
+    });
+  });
+
+  describe("deleteLink", () => {
+    it("should delete an existing link", () => {
+      const link = createLink(db, "doc-a", "doc-b", "related");
+      deleteLink(db, link.id);
+
+      const { outgoing } = getDocumentLinks(db, "doc-a");
+      expect(outgoing.length).toBe(0);
+    });
+
+    it("should throw for non-existent link", () => {
+      expect(() => deleteLink(db, "nonexistent")).toThrow("Link not found");
+    });
+  });
+
+  describe("getPrerequisiteChain", () => {
+    it("should return ordered prerequisite chain", () => {
+      insertDoc(db, "doc-d", "Document D");
+      createLink(db, "doc-a", "doc-b", "prerequisite"); // A before B
+      createLink(db, "doc-b", "doc-c", "prerequisite"); // B before C
+      createLink(db, "doc-c", "doc-d", "prerequisite"); // C before D
+
+      const chain = getPrerequisiteChain(db, "doc-d");
+      expect(chain.length).toBe(3);
+      expect(chain[0]!.id).toBe("doc-a");
+      expect(chain[1]!.id).toBe("doc-b");
+      expect(chain[2]!.id).toBe("doc-c");
+    });
+
+    it("should return empty array for document with no prerequisites", () => {
+      const chain = getPrerequisiteChain(db, "doc-a");
+      expect(chain).toEqual([]);
+    });
+
+    it("should handle cycles gracefully", () => {
+      createLink(db, "doc-a", "doc-b", "prerequisite");
+      createLink(db, "doc-b", "doc-c", "prerequisite");
+      createLink(db, "doc-c", "doc-a", "prerequisite"); // cycle!
+
+      const chain = getPrerequisiteChain(db, "doc-a");
+      // Should not infinite loop — returns chain up to the cycle point
+      expect(chain.length).toBeLessThanOrEqual(3);
+    });
+  });
+
+  describe("listLinks", () => {
+    it("should list all links", () => {
+      createLink(db, "doc-a", "doc-b", "see_also");
+      createLink(db, "doc-b", "doc-c", "prerequisite");
+
+      const links = listLinks(db);
+      expect(links.length).toBe(2);
+    });
+
+    it("should filter by link type", () => {
+      createLink(db, "doc-a", "doc-b", "see_also");
+      createLink(db, "doc-b", "doc-c", "prerequisite");
+
+      const links = listLinks(db, "prerequisite");
+      expect(links.length).toBe(1);
+      expect(links[0]!.linkType).toBe("prerequisite");
+    });
+
+    it("should return empty array when no links exist", () => {
+      expect(listLinks(db)).toEqual([]);
+    });
+  });
+
+  describe("cascade delete", () => {
+    it("should remove links when source document is deleted", () => {
+      createLink(db, "doc-a", "doc-b", "related");
+      db.prepare("DELETE FROM documents WHERE id = ?").run("doc-a");
+
+      const { incoming } = getDocumentLinks(db, "doc-b");
+      expect(incoming.length).toBe(0);
+    });
+
+    it("should remove links when target document is deleted", () => {
+      createLink(db, "doc-a", "doc-b", "related");
+      db.prepare("DELETE FROM documents WHERE id = ?").run("doc-b");
+
+      const { outgoing } = getDocumentLinks(db, "doc-a");
+      expect(outgoing.length).toBe(0);
+    });
+  });
+});

--- a/tests/unit/schema.test.ts
+++ b/tests/unit/schema.test.ts
@@ -35,7 +35,7 @@ describe("database schema", () => {
       const version = db.prepare("SELECT MAX(version) as v FROM schema_version").get() as {
         v: number;
       };
-      expect(version.v).toBe(12);
+      expect(version.v).toBe(13);
     });
 
     it("should create expected indexes", () => {


### PR DESCRIPTION
## Summary

Adds explicit document-to-document relationships (cross-references) that complement the automatic knowledge graph with human-curated links.

## Link Types

| Type | Meaning |
|------|---------|
| `see_also` | Related reading |
| `prerequisite` | Must read source before target |
| `supersedes` | Source replaces target |
| `related` | Loose association |

## Changes

### Database (`src/db/schema.ts`)
- Migration 13: `document_links` table with `UNIQUE(source_id, target_id, link_type)`, cascade deletes, indexes on source/target

### Core (`src/core/links.ts`) — new module
- `createLink()` — with duplicate detection (returns existing on conflict)
- `getDocumentLinks()` — returns outgoing + incoming links with titles
- `deleteLink()` — with not-found validation
- `getPrerequisiteChain()` — walks backwards through prerequisite links with cycle detection
- `listLinks()` — all links, optionally filtered by type

### MCP Tools (`src/mcp/server.ts`)
- `link-documents` — create relationship between two documents
- `get-document-links` — retrieve all links for a document
- `delete-link` — remove a link

### CLI (`src/cli/index.ts`)
- `libscope link <sourceId> <targetId> --type see_also --label "..."`
- `libscope links <documentId>`
- `libscope unlink <linkId>`
- `libscope prereqs <documentId>`

### REST API (`src/api/routes.ts`)
- `POST /api/v1/documents/:id/links` — create link
- `GET /api/v1/documents/:id/links` — get links
- `DELETE /api/v1/links/:id` — delete link

### Tests — 20 new unit tests
- CRUD operations, duplicate handling
- Prerequisite chain traversal + cycle detection
- Cascade delete (source/target document deleted)
- Validation (self-links, invalid types, missing documents)

Closes #169