### PR TITLE
feat: bulk operations for documents (#170)

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -154,6 +154,49 @@ libscope docs update <documentId> --library vue --version 3.0.0
 | `--url <url>` | New source URL |
 | `--topic <topicId>` | New topic ID |
 
+## Bulk Operations
+
+Perform operations on multiple documents at once using filter criteria.
+
+### `libscope bulk delete`
+
+Delete all documents matching the specified filters.
+
+```bash
+libscope bulk delete --library react --dry-run
+libscope bulk delete --topic topic-1 --source-type manual --yes
+```
+
+### `libscope bulk retag`
+
+Add or remove tags from all matching documents.
+
+```bash
+libscope bulk retag --library react --add-tags important,v2 --dry-run
+libscope bulk retag --topic topic-1 --remove-tags deprecated --yes
+```
+
+### `libscope bulk move`
+
+Move all matching documents to a different topic.
+
+```bash
+libscope bulk move --library react --to new-topic-id --dry-run
+libscope bulk move --topic old-topic --to new-topic --yes
+```
+
+| Option | Description |
+|--------|-------------|
+| `--topic <topicId>` | Filter by topic ID |
+| `--library <name>` | Filter by library name |
+| `--source-type <type>` | Filter by source type |
+| `--tags <tags>` | Filter by tags (comma-separated) |
+| `--to <targetTopicId>` | Target topic (move only) |
+| `--add-tags <tags>` | Tags to add (retag only, comma-separated) |
+| `--remove-tags <tags>` | Tags to remove (retag only, comma-separated) |
+| `--dry-run` | Preview affected documents without making changes |
+| `-y, --yes` | Skip confirmation prompt |
+
 ## Document Links (Cross-references)
 
 | Command | Description |

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -30,6 +30,9 @@ The OpenAPI 3.0 spec is available at `GET /openapi.json`.
 | `POST` | `/api/v1/searches/:id/run` | Run a saved search |
 | `DELETE` | `/api/v1/searches/:id` | Delete a saved search |
 | `GET` | `/openapi.json` | OpenAPI 3.0 specification |
+| `POST` | `/api/v1/bulk/delete` | Bulk delete documents |
+| `POST` | `/api/v1/bulk/retag` | Bulk add/remove tags |
+| `POST` | `/api/v1/bulk/move` | Bulk move documents to a topic |
 
 ## Examples
 

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -28,8 +28,11 @@ import {
   listSavedSearches,
   runSavedSearch,
   deleteSavedSearch,
+  bulkDelete,
+  bulkRetag,
+  bulkMove,
 } from "../core/index.js";
-import type { LinkType } from "../core/index.js";
+import type { LinkType, BulkSelector } from "../core/index.js";
 import { loadConfig } from "../config.js";
 import { DocumentNotFoundError, LibScopeError } from "../errors.js";
 import { getLogger } from "../logger.js";
@@ -554,6 +557,60 @@ export async function handleRequest(
         const saved = createSavedSearch(db, body.name, body.query, body.filters);
         const took = Math.round(performance.now() - start);
         sendJson(res, 201, saved, took);
+        return;
+      }
+    }
+
+    // Bulk operations: POST /api/v1/bulk/:operation
+    if (
+      segments.length === 4 &&
+      segments[0] === "api" &&
+      segments[1] === "v1" &&
+      segments[2] === "bulk" &&
+      method === "POST"
+    ) {
+      const operation = segments[3];
+      const body = (await parseJsonBody(req)) as {
+        selector?: BulkSelector;
+        dryRun?: boolean;
+        addTags?: string[];
+        removeTags?: string[];
+        targetTopicId?: string;
+      };
+
+      if (!body.selector) {
+        sendError(res, 400, "VALIDATION_ERROR", "selector is required");
+        return;
+      }
+
+      if (operation === "delete") {
+        const result = bulkDelete(db, body.selector, body.dryRun ?? false);
+        const took = Math.round(performance.now() - start);
+        sendJson(res, 200, result, took);
+        return;
+      }
+
+      if (operation === "retag") {
+        const result = bulkRetag(
+          db,
+          body.selector,
+          body.addTags,
+          body.removeTags,
+          body.dryRun ?? false,
+        );
+        const took = Math.round(performance.now() - start);
+        sendJson(res, 200, result, took);
+        return;
+      }
+
+      if (operation === "move") {
+        if (!body.targetTopicId) {
+          sendError(res, 400, "VALIDATION_ERROR", "targetTopicId is required");
+          return;
+        }
+        const result = bulkMove(db, body.selector, body.targetTopicId, body.dryRun ?? false);
+        const took = Math.round(performance.now() - start);
+        sendJson(res, 200, result, took);
         return;
       }
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -37,6 +37,8 @@ import {
   listTags,
   getDocumentTags,
 } from "../core/tags.js";
+import { bulkDelete, bulkRetag, bulkMove } from "../core/bulk.js";
+import type { BulkSelector } from "../core/bulk.js";
 import {
   createWorkspace,
   deleteWorkspace,
@@ -2174,5 +2176,185 @@ program
       process.exit(1);
     }
   });
