### PR TITLE
feat: deduplicate search results by document (#245)

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -71,6 +71,7 @@ libscope search "deploy process" --context 1    # include neighboring chunks
 | `--source <type>` | Filter by source type (e.g., `library`, `topic`, `manual`, `model-generated`) |
 | `--limit <n>` | Max results (default: 10) |
 | `--min-rating <n>` | Minimum average rating |
+| `--max-chunks-per-doc <n>` | Max chunks per document in results (default: no limit) |
 | `--context <n>` | Include N neighboring chunks before/after each result (0-2, default: 0) |
 
 ### `libscope ask`

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -151,6 +151,9 @@ export async function handleRequest(
       const offsetParsed = offsetRaw ? parseInt(offsetRaw, 10) : NaN;
       const offset = Number.isNaN(offsetParsed) ? undefined : offsetParsed;
       const tags = tag ? [tag] : undefined;
+      const maxChunksRaw = url.searchParams.get("maxChunksPerDocument");
+      const maxChunksParsed = maxChunksRaw ? parseInt(maxChunksRaw, 10) : NaN;
+      const maxChunksPerDocument = Number.isNaN(maxChunksParsed) ? undefined : maxChunksParsed;
 
       const result = await searchDocuments(db, provider, {
         query: q,
@@ -159,6 +162,7 @@ export async function handleRequest(
         source,
         limit,
         offset,
+        maxChunksPerDocument,
       });
       const took = Math.round(performance.now() - start);
       sendJson(res, 200, result, took);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -336,6 +336,7 @@ program
   )
   .option("--limit <n>", "Max results", "5")
   .option("--offset <n>", "Offset for pagination", "0")
+  .option("--max-chunks-per-doc <n>", "Max chunks per document in results (default: no limit)")
   .option("--context <n>", "Include N neighboring chunks before/after each result (0-2)", "0")
   .action(
     async (
@@ -346,12 +347,16 @@ program
         source?: string;
         limit: string;
         offset: string;
+        maxChunksPerDoc?: string;
         context: string;
       },
     ) => {
       const { db, provider } = initializeAppWithEmbedding();
       try {
         const contextChunks = parseIntOption(opts.context, "--context");
+        const maxChunksPerDoc = opts.maxChunksPerDoc
+          ? parseIntOption(opts.maxChunksPerDoc, "--max-chunks-per-doc")
+          : undefined;
         const { results, totalCount } = await searchDocuments(db, provider, {
           query,
           topic: opts.topic,
@@ -359,6 +364,7 @@ program
           source: opts.source,
           limit: parseIntOption(opts.limit, "--limit"),
           offset: parseIntOption(opts.offset, "--offset"),
+          maxChunksPerDocument: maxChunksPerDoc,
           contextChunks: contextChunks > 0 ? contextChunks : undefined,
         });
 

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -56,6 +56,7 @@ export interface SearchOptions {
   tags?: string[] | undefined;
   limit?: number | undefined;
   offset?: number | undefined;
+  maxChunksPerDocument?: number | undefined;
   contextChunks?: number | undefined;
   analyticsEnabled?: boolean | undefined;
 }
@@ -313,6 +314,17 @@ export async function searchDocuments(
       });
     }
 
+    // Deduplicate by document — keep top N chunks per document
+    if (options.maxChunksPerDocument !== undefined && options.maxChunksPerDocument > 0) {
+      const countByDoc = new Map<string, number>();
+      response.results = response.results.filter((r) => {
+        const count = countByDoc.get(r.documentId) ?? 0;
+        if (count >= options.maxChunksPerDocument!) return false;
+        countByDoc.set(r.documentId, count + 1);
+        return true;
+      });
+    }
+
     if (options.contextChunks) {
       response.results = attachContext(db, response.results, options.contextChunks);
     }
@@ -339,6 +351,17 @@ export async function searchDocuments(
         resultCount: response.results.length,
         topScore: response.results[0]?.score ?? null,
         searchType: method,
+      });
+    }
+
+    // Deduplicate by document — keep top N chunks per document
+    if (options.maxChunksPerDocument !== undefined && options.maxChunksPerDocument > 0) {
+      const countByDoc = new Map<string, number>();
+      response.results = response.results.filter((r) => {
+        const count = countByDoc.get(r.documentId) ?? 0;
+        if (count >= options.maxChunksPerDocument!) return false;
+        countByDoc.set(r.documentId, count + 1);
+        return true;
       });
     }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -130,6 +130,14 @@ async function main(): Promise<void> {
         .max(50)
         .optional()
         .describe("Maximum results to return (default: 10)"),
+      maxChunksPerDocument: z
+        .number()
+        .min(0)
+        .max(50)
+        .optional()
+        .describe(
+          "Maximum chunks per document in results (default: no limit, set to 2 for diversity)",
+        ),
       contextChunks: z
         .number()
         .min(0)
@@ -149,6 +157,7 @@ async function main(): Promise<void> {
         minRating: params.minRating,
         limit: params.limit,
         offset: params.offset,
+        maxChunksPerDocument: params.maxChunksPerDocument,
         contextChunks: params.contextChunks,
       });
 

