### PR TITLE
feat: add source-type filter to search (#246)

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -68,7 +68,7 @@ libscope search "deploy process" --context 1    # include neighboring chunks
 |--------|-------------|
 | `--library <name>` | Filter by library |
 | `--topic <name>` | Filter by topic |
-| `--source <type>` | Filter by source type (e.g., `confluence`, `url`, `topic`, `file`) |
+| `--source <type>` | Filter by source type (e.g., `library`, `topic`, `manual`, `model-generated`) |
 | `--limit <n>` | Max results (default: 10) |
 | `--min-rating <n>` | Minimum average rating |
 | `--context <n>` | Include N neighboring chunks before/after each result (0-2, default: 0) |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -68,6 +68,7 @@ libscope search "deploy process" --context 1    # include neighboring chunks
 |--------|-------------|
 | `--library <name>` | Filter by library |
 | `--topic <name>` | Filter by topic |
+| `--source <type>` | Filter by source type (e.g., `confluence`, `url`, `topic`, `file`) |
 | `--limit <n>` | Max results (default: 10) |
 | `--min-rating <n>` | Minimum average rating |
 | `--context <n>` | Include N neighboring chunks before/after each result (0-2, default: 0) |

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -142,6 +142,7 @@ export async function handleRequest(
         return;
       }
       const topic = url.searchParams.get("topic") ?? undefined;
+      const source = url.searchParams.get("source") ?? undefined;
       const tag = url.searchParams.get("tag") ?? undefined;
       const limitRaw = url.searchParams.get("limit");
       const limitParsed = limitRaw ? parseInt(limitRaw, 10) : NaN;
@@ -151,7 +152,14 @@ export async function handleRequest(
       const offset = Number.isNaN(offsetParsed) ? undefined : offsetParsed;
       const tags = tag ? [tag] : undefined;
 
-      const result = await searchDocuments(db, provider, { query: q, topic, tags, limit, offset });
+      const result = await searchDocuments(db, provider, {
+        query: q,
+        topic,
+        tags,
+        source,
+        limit,
+        offset,
+      });
       const took = Math.round(performance.now() - start);
       sendJson(res, 200, result, took);
       return;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -330,7 +330,10 @@ program
   .description("Search indexed documents")
   .option("--topic <topicId>", "Filter by topic")
   .option("--library <name>", "Filter by library")
-  .option("--source <type>", "Filter by source type (e.g., 'confluence', 'url', 'topic', 'file')")
+  .option(
+    "--source <type>",
+    "Filter by source type (e.g., 'library', 'topic', 'manual', 'model-generated')",
+  )
   .option("--limit <n>", "Max results", "5")
   .option("--offset <n>", "Offset for pagination", "0")
   .option("--context <n>", "Include N neighboring chunks before/after each result (0-2)", "0")

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -330,6 +330,7 @@ program
   .description("Search indexed documents")
   .option("--topic <topicId>", "Filter by topic")
   .option("--library <name>", "Filter by library")
+  .option("--source <type>", "Filter by source type (e.g., 'confluence', 'url', 'topic', 'file')")
   .option("--limit <n>", "Max results", "5")
   .option("--offset <n>", "Offset for pagination", "0")
   .option("--context <n>", "Include N neighboring chunks before/after each result (0-2)", "0")
@@ -339,6 +340,7 @@ program
       opts: {
         topic?: string;
         library?: string;
+        source?: string;
         limit: string;
         offset: string;
         context: string;
@@ -351,6 +353,7 @@ program
           query,
           topic: opts.topic,
           library: opts.library,
+          source: opts.source,
           limit: parseIntOption(opts.limit, "--limit"),
           offset: parseIntOption(opts.offset, "--offset"),
           contextChunks: contextChunks > 0 ? contextChunks : undefined,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -121,7 +121,7 @@ async function main(): Promise<void> {
       source: z
         .string()
         .optional()
-        .describe("Filter by source type (e.g., 'confluence', 'url', 'topic', 'file')"),
+        .describe("Filter by source type (e.g., 'library', 'topic', 'manual', 'model-generated')"),
       minRating: z.number().min(1).max(5).optional().describe("Minimum average rating filter"),
       offset: z.number().min(0).optional().describe("Offset for pagination (default: 0)"),
       limit: z

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -118,6 +118,10 @@ async function main(): Promise<void> {
       topic: z.string().optional().describe("Filter by topic ID"),
       library: z.string().optional().describe("Filter by library name"),
       version: z.string().optional().describe("Filter by library version"),
+      source: z
+        .string()
+        .optional()
+        .describe("Filter by source type (e.g., 'confluence', 'url', 'topic', 'file')"),
       minRating: z.number().min(1).max(5).optional().describe("Minimum average rating filter"),
       offset: z.number().min(0).optional().describe("Offset for pagination (default: 0)"),
       limit: z
@@ -141,6 +145,7 @@ async function main(): Promise<void> {
         topic: params.topic,
         library: params.library,
         version: params.version,
+        source: params.source,
         minRating: params.minRating,
         limit: params.limit,
         offset: params.offset,


### PR DESCRIPTION
Closes #246

Wires the existing `source` filter in SearchOptions to MCP, CLI, and REST API:
- MCP `search-docs` tool: new `source` parameter
- CLI: `--source <type>` flag on search command
- API: `source` query parameter on `/api/v1/search`

Supported source types: `confluence`, `url`, `topic`, `file`, etc.