+
+// bulk
+const bulkCmd = program.command("bulk").description("Bulk operations on documents");
+
+bulkCmd
+  .command("delete")
+  .description("Delete multiple documents matching filters")
+  .option("--topic <topicId>", "Filter by topic ID")
+  .option("--library <name>", "Filter by library name")
+  .option("--source-type <type>", "Filter by source type")
+  .option("--tags <tags>", "Filter by tags (comma-separated)")
+  .option("--dry-run", "Show what would be affected without making changes")
+  .option("-y, --yes", "Skip confirmation prompt")
+  .action(
+    async (opts: {
+      topic?: string;
+      library?: string;
+      sourceType?: string;
+      tags?: string;
+      dryRun?: boolean;
+      yes?: boolean;
+    }) => {
+      const { db } = initializeApp();
+      try {
+        const selector: BulkSelector = {};
+        if (opts.topic) selector.topicId = opts.topic;
+        if (opts.library) selector.library = opts.library;
+        if (opts.sourceType) selector.sourceType = opts.sourceType;
+        if (opts.tags) selector.tags = opts.tags.split(",").map((t) => t.trim());
+
+        const result = bulkDelete(db, selector, true);
+        console.log(`Found ${result.affected} document(s) matching filters.`);
+
+        if (result.affected === 0) return;
+
+        if (opts.dryRun) {
+          for (const id of result.documentIds) {
+            console.log(`  - ${id}`);
+          }
+          console.log("(dry run — no changes made)");
+          return;
+        }
+
+        if (
+          !(await confirmAction(
+            `Delete ${result.affected} document(s)? This cannot be undone.`,
+            !!opts.yes,
+          ))
+        ) {
+          console.log("Cancelled.");
+          return;
+        }
+
+        const actual = bulkDelete(db, selector);
+        console.log(`✓ Deleted ${actual.affected} document(s).`);
+      } finally {
+        closeDatabase();
+      }
+    },
+  );
+
+bulkCmd
+  .command("retag")
+  .description("Add or remove tags from multiple documents")
+  .option("--topic <topicId>", "Filter by topic ID")
+  .option("--library <name>", "Filter by library name")
+  .option("--source-type <type>", "Filter by source type")
+  .option("--tags <tags>", "Filter by tags (comma-separated)")
+  .option("--add-tags <tags>", "Tags to add (comma-separated)")
+  .option("--remove-tags <tags>", "Tags to remove (comma-separated)")
+  .option("--dry-run", "Show what would be affected without making changes")
+  .option("-y, --yes", "Skip confirmation prompt")
+  .action(
+    async (opts: {
+      topic?: string;
+      library?: string;
+      sourceType?: string;
+      tags?: string;
+      addTags?: string;
+      removeTags?: string;
+      dryRun?: boolean;
+      yes?: boolean;
+    }) => {
+      const { db } = initializeApp();
+      try {
+        const selector: BulkSelector = {};
+        if (opts.topic) selector.topicId = opts.topic;
+        if (opts.library) selector.library = opts.library;
+        if (opts.sourceType) selector.sourceType = opts.sourceType;
+        if (opts.tags) selector.tags = opts.tags.split(",").map((t) => t.trim());
+
+        const addTags = opts.addTags ? opts.addTags.split(",").map((t) => t.trim()) : undefined;
+        const removeTags = opts.removeTags
+          ? opts.removeTags.split(",").map((t) => t.trim())
+          : undefined;
+
+        const result = bulkRetag(db, selector, addTags, removeTags, true);
+        console.log(`Found ${result.affected} document(s) matching filters.`);
+
+        if (result.affected === 0) return;
+
+        if (opts.dryRun) {
+          for (const id of result.documentIds) {
+            console.log(`  - ${id}`);
+          }
+          console.log("(dry run — no changes made)");
+          return;
+        }
+
+        if (!(await confirmAction(`Retag ${result.affected} document(s)?`, !!opts.yes))) {
+          console.log("Cancelled.");
+          return;
+        }
+
+        const actual = bulkRetag(db, selector, addTags, removeTags);
+        console.log(`✓ Retagged ${actual.affected} document(s).`);
+      } finally {
+        closeDatabase();
+      }
+    },
+  );
+
+bulkCmd
+  .command("move")
+  .description("Move multiple documents to a different topic")
+  .option("--topic <topicId>", "Filter by topic ID")
+  .option("--library <name>", "Filter by library name")
+  .option("--source-type <type>", "Filter by source type")
+  .option("--tags <tags>", "Filter by tags (comma-separated)")
+  .requiredOption("--to <targetTopicId>", "Target topic ID to move documents to")
+  .option("--dry-run", "Show what would be affected without making changes")
+  .option("-y, --yes", "Skip confirmation prompt")
+  .action(
+    async (opts: {
+      topic?: string;
+      library?: string;
+      sourceType?: string;
+      tags?: string;
+      to: string;
+      dryRun?: boolean;
+      yes?: boolean;
+    }) => {
+      const { db } = initializeApp();
+      try {
+        const selector: BulkSelector = {};
+        if (opts.topic) selector.topicId = opts.topic;
+        if (opts.library) selector.library = opts.library;
+        if (opts.sourceType) selector.sourceType = opts.sourceType;
+        if (opts.tags) selector.tags = opts.tags.split(",").map((t) => t.trim());
+
+        const result = bulkMove(db, selector, opts.to, true);
+        console.log(`Found ${result.affected} document(s) matching filters.`);
+
+        if (result.affected === 0) return;
+
+        if (opts.dryRun) {
+          for (const id of result.documentIds) {
+            console.log(`  - ${id}`);
+          }
+          console.log("(dry run — no changes made)");
+          return;
+        }
+
+        if (
+          !(await confirmAction(
+            `Move ${result.affected} document(s) to topic "${opts.to}"?`,
+            !!opts.yes,
+          ))
+        ) {
+          console.log("Cancelled.");
+          return;
+        }
+
+        const actual = bulkMove(db, selector, opts.to);
+        console.log(`✓ Moved ${actual.affected} document(s) to topic "${opts.to}".`);
+      } finally {
+        closeDatabase();
+      }
+    },
+  );
 
 program.parse();