--- a/tests/unit/search.test.ts
+++ b/tests/unit/search.test.ts
@@ -329,6 +329,69 @@ describe("search result scoring explanation (issue #89)", () => {
   });
 });
 
+describe("deduplicate search results by document (issue #245)", () => {
+  let db: Database.Database;
+  let provider: MockEmbeddingProvider;
+
+  beforeEach(() => {
+    db = createTestDb();
+    provider = new MockEmbeddingProvider();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("should return all chunks without dedup by default", async () => {
+    insertDoc(db, "doc1", "TypeScript Guide");
+    insertChunk(db, "c1-0", "doc1", "TypeScript basics and fundamentals", 0);
+    insertChunk(db, "c1-1", "doc1", "TypeScript advanced generics", 1);
+    insertChunk(db, "c1-2", "doc1", "TypeScript utility types overview", 2);
+
+    const { results } = await searchDocuments(db, provider, { query: "TypeScript" });
+
+    expect(results.length).toBe(3);
+    expect(results.every((r) => r.documentId === "doc1")).toBe(true);
+  });
+
+  it("should limit to 1 chunk per document with maxChunksPerDocument=1", async () => {
+    insertDoc(db, "doc1", "TypeScript Guide");
+    insertChunk(db, "c1-0", "doc1", "TypeScript basics and fundamentals", 0);
+    insertChunk(db, "c1-1", "doc1", "TypeScript advanced generics", 1);
+    insertChunk(db, "c1-2", "doc1", "TypeScript utility types overview", 2);
+
+    insertDoc(db, "doc2", "JavaScript Guide");
+    insertChunk(db, "c2-0", "doc2", "TypeScript vs JavaScript comparison", 0);
+    insertChunk(db, "c2-1", "doc2", "TypeScript migration from JavaScript", 1);
+
+    const { results } = await searchDocuments(db, provider, {
+      query: "TypeScript",
+      maxChunksPerDocument: 1,
+    });
+
+    const doc1Results = results.filter((r) => r.documentId === "doc1");
+    const doc2Results = results.filter((r) => r.documentId === "doc2");
+
+    expect(doc1Results.length).toBe(1);
+    expect(doc2Results.length).toBe(1);
+  });
+
+  it("should limit to at most 2 chunks per document with maxChunksPerDocument=2", async () => {
+    insertDoc(db, "doc1", "TypeScript Guide");
+    insertChunk(db, "c1-0", "doc1", "TypeScript basics and fundamentals", 0);
+    insertChunk(db, "c1-1", "doc1", "TypeScript advanced generics", 1);
+    insertChunk(db, "c1-2", "doc1", "TypeScript utility types overview", 2);
+
+    const { results } = await searchDocuments(db, provider, {
+      query: "TypeScript",
+      maxChunksPerDocument: 2,
+    });
+
+    expect(results.length).toBe(2);
+    expect(results.every((r) => r.documentId === "doc1")).toBe(true);
+  });
+});
+
 describe("context chunk expansion (issue #247)", () => {
   let db: Database.Database;
   let provider: MockEmbeddingProvider;


### PR DESCRIPTION
Closes #245

Adds `maxChunksPerDocument` option to limit how many chunks from the same document appear in results:
- Default: no limit (backward compatible)
- Set to 1 for "one result per document" (broadest coverage)
- Set to 2 for balanced dedup

Exposed in MCP, CLI (`--max-chunks-per-doc`), and REST API. Includes 3 new tests.