### PR TITLE
feat: saved searches with filters (#166)

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -73,6 +73,24 @@ libscope search "deploy process" --context 1    # include neighboring chunks
 | `--min-rating <n>` | Minimum average rating |
 | `--max-chunks-per-doc <n>` | Max chunks per document in results (default: no limit) |
 | `--context <n>` | Include N neighboring chunks before/after each result (0-2, default: 0) |
+| `--save <name>` | Save this search with the given name for later re-use |
+
+### `libscope searches`
+
+Manage saved searches.
+
+```bash
+libscope searches list                          # list all saved searches
+libscope searches run "My Search"               # re-run a saved search by name or ID
+libscope searches delete "My Search"            # delete a saved search
+libscope search "auth best practices" --save "Auth Docs"  # save a search while running it
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `searches list` | List all saved searches |
+| `searches run <nameOrId>` | Run a saved search by name or ID |
+| `searches delete <nameOrId>` | Delete a saved search |
 
 ### `libscope ask`
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -170,3 +170,41 @@ List installed or available knowledge packs.
 |-----------|------|----------|-------------|
 | `available` | boolean | | If true, list from registry instead of installed |
 | `registryUrl` | string | | Custom registry URL |
+
+## save-search
+
+Save a search query with optional filters for later re-use.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | ✅ | Unique name for this saved search |
+| `query` | string | ✅ | The search query |
+| `topic` | string | | Filter by topic ID |
+| `library` | string | | Filter by library name |
+| `version` | string | | Filter by library version |
+| `source` | string | | Filter by source type |
+| `minRating` | number | | Minimum average rating filter |
+| `limit` | number | | Maximum results to return |
+| `tags` | string[] | | Filter by tags |
+
+## list-saved-searches
+
+List all saved searches.
+
+*No parameters.*
+
+## run-saved-search
+
+Execute a saved search by name or ID and return results.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `nameOrId` | string | ✅ | The name or ID of the saved search to run |
+
+## delete-saved-search
+
+Delete a saved search by name or ID.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `nameOrId` | string | ✅ | The name or ID of the saved search to delete |

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -25,6 +25,10 @@ The OpenAPI 3.0 spec is available at `GET /openapi.json`.
 | `POST` | `/api/v1/topics` | Create a topic |
 | `GET` | `/api/v1/tags` | List all tags |
 | `GET` | `/api/v1/stats` | Usage statistics |
+| `GET` | `/api/v1/searches` | List saved searches |
+| `POST` | `/api/v1/searches` | Create a saved search |
+| `POST` | `/api/v1/searches/:id/run` | Run a saved search |
+| `DELETE` | `/api/v1/searches/:id` | Delete a saved search |
 | `GET` | `/openapi.json` | OpenAPI 3.0 specification |
 
 ## Examples

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -24,6 +24,10 @@ import {
   createLink,
   getDocumentLinks,
   deleteLink,
+  createSavedSearch,
+  listSavedSearches,
+  runSavedSearch,
+  deleteSavedSearch,
 } from "../core/index.js";
 import type { LinkType } from "../core/index.js";
 import { loadConfig } from "../config.js";
@@ -93,6 +97,33 @@ function matchLinkId(segments: string[]): string | null {
     segments[0] === "api" &&
     segments[1] === "v1" &&
     segments[2] === "links"
+  ) {
+    return segments[3] ?? null;
+  }
+  return null;
+}
+
+/** Match /api/v1/searches/:id */
+function matchSearchId(segments: string[]): string | null {
+  if (
+    segments.length === 4 &&
+    segments[0] === "api" &&
+    segments[1] === "v1" &&
+    segments[2] === "searches"
+  ) {
+    return segments[3] ?? null;
+  }
+  return null;
+}
+
+/** Match /api/v1/searches/:id/run */
+function matchSearchRun(segments: string[]): string | null {
+  if (
+    segments.length === 5 &&
+    segments[0] === "api" &&
+    segments[1] === "v1" &&
+    segments[2] === "searches" &&
+    segments[4] === "run"
   ) {
     return segments[3] ?? null;
   }
@@ -483,6 +514,54 @@ export async function handleRequest(
     const linkId = matchLinkId(segments);
     if (linkId && method === "DELETE") {
       deleteLink(db, linkId);
+      const took = Math.round(performance.now() - start);
+      sendJson(res, 200, { deleted: true }, took);
+      return;
+    }
+
+    // Saved searches: run must be matched before generic :id routes
+    const searchRunId = matchSearchRun(segments);
+    if (searchRunId && method === "POST") {
+      const { search, results } = await runSavedSearch(db, provider, searchRunId);
+      const took = Math.round(performance.now() - start);
+      sendJson(res, 200, { search, resultCount: results.length, results }, took);
+      return;
+    }
+
+    // Saved searches: list + create
+    if (
+      segments.length === 3 &&
+      segments[0] === "api" &&
+      segments[1] === "v1" &&
+      segments[2] === "searches"
+    ) {
+      if (method === "GET") {
+        const searches = listSavedSearches(db);
+        const took = Math.round(performance.now() - start);
+        sendJson(res, 200, searches, took);
+        return;
+      }
+      if (method === "POST") {
+        const body = (await parseJsonBody(req)) as {
+          name?: string;
+          query?: string;
+          filters?: Record<string, unknown>;
+        };
+        if (!body.name || !body.query) {
+          sendError(res, 400, "VALIDATION_ERROR", "name and query are required");
+          return;
+        }
+        const saved = createSavedSearch(db, body.name, body.query, body.filters);
+        const took = Math.round(performance.now() - start);
+        sendJson(res, 201, saved, took);
+        return;
+      }
+    }
+
+    // Saved searches: delete
+    const savedSearchId = matchSearchId(segments);
+    if (savedSearchId && method === "DELETE") {
+      deleteSavedSearch(db, savedSearchId);
       const took = Math.round(performance.now() - start);
       sendJson(res, 200, { deleted: true }, took);
       return;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -72,6 +72,12 @@ import {
   loadNamedConnectorConfig,
   hasNamedConnectorConfig,
 } from "../connectors/index.js";
+import {
+  createSavedSearch,
+  listSavedSearches,
+  runSavedSearch,
+  deleteSavedSearch,
+} from "../core/saved-searches.js";
 
 // Graceful shutdown
 process.on("SIGINT", () => {
@@ -338,6 +344,7 @@ program
   .option("--offset <n>", "Offset for pagination", "0")
   .option("--max-chunks-per-doc <n>", "Max chunks per document in results (default: no limit)")
   .option("--context <n>", "Include N neighboring chunks before/after each result (0-2)", "0")
+  .option("--save <name>", "Save this search with the given name for later re-use")
   .action(
     async (
       query: string,
@@ -349,6 +356,7 @@ program
         offset: string;
         maxChunksPerDoc?: string;
         context: string;
+        save?: string;
       },
     ) => {
       const { db, provider } = initializeAppWithEmbedding();
@@ -396,11 +404,89 @@ program
             }
           }
         }
+
+        if (opts.save) {
+          const filters: Record<string, unknown> = {};
+          if (opts.topic) filters.topic = opts.topic;
+          if (opts.library) filters.library = opts.library;
+          if (opts.source) filters.source = opts.source;
+          const saved = createSavedSearch(
+            db,
+            opts.save,
+            query,
+            Object.keys(filters).length > 0 ? filters : undefined,
+          );
+          console.log(`\n✓ Search saved as "${saved.name}" (${saved.id})`);
+        }
       } finally {
         closeDatabase();
       }
     },
   );
+
+// saved searches
+const searchesCmd = program.command("searches").description("Manage saved searches");
+
+searchesCmd
+  .command("list")
+  .description("List all saved searches")
+  .action(() => {
+    const { db } = initializeApp();
+    try {
+      const searches = listSavedSearches(db);
+      if (searches.length === 0) {
+        console.log("No saved searches.");
+      } else {
+        console.log(`Found ${searches.length} saved searches:\n`);
+        for (const s of searches) {
+          console.log(`  ${s.name}`);
+          console.log(`    ID: ${s.id}`);
+          console.log(`    Query: "${s.query}"`);
+          if (s.filters) console.log(`    Filters: ${JSON.stringify(s.filters)}`);
+          if (s.lastRunAt) console.log(`    Last run: ${s.lastRunAt} (${s.resultCount} results)`);
+          console.log();
+        }
+      }
+    } finally {
+      closeDatabase();
+    }
+  });
+
+searchesCmd
+  .command("run <nameOrId>")
+  .description("Run a saved search")
+  .action(async (nameOrId: string) => {
+    const { db, provider } = initializeAppWithEmbedding();
+    try {
+      const { search, results } = await runSavedSearch(db, provider, nameOrId);
+      console.log(`\nRunning saved search "${search.name}" (query: "${search.query}"):\n`);
+      if (results.length === 0) {
+        console.log("No results found.");
+      } else {
+        console.log(`Found ${results.length} results:\n`);
+        for (const r of results) {
+          console.log(`── ${r.title} (score: ${r.score.toFixed(2)}) ──`);
+          if (r.library) console.log(`  Library: ${r.library}`);
+          console.log(`  ${r.content.slice(0, 200)}${r.content.length > 200 ? "..." : ""}`);
+        }
+      }
+    } finally {
+      closeDatabase();
+    }
+  });
+
+searchesCmd
+  .command("delete <nameOrId>")
+  .description("Delete a saved search")
+  .action((nameOrId: string) => {
+    const { db } = initializeApp();
+    try {
+      deleteSavedSearch(db, nameOrId);
+      console.log(`✓ Saved search "${nameOrId}" deleted.`);
+    } finally {
+      closeDatabase();
+    }
+  });
 
 // ask (RAG question answering)
 program

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -188,6 +188,15 @@ export {
 export type { ConnectorConfig } from "../connectors/index.js";
 
 export {
+  createSavedSearch,
+  listSavedSearches,
+  getSavedSearch,
+  deleteSavedSearch,
+  runSavedSearch,
+} from "./saved-searches.js";
+export type { SavedSearch } from "./saved-searches.js";
+
+export {
   syncConfluence,
   convertConfluenceStorage,
   disconnectConfluence,

--- a/src/core/saved-searches.ts
+++ b/src/core/saved-searches.ts
@@ -1,0 +1,125 @@
+import { randomUUID } from "node:crypto";
+import type Database from "better-sqlite3";
+import type { EmbeddingProvider } from "../providers/embedding.js";
+import { searchDocuments } from "./search.js";
+import type { SearchOptions, SearchResult } from "./search.js";
+import { ValidationError, DocumentNotFoundError } from "../errors.js";
+
+export interface SavedSearch {
+  id: string;
+  name: string;
+  query: string;
+  filters: Omit<SearchOptions, "query"> | null;
+  createdAt: string;
+  lastRunAt: string | null;
+  resultCount: number;
+}
+
+interface SavedSearchRow {
+  id: string;
+  name: string;
+  query: string;
+  filters: string | null;
+  created_at: string;
+  last_run_at: string | null;
+  result_count: number;
+}
+
+function rowToSavedSearch(row: SavedSearchRow): SavedSearch {
+  let filters: Omit<SearchOptions, "query"> | null = null;
+  if (row.filters) {
+    filters = JSON.parse(row.filters) as Omit<SearchOptions, "query">;
+  }
+  return {
+    id: row.id,
+    name: row.name,
+    query: row.query,
+    filters,
+    createdAt: row.created_at,
+    lastRunAt: row.last_run_at,
+    resultCount: row.result_count,
+  };
+}
+
+export function createSavedSearch(
+  db: Database.Database,
+  name: string,
+  query: string,
+  filters?: Omit<SearchOptions, "query">,
+): SavedSearch {
+  const trimmedName = name.trim();
+  const trimmedQuery = query.trim();
+
+  if (!trimmedName) {
+    throw new ValidationError("Saved search name is required");
+  }
+  if (!trimmedQuery) {
+    throw new ValidationError("Saved search query is required");
+  }
+
+  const existing = db.prepare("SELECT id FROM saved_searches WHERE name = ?").get(trimmedName) as
+    | { id: string }
+    | undefined;
+  if (existing) {
+    throw new ValidationError(`A saved search named "${trimmedName}" already exists`);
+  }
+
+  const id = randomUUID();
+  const filtersJson = filters ? JSON.stringify(filters) : null;
+
+  db.prepare("INSERT INTO saved_searches (id, name, query, filters) VALUES (?, ?, ?, ?)").run(
+    id,
+    trimmedName,
+    trimmedQuery,
+    filtersJson,
+  );
+
+  const row = db.prepare("SELECT * FROM saved_searches WHERE id = ?").get(id) as SavedSearchRow;
+  return rowToSavedSearch(row);
+}
+
+export function listSavedSearches(db: Database.Database): SavedSearch[] {
+  const rows = db
+    .prepare("SELECT * FROM saved_searches ORDER BY created_at DESC")
+    .all() as SavedSearchRow[];
+  return rows.map(rowToSavedSearch);
+}
+
+export function getSavedSearch(db: Database.Database, id: string): SavedSearch {
+  const row = db.prepare("SELECT * FROM saved_searches WHERE id = ? OR name = ?").get(id, id) as
+    | SavedSearchRow
+    | undefined;
+  if (!row) {
+    throw new DocumentNotFoundError(id);
+  }
+  return rowToSavedSearch(row);
+}
+
+export function deleteSavedSearch(db: Database.Database, id: string): void {
+  const result = db.prepare("DELETE FROM saved_searches WHERE id = ? OR name = ?").run(id, id);
+  if (result.changes === 0) {
+    throw new DocumentNotFoundError(id);
+  }
+}
+
+export async function runSavedSearch(
+  db: Database.Database,
+  provider: EmbeddingProvider,
+  id: string,
+): Promise<{ search: SavedSearch; results: SearchResult[] }> {
+  const search = getSavedSearch(db, id);
+
+  const options: SearchOptions = {
+    query: search.query,
+    ...search.filters,
+  };
+
+  const { results } = await searchDocuments(db, provider, options);
+
+  db.prepare(
+    "UPDATE saved_searches SET last_run_at = datetime('now'), result_count = ? WHERE id = ?",
+  ).run(results.length, search.id);
+
+  const updated = getSavedSearch(db, search.id);
+  return { search: updated, results };
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -2,7 +2,7 @@ import type Database from "better-sqlite3";
 import { DatabaseError } from "../errors.js";
 import { getLogger } from "../logger.js";
 
-const SCHEMA_VERSION = 13;
+const SCHEMA_VERSION = 14;
 
 const MIGRATIONS: Record<number, string> = {
   1: `
@@ -229,6 +229,19 @@ const MIGRATIONS: Record<number, string> = {
     CREATE INDEX IF NOT EXISTS idx_links_target ON document_links(target_id);
 
     INSERT INTO schema_version (version) VALUES (13);
+  `,
+  14: `
+    CREATE TABLE IF NOT EXISTS saved_searches (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL UNIQUE,
+      query TEXT NOT NULL,
+      filters TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      last_run_at TEXT,
+      result_count INTEGER NOT NULL DEFAULT 0
+    );
+
+    INSERT INTO schema_version (version) VALUES (14);
   `,
 };
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -13,6 +13,12 @@ import { indexDocument } from "../core/indexing.js";
 import { listTopics } from "../core/topics.js";
 import { createLink, getDocumentLinks, deleteLink } from "../core/links.js";
 import type { LinkType } from "../core/links.js";
+import {
+  createSavedSearch,
+  listSavedSearches,
+  runSavedSearch,
+  deleteSavedSearch,
+} from "../core/saved-searches.js";
 import { fetchAndConvert } from "../core/url-fetcher.js";
 import { initLogger, getLogger } from "../logger.js";
 import { LibScopeError, ValidationError } from "../errors.js";
@@ -969,6 +975,101 @@ async function main(): Promise<void> {
     withErrorHandling((params) => {
       deleteLink(db, params.linkId);
       return { content: [{ type: "text" as const, text: `✓ Link ${params.linkId} deleted.` }] };
+    }),
+  );
+
+  // Tool: save-search
+  server.tool(
+    "save-search",
+    "Save a search query with optional filters for later re-use",
+    {
+      name: z.string().describe("A unique name for this saved search"),
+      query: z.string().describe("The search query"),
+      topic: z.string().optional().describe("Filter by topic ID"),
+      library: z.string().optional().describe("Filter by library name"),
+      version: z.string().optional().describe("Filter by library version"),
+      source: z.string().optional().describe("Filter by source type"),
+      minRating: z.number().min(1).max(5).optional().describe("Minimum average rating filter"),
+      limit: z.number().min(1).max(50).optional().describe("Maximum results to return"),
+      tags: z.array(z.string()).optional().describe("Filter by tags"),
+    },
+    withErrorHandling((params) => {
+      const { name, query, ...rest } = params;
+      const filters: Record<string, unknown> = {};
+      if (rest.topic !== undefined) filters.topic = rest.topic;
+      if (rest.library !== undefined) filters.library = rest.library;
+      if (rest.version !== undefined) filters.version = rest.version;
+      if (rest.source !== undefined) filters.source = rest.source;
+      if (rest.minRating !== undefined) filters.minRating = rest.minRating;
+      if (rest.limit !== undefined) filters.limit = rest.limit;
+      if (rest.tags !== undefined) filters.tags = rest.tags;
+      const saved = createSavedSearch(
+        db,
+        name,
+        query,
+        Object.keys(filters).length > 0 ? filters : undefined,
+      );
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(saved, null, 2),
+          },
+        ],
+      };
+    }),
+  );
+
+  // Tool: list-saved-searches
+  server.tool(
+    "list-saved-searches",
+    "List all saved searches",
+    {},
+    withErrorHandling(() => {
+      const searches = listSavedSearches(db);
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: searches.length === 0 ? "No saved searches." : JSON.stringify(searches, null, 2),
+          },
+        ],
+      };
+    }),
+  );
+
+  // Tool: run-saved-search
+  server.tool(
+    "run-saved-search",
+    "Execute a saved search by name or ID and return results",
+    {
+      nameOrId: z.string().describe("The name or ID of the saved search to run"),
+    },
+    withErrorHandling(async (params) => {
+      const { search, results } = await runSavedSearch(db, provider, params.nameOrId);
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({ search, resultCount: results.length, results }, null, 2),
+          },
+        ],
+      };
+    }),
+  );
+
+  // Tool: delete-saved-search
+  server.tool(
+    "delete-saved-search",
+    "Delete a saved search by name or ID",
+    {
+      nameOrId: z.string().describe("The name or ID of the saved search to delete"),
+    },
+    withErrorHandling((params) => {
+      deleteSavedSearch(db, params.nameOrId);
+      return {
+        content: [{ type: "text" as const, text: `✓ Saved search "${params.nameOrId}" deleted.` }],
+      };
     }),
   );
 

--- a/tests/unit/saved-searches.test.ts
+++ b/tests/unit/saved-searches.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createTestDb, createTestDbWithVec } from "../fixtures/test-db.js";
+import { MockEmbeddingProvider } from "../fixtures/mock-provider.js";
+import {
+  createSavedSearch,
+  listSavedSearches,
+  getSavedSearch,
+  deleteSavedSearch,
+  runSavedSearch,
+} from "../../src/core/saved-searches.js";
+import { indexDocument } from "../../src/core/indexing.js";
+import { ValidationError, DocumentNotFoundError } from "../../src/errors.js";
+import type Database from "better-sqlite3";
+
+describe("saved-searches", () => {
+  let db: Database.Database;
+  let provider: MockEmbeddingProvider;
+
+  beforeEach(() => {
+    db = createTestDb();
+    provider = new MockEmbeddingProvider();
+  });
+
+  describe("createSavedSearch", () => {
+    it("should create a saved search", () => {
+      const search = createSavedSearch(db, "My Search", "typescript generics");
+
+      expect(search.id).toBeTruthy();
+      expect(search.name).toBe("My Search");
+      expect(search.query).toBe("typescript generics");
+      expect(search.filters).toBeNull();
+      expect(search.createdAt).toBeTruthy();
+      expect(search.lastRunAt).toBeNull();
+      expect(search.resultCount).toBe(0);
+    });
+
+    it("should create a saved search with filters", () => {
+      const filters = { topic: "auth", library: "express", limit: 10 };
+      const search = createSavedSearch(db, "Auth Docs", "authentication", filters);
+
+      expect(search.filters).toEqual(filters);
+    });
+
+    it("should reject empty name", () => {
+      expect(() => createSavedSearch(db, "", "query")).toThrow(ValidationError);
+      expect(() => createSavedSearch(db, "   ", "query")).toThrow(ValidationError);
+    });
+
+    it("should reject empty query", () => {
+      expect(() => createSavedSearch(db, "name", "")).toThrow(ValidationError);
+      expect(() => createSavedSearch(db, "name", "   ")).toThrow(ValidationError);
+    });
+
+    it("should reject duplicate names", () => {
+      createSavedSearch(db, "Unique Name", "query1");
+      expect(() => createSavedSearch(db, "Unique Name", "query2")).toThrow(ValidationError);
+      expect(() => createSavedSearch(db, "Unique Name", "query2")).toThrow("already exists");
+    });
+  });
+
+  describe("listSavedSearches", () => {
+    it("should return empty array when none exist", () => {
+      const result = listSavedSearches(db);
+      expect(result).toEqual([]);
+    });
+
+    it("should return all saved searches", () => {
+      createSavedSearch(db, "Search A", "query a");
+      createSavedSearch(db, "Search B", "query b");
+
+      const result = listSavedSearches(db);
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe("getSavedSearch", () => {
+    it("should get by ID", () => {
+      const created = createSavedSearch(db, "By ID", "test query");
+      const fetched = getSavedSearch(db, created.id);
+      expect(fetched.name).toBe("By ID");
+    });
+
+    it("should get by name", () => {
+      createSavedSearch(db, "By Name", "test query");
+      const fetched = getSavedSearch(db, "By Name");
+      expect(fetched.name).toBe("By Name");
+    });
+
+    it("should throw for nonexistent search", () => {
+      expect(() => getSavedSearch(db, "nonexistent")).toThrow(DocumentNotFoundError);
+    });
+  });
+
+  describe("deleteSavedSearch", () => {
+    it("should delete by ID", () => {
+      const created = createSavedSearch(db, "To Delete", "query");
+      deleteSavedSearch(db, created.id);
+      expect(listSavedSearches(db)).toHaveLength(0);
+    });
+
+    it("should delete by name", () => {
+      createSavedSearch(db, "Delete Me", "query");
+      deleteSavedSearch(db, "Delete Me");
+      expect(listSavedSearches(db)).toHaveLength(0);
+    });
+
+    it("should throw for nonexistent search", () => {
+      expect(() => deleteSavedSearch(db, "nonexistent")).toThrow(DocumentNotFoundError);
+    });
+  });
+
+  describe("runSavedSearch", () => {
+    it("should run a saved search and update metadata", async () => {
+      const vecDb = createTestDbWithVec();
+      const vecProvider = new MockEmbeddingProvider();
+
+      await indexDocument(vecDb, vecProvider, {
+        title: "TypeScript Guide",
+        content: "# TypeScript\n\nTypeScript is a typed superset of JavaScript.",
+        sourceType: "manual",
+      });
+
+      const saved = createSavedSearch(vecDb, "TS Search", "typescript");
+      expect(saved.lastRunAt).toBeNull();
+      expect(saved.resultCount).toBe(0);
+
+      const { search, results } = await runSavedSearch(vecDb, vecProvider, saved.id);
+      expect(search.lastRunAt).toBeTruthy();
+      expect(search.resultCount).toBe(results.length);
+      expect(results.length).toBeGreaterThan(0);
+    });
+
+    it("should run by name", async () => {
+      const vecDb = createTestDbWithVec();
+      const vecProvider = new MockEmbeddingProvider();
+
+      await indexDocument(vecDb, vecProvider, {
+        title: "Test Doc",
+        content: "# Test\n\nSome test content here.",
+        sourceType: "manual",
+      });
+
+      createSavedSearch(vecDb, "Run By Name", "test");
+      const { search } = await runSavedSearch(vecDb, vecProvider, "Run By Name");
+      expect(search.name).toBe("Run By Name");
+      expect(search.lastRunAt).toBeTruthy();
+    });
+
+    it("should apply saved filters", async () => {
+      const vecDb = createTestDbWithVec();
+      const vecProvider = new MockEmbeddingProvider();
+
+      await indexDocument(vecDb, vecProvider, {
+        title: "Express Auth",
+        content: "# Auth\n\nAuthentication with Express.",
+        sourceType: "library",
+        library: "express",
+      });
+
+      const saved = createSavedSearch(vecDb, "Express Only", "auth", { library: "express" });
+      const { results } = await runSavedSearch(vecDb, vecProvider, saved.id);
+      for (const r of results) {
+        expect(r.library).toBe("express");
+      }
+    });
+
+    it("should throw for nonexistent search", async () => {
+      await expect(runSavedSearch(db, provider, "nonexistent")).rejects.toThrow(
+        DocumentNotFoundError,
+      );
+    });
+  });
+
+  describe("filter serialization", () => {
+    it("should round-trip filters through JSON", () => {
+      const filters = {
+        topic: "testing",
+        library: "vitest",
+        version: "1.0",
+        minRating: 3,
+        tags: ["unit", "integration"],
+        limit: 20,
+      };
+      const created = createSavedSearch(db, "Complex Filters", "testing", filters);
+      const fetched = getSavedSearch(db, created.id);
+      expect(fetched.filters).toEqual(filters);
+    });
+
+    it("should handle null filters", () => {
+      const created = createSavedSearch(db, "No Filters", "query");
+      const fetched = getSavedSearch(db, created.id);
+      expect(fetched.filters).toBeNull();
+    });
+  });
+});

--- a/tests/unit/schema.test.ts
+++ b/tests/unit/schema.test.ts
@@ -35,7 +35,7 @@ describe("database schema", () => {
       const version = db.prepare("SELECT MAX(version) as v FROM schema_version").get() as {
         v: number;
       };
-      expect(version.v).toBe(13);
+      expect(version.v).toBe(14);
     });
 
     it("should create expected indexes", () => {


### PR DESCRIPTION
Closes #166

Adds saved search functionality:
- New `saved_searches` table (migration 14)
- Core CRUD: create, list, get, delete, run
- MCP: `save-search`, `list-saved-searches`, `run-saved-search`, `delete-saved-search`
- CLI: `--save <name>` on search, `searches list|run|delete`
- REST: `GET/POST /api/v1/searches`, `POST /searches/:id/run`, `DELETE /searches/:id`
- 19 new tests