--- a/src/core/bulk.ts
+++ b/src/core/bulk.ts
@@ -1,0 +1,169 @@
+import type Database from "better-sqlite3";
+import { getLogger } from "../logger.js";
+import { ValidationError } from "../errors.js";
+import { deleteDocument, listDocuments } from "./documents.js";
+import { addTagsToDocument, removeTagFromDocument, getDocumentTags } from "./tags.js";
+
+export interface BulkSelector {
+  topicId?: string;
+  tags?: string[];
+  library?: string;
+  sourceType?: string;
+  dateFrom?: string;
+  dateTo?: string;
+}
+
+export interface BulkResult {
+  affected: number;
+  documentIds: string[];
+}
+
+/** Max batch size safety limit to prevent mass accidents. */
+const MAX_BATCH_SIZE = 1000;
+
+function isSelectorEmpty(selector: BulkSelector): boolean {
+  return (
+    !selector.topicId &&
+    (!selector.tags || selector.tags.length === 0) &&
+    !selector.library &&
+    !selector.sourceType &&
+    !selector.dateFrom &&
+    !selector.dateTo
+  );
+}
+
+/** Resolve a selector to matching document IDs. */
+export function resolveSelector(
+  db: Database.Database,
+  selector: BulkSelector,
+  limit?: number,
+): string[] {
+  if (isSelectorEmpty(selector)) {
+    throw new ValidationError("Bulk selector must specify at least one filter criterion");
+  }
+
+  const effectiveLimit = Math.min(limit ?? MAX_BATCH_SIZE, MAX_BATCH_SIZE);
+
+  // Use listDocuments for basic filters
+  const docs = listDocuments(db, {
+    library: selector.library,
+    topicId: selector.topicId,
+    sourceType: selector.sourceType,
+    limit: effectiveLimit,
+  });
+
+  let ids = docs.map((d) => d.id);
+
+  // Apply date filters
+  if (selector.dateFrom) {
+    const from = selector.dateFrom;
+    ids = ids.filter((id) => {
+      const doc = docs.find((d) => d.id === id);
+      return doc != null && doc.createdAt >= from;
+    });
+  }
+  if (selector.dateTo) {
+    const to = selector.dateTo;
+    ids = ids.filter((id) => {
+      const doc = docs.find((d) => d.id === id);
+      return doc != null && doc.createdAt <= to;
+    });
+  }
+
+  // Apply tag filter (AND logic — document must have ALL specified tags)
+  if (selector.tags && selector.tags.length > 0) {
+    const requiredTags = selector.tags.map((t) => t.trim().toLowerCase());
+    ids = ids.filter((id) => {
+      const docTags = getDocumentTags(db, id).map((t) => t.name);
+      return requiredTags.every((rt) => docTags.includes(rt));
+    });
+  }
+
+  return ids.slice(0, effectiveLimit);
+}
+
+/** Delete all documents matching selector. If dryRun, return what WOULD be deleted. */
+export function bulkDelete(
+  db: Database.Database,
+  selector: BulkSelector,
+  dryRun?: boolean,
+): BulkResult {
+  const log = getLogger();
+  const ids = resolveSelector(db, selector);
+
+  if (!dryRun) {
+    for (const id of ids) {
+      deleteDocument(db, id);
+    }
+    log.info({ count: ids.length, dryRun: false }, "Bulk delete completed");
+  } else {
+    log.info({ count: ids.length, dryRun: true }, "Bulk delete dry run");
+  }
+
+  return { affected: ids.length, documentIds: ids };
+}
+
+/** Add/remove tags from matching documents. */
+export function bulkRetag(
+  db: Database.Database,
+  selector: BulkSelector,
+  addTags?: string[],
+  removeTags?: string[],
+  dryRun?: boolean,
+): BulkResult {
+  const log = getLogger();
+
+  if ((!addTags || addTags.length === 0) && (!removeTags || removeTags.length === 0)) {
+    throw new ValidationError("At least one of addTags or removeTags must be specified");
+  }
+
+  const ids = resolveSelector(db, selector);
+
+  if (!dryRun) {
+    for (const id of ids) {
+      if (addTags && addTags.length > 0) {
+        addTagsToDocument(db, id, addTags);
+      }
+      if (removeTags && removeTags.length > 0) {
+        const docTags = getDocumentTags(db, id);
+        for (const tagName of removeTags) {
+          const normalized = tagName.trim().toLowerCase();
+          const tag = docTags.find((t) => t.name === normalized);
+          if (tag) {
+            removeTagFromDocument(db, id, tag.id);
+          }
+        }
+      }
+    }
+    log.info({ count: ids.length, addTags, removeTags, dryRun: false }, "Bulk retag completed");
+  } else {
+    log.info({ count: ids.length, addTags, removeTags, dryRun: true }, "Bulk retag dry run");
+  }
+
+  return { affected: ids.length, documentIds: ids };
+}
+
+/** Move matching documents to a different topic. */
+export function bulkMove(
+  db: Database.Database,
+  selector: BulkSelector,
+  targetTopicId: string,
+  dryRun?: boolean,
+): BulkResult {
+  const log = getLogger();
+  const ids = resolveSelector(db, selector);
+
+  if (!dryRun) {
+    const stmt = db.prepare(
+      "UPDATE documents SET topic_id = ?, updated_at = datetime('now') WHERE id = ?",
+    );
+    for (const id of ids) {
+      stmt.run(targetTopicId, id);
+    }
+    log.info({ count: ids.length, targetTopicId, dryRun: false }, "Bulk move completed");
+  } else {
+    log.info({ count: ids.length, targetTopicId, dryRun: true }, "Bulk move dry run");
+  }
+
+  return { affected: ids.length, documentIds: ids };
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -202,3 +202,6 @@ export {
   disconnectConfluence,
 } from "../connectors/confluence.js";
 export type { ConfluenceConfig, ConfluenceSyncResult } from "../connectors/confluence.js";
+
+export { resolveSelector, bulkDelete, bulkRetag, bulkMove } from "./bulk.js";
+export type { BulkSelector, BulkResult } from "./bulk.js";

--- a/tests/unit/bulk.test.ts
+++ b/tests/unit/bulk.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type Database from "better-sqlite3";
+import { createTestDb } from "../fixtures/test-db.js";
+import { insertDoc } from "../fixtures/helpers.js";
+import { resolveSelector, bulkDelete, bulkRetag, bulkMove } from "../../src/core/bulk.js";
+import { getDocument, listDocuments } from "../../src/core/documents.js";
+import { addTagsToDocument, getDocumentTags } from "../../src/core/tags.js";
+import { ValidationError } from "../../src/errors.js";
+import { initLogger } from "../../src/logger.js";
+
+initLogger("silent");
+
+describe("bulk operations", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+
+    // Create topics first (foreign key constraint)
+    db.prepare("INSERT INTO topics (id, name) VALUES (?, ?)").run("topic-1", "Topic 1");
+    db.prepare("INSERT INTO topics (id, name) VALUES (?, ?)").run("topic-2", "Topic 2");
+    db.prepare("INSERT INTO topics (id, name) VALUES (?, ?)").run("topic-3", "Topic 3");
+
+    // Seed test documents
+    insertDoc(db, "doc-a", "Doc A", {
+      library: "react",
+      topicId: "topic-1",
+      sourceType: "library",
+    });
+    insertDoc(db, "doc-b", "Doc B", { library: "react", topicId: "topic-1", sourceType: "manual" });
+    insertDoc(db, "doc-c", "Doc C", { library: "vue", topicId: "topic-2", sourceType: "library" });
+    insertDoc(db, "doc-d", "Doc D", { library: "vue", topicId: "topic-2", sourceType: "library" });
+    insertDoc(db, "doc-e", "Doc E", {
+      library: "angular",
+      topicId: "topic-3",
+      sourceType: "manual",
+    });
+  });
+
+  describe("resolveSelector", () => {
+    it("resolves by topicId", () => {
+      const ids = resolveSelector(db, { topicId: "topic-1" });
+      expect(ids).toHaveLength(2);
+      expect(ids).toContain("doc-a");
+      expect(ids).toContain("doc-b");
+    });
+
+    it("resolves by library", () => {
+      const ids = resolveSelector(db, { library: "vue" });
+      expect(ids).toHaveLength(2);
+      expect(ids).toContain("doc-c");
+      expect(ids).toContain("doc-d");
+    });
+
+    it("resolves by sourceType", () => {
+      const ids = resolveSelector(db, { sourceType: "library" });
+      expect(ids).toHaveLength(3);
+      expect(ids).toContain("doc-a");
+      expect(ids).toContain("doc-c");
+      expect(ids).toContain("doc-d");
+    });
+
+    it("resolves by multiple filters", () => {
+      const ids = resolveSelector(db, { library: "react", sourceType: "library" });
+      expect(ids).toEqual(["doc-a"]);
+    });
+
+    it("resolves by tags", () => {
+      addTagsToDocument(db, "doc-a", ["frontend"]);
+      addTagsToDocument(db, "doc-b", ["frontend"]);
+      addTagsToDocument(db, "doc-c", ["frontend"]);
+
+      const ids = resolveSelector(db, { tags: ["frontend"], library: "react" });
+      expect(ids).toHaveLength(2);
+      expect(ids).toContain("doc-a");
+      expect(ids).toContain("doc-b");
+    });
+
+    it("throws on empty selector", () => {
+      expect(() => resolveSelector(db, {})).toThrow(ValidationError);
+    });
+
+    it("respects max batch size limit", () => {
+      // Insert many docs
+      for (let i = 0; i < 50; i++) {
+        insertDoc(db, `bulk-${i}`, `Bulk Doc ${i}`, { library: "mass" });
+      }
+
+      const ids = resolveSelector(db, { library: "mass" }, 10);
+      expect(ids.length).toBeLessThanOrEqual(10);
+    });
+  });
+
+  describe("bulkDelete", () => {
+    it("deletes matching documents", () => {
+      const result = bulkDelete(db, { library: "react" });
+      expect(result.affected).toBe(2);
+      expect(result.documentIds).toContain("doc-a");
+      expect(result.documentIds).toContain("doc-b");
+
+      // Verify they're actually gone
+      const remaining = listDocuments(db, { limit: 100 });
+      expect(remaining).toHaveLength(3);
+      expect(remaining.map((d) => d.id)).not.toContain("doc-a");
+      expect(remaining.map((d) => d.id)).not.toContain("doc-b");
+    });
+
+    it("dry run does not delete", () => {
+      const result = bulkDelete(db, { library: "react" }, true);
+      expect(result.affected).toBe(2);
+
+      // Verify nothing was deleted
+      const remaining = listDocuments(db, { limit: 100 });
+      expect(remaining).toHaveLength(5);
+    });
+  });
+
+  describe("bulkRetag", () => {
+    it("adds tags to matching documents", () => {
+      const result = bulkRetag(db, { library: "react" }, ["important", "v2"]);
+      expect(result.affected).toBe(2);
+
+      const tagsA = getDocumentTags(db, "doc-a").map((t) => t.name);
+      const tagsB = getDocumentTags(db, "doc-b").map((t) => t.name);
+      expect(tagsA).toContain("important");
+      expect(tagsA).toContain("v2");
+      expect(tagsB).toContain("important");
+      expect(tagsB).toContain("v2");
+    });
+
+    it("removes tags from matching documents", () => {
+      addTagsToDocument(db, "doc-a", ["old-tag"]);
+      addTagsToDocument(db, "doc-b", ["old-tag"]);
+
+      const result = bulkRetag(db, { library: "react" }, undefined, ["old-tag"]);
+      expect(result.affected).toBe(2);
+
+      const tagsA = getDocumentTags(db, "doc-a").map((t) => t.name);
+      const tagsB = getDocumentTags(db, "doc-b").map((t) => t.name);
+      expect(tagsA).not.toContain("old-tag");
+      expect(tagsB).not.toContain("old-tag");
+    });
+
+    it("dry run does not modify tags", () => {
+      const result = bulkRetag(db, { library: "react" }, ["new-tag"], undefined, true);
+      expect(result.affected).toBe(2);
+
+      const tagsA = getDocumentTags(db, "doc-a").map((t) => t.name);
+      expect(tagsA).not.toContain("new-tag");
+    });
+
+    it("throws if no addTags or removeTags specified", () => {
+      expect(() => bulkRetag(db, { library: "react" })).toThrow(ValidationError);
+    });
+  });
+
+  describe("bulkMove", () => {
+    it("moves matching documents to target topic", () => {
+      db.prepare("INSERT INTO topics (id, name) VALUES (?, ?)").run("topic-99", "Target Topic");
+      const result = bulkMove(db, { library: "react" }, "topic-99");
+      expect(result.affected).toBe(2);
+
+      const docA = getDocument(db, "doc-a");
+      const docB = getDocument(db, "doc-b");
+      expect(docA.topicId).toBe("topic-99");
+      expect(docB.topicId).toBe("topic-99");
+    });
+
+    it("dry run does not move documents", () => {
+      db.prepare("INSERT INTO topics (id, name) VALUES (?, ?)").run("topic-99", "Target Topic");
+      const result = bulkMove(db, { library: "react" }, "topic-99", true);
+      expect(result.affected).toBe(2);
+
+      const docA = getDocument(db, "doc-a");
+      expect(docA.topicId).toBe("topic-1");
+    });
+  });
+});


### PR DESCRIPTION
Closes #170

Adds bulk operations:
- Core: `resolveSelector`, `bulkDelete`, `bulkRetag`, `bulkMove` with dry-run + 1000-doc safety limit
- CLI: `libscope bulk delete|retag|move` with `--dry-run`, `--yes`, filter flags
- REST: `POST /api/v1/bulk/{delete,retag,move}`
- 15 new tests