### PR TITLE
feat: auto-suggest tags based on content analysis (#243)

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -14,6 +14,7 @@ import {
   createTopic,
   listTags,
   addTagsToDocument,
+  suggestTags,
   getStats,
   getSearchAnalytics,
   getKnowledgeGaps,
@@ -73,6 +74,20 @@ function matchDocumentTags(segments: string[]): string | null {
     segments[1] === "v1" &&
     segments[2] === "documents" &&
     segments[4] === "tags"
+  ) {
+    return segments[3] ?? null;
+  }
+  return null;
+}
+
+/** Match /api/v1/documents/:id/suggest-tags */
+function matchDocumentSuggestTags(segments: string[]): string | null {
+  if (
+    segments.length === 5 &&
+    segments[0] === "api" &&
+    segments[1] === "v1" &&
+    segments[2] === "documents" &&
+    segments[4] === "suggest-tags"
   ) {
     return segments[3] ?? null;
   }
@@ -393,6 +408,17 @@ export async function handleRequest(
       const tags = addTagsToDocument(db, tagDocId, tagNames);
       const took = Math.round(performance.now() - start);
       sendJson(res, 200, tags, took);
+      return;
+    }
+
+    // Suggest tags for a document
+    const suggestDocId = matchDocumentSuggestTags(segments);
+    if (suggestDocId && method === "GET") {
+      const limitRaw = url.searchParams.get("limit");
+      const limit = limitRaw ? parseInt(limitRaw, 10) : 5;
+      const suggestions = suggestTags(db, suggestDocId, limit);
+      const took = Math.round(performance.now() - start);
+      sendJson(res, 200, { documentId: suggestDocId, suggestions }, took);
       return;
     }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -36,6 +36,7 @@ import {
   removeTagFromDocument,
   listTags,
   getDocumentTags,
+  suggestTags,
 } from "../core/tags.js";
 import { bulkDelete, bulkRetag, bulkMove } from "../core/bulk.js";
 import type { BulkSelector } from "../core/bulk.js";
@@ -897,6 +898,28 @@ tagCmd
       } else {
         for (const t of allTags) {
           console.log(`  ${t.name} (${t.documentCount} doc${t.documentCount !== 1 ? "s" : ""})`);
+        }
+      }
+    } finally {
+      closeDatabase();
+    }
+  });
+
+tagCmd
+  .command("suggest <documentId>")
+  .description("Suggest tags for a document based on content analysis")
+  .option("-l, --limit <n>", "Max number of suggestions", "5")
+  .action((documentId: string, opts: { limit: string }) => {
+    const { db } = initializeApp();
+    try {
+      const limit = parseInt(opts.limit, 10);
+      const suggestions = suggestTags(db, documentId, limit);
+      if (suggestions.length === 0) {
+        console.log("No tag suggestions found for this document.");
+      } else {
+        console.log(`Suggested tags for ${documentId}:`);
+        for (const tag of suggestions) {
+          console.log(`  • ${tag}`);
         }
       }
     } finally {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -84,6 +84,7 @@ export {
   removeTagFromDocument,
   getDocumentTags,
   getDocumentsByTag,
+  suggestTags,
 } from "./tags.js";
 export type { Tag, TagWithCount, GetDocumentsByTagOptions } from "./tags.js";
 

--- a/src/core/tags.ts
+++ b/src/core/tags.ts
@@ -1,8 +1,111 @@
 import type Database from "better-sqlite3";
 import { randomUUID } from "node:crypto";
-import { ValidationError } from "../errors.js";
+import { DocumentNotFoundError, ValidationError } from "../errors.js";
 import { createChildLogger } from "../logger.js";
 import type { Document } from "./documents.js";
+
+const STOPWORDS = new Set([
+  "the",
+  "a",
+  "an",
+  "is",
+  "are",
+  "was",
+  "were",
+  "be",
+  "been",
+  "being",
+  "have",
+  "has",
+  "had",
+  "do",
+  "does",
+  "did",
+  "will",
+  "would",
+  "shall",
+  "should",
+  "may",
+  "might",
+  "must",
+  "can",
+  "could",
+  "that",
+  "this",
+  "with",
+  "from",
+  "for",
+  "not",
+  "but",
+  "and",
+  "or",
+  "nor",
+  "so",
+  "yet",
+  "both",
+  "either",
+  "neither",
+  "each",
+  "every",
+  "all",
+  "any",
+  "few",
+  "more",
+  "most",
+  "other",
+  "some",
+  "such",
+  "than",
+  "too",
+  "very",
+  "just",
+  "about",
+  "above",
+  "after",
+  "again",
+  "against",
+  "below",
+  "between",
+  "during",
+  "into",
+  "through",
+  "under",
+  "until",
+  "also",
+  "how",
+  "what",
+  "when",
+  "where",
+  "which",
+  "while",
+  "who",
+  "whom",
+  "why",
+  "its",
+  "our",
+  "their",
+  "your",
+  "his",
+  "her",
+  "our",
+  "out",
+  "then",
+  "there",
+  "these",
+  "those",
+  "them",
+  "they",
+  "you",
+  "your",
+  "only",
+  "own",
+  "same",
+  "here",
+  "over",
+  "once",
+  "use",
+  "used",
+]);
 
 export interface Tag {
   id: string;
@@ -207,4 +310,77 @@ export function getDocumentsByTag(
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }));
+}
+
+/** Tokenize text into lowercase words, filtering stopwords and short words. */
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((w) => w.length >= 3 && !STOPWORDS.has(w));
+}
+
+/** Suggest tags for a document based on content analysis (TF-IDF-like keyword extraction). */
+export function suggestTags(
+  db: Database.Database,
+  documentId: string,
+  maxSuggestions?: number,
+): string[] {
+  const log = createChildLogger({ operation: "suggestTags" });
+  const limit = maxSuggestions ?? 5;
+
+  const row = db.prepare("SELECT title, content FROM documents WHERE id = ?").get(documentId) as
+    | { title: string; content: string }
+    | undefined;
+
+  if (!row) {
+    throw new DocumentNotFoundError(documentId);
+  }
+
+  const fullText = `${row.title} ${row.content}`;
+  const tokens = tokenize(fullText);
+  if (tokens.length === 0) {
+    return [];
+  }
+
+  // Calculate term frequency
+  const tf = new Map<string, number>();
+  for (const token of tokens) {
+    tf.set(token, (tf.get(token) ?? 0) + 1);
+  }
+
+  // Get existing tags already on this document (to exclude them)
+  const existingTags = new Set(
+    (
+      db
+        .prepare(
+          `SELECT t.name FROM tags t
+           JOIN document_tags dt ON dt.tag_id = t.id
+           WHERE dt.document_id = ?`,
+        )
+        .all(documentId) as Array<{ name: string }>
+    ).map((r) => r.name),
+  );
+
+  // Get all known tags in the system for boosting
+  const knownTags = new Set(
+    (db.prepare("SELECT name FROM tags").all() as Array<{ name: string }>).map((r) => r.name),
+  );
+
+  // Score each term: TF normalized + boost for known tags
+  const maxTf = Math.max(...tf.values());
+  const scored: Array<{ term: string; score: number }> = [];
+
+  for (const [term, count] of tf) {
+    if (existingTags.has(term)) continue;
+    const normalizedTf = count / maxTf;
+    const knownBoost = knownTags.has(term) ? 2.0 : 1.0;
+    scored.push({ term, score: normalizedTf * knownBoost });
+  }
+
+  scored.sort((a, b) => b.score - a.score);
+
+  const suggestions = scored.slice(0, limit).map((s) => s.term);
+  log.info({ documentId, suggestionCount: suggestions.length }, "Tags suggested");
+  return suggestions;
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -19,6 +19,7 @@ import {
   runSavedSearch,
   deleteSavedSearch,
 } from "../core/saved-searches.js";
+import { suggestTags } from "../core/tags.js";
 import { fetchAndConvert } from "../core/url-fetcher.js";
 import { initLogger, getLogger } from "../logger.js";
 import { LibScopeError, ValidationError } from "../errors.js";
@@ -1014,6 +1015,27 @@ async function main(): Promise<void> {
           {
             type: "text" as const,
             text: JSON.stringify(saved, null, 2),
+          },
+        ],
+      };
+    }),
+  );
+
+  // Tool: suggest-tags
+  server.tool(
+    "suggest-tags",
+    "Suggest tags for a document based on content analysis",
+    {
+      documentId: z.string().describe("Document ID"),
+      maxSuggestions: z.number().min(1).max(20).optional().describe("Max suggestions (default: 5)"),
+    },
+    withErrorHandling((params) => {
+      const suggestions = suggestTags(db, params.documentId, params.maxSuggestions);
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({ documentId: params.documentId, suggestions }, null, 2),
           },
         ],
       };

--- a/tests/unit/tags.test.ts
+++ b/tests/unit/tags.test.ts
@@ -8,8 +8,9 @@ import {
   removeTagFromDocument,
   getDocumentTags,
   getDocumentsByTag,
+  suggestTags,
 } from "../../src/core/tags.js";
-import { ValidationError } from "../../src/errors.js";
+import { ValidationError, DocumentNotFoundError } from "../../src/errors.js";
 import type Database from "better-sqlite3";
 
 function insertDocument(db: Database.Database, id: string, title: string): void {
@@ -17,6 +18,18 @@ function insertDocument(db: Database.Database, id: string, title: string): void 
     `INSERT INTO documents (id, source_type, title, content, submitted_by)
      VALUES (?, 'manual', ?, 'content', 'manual')`,
   ).run(id, title);
+}
+
+function insertDocumentWithContent(
+  db: Database.Database,
+  id: string,
+  title: string,
+  content: string,
+): void {
+  db.prepare(
+    `INSERT INTO documents (id, source_type, title, content, submitted_by)
+     VALUES (?, 'manual', ?, ?, 'manual')`,
+  ).run(id, title, content);
 }
 
 describe("tags", () => {
@@ -162,6 +175,73 @@ describe("tags", () => {
       const tags = listTags(db);
       const orphan = tags.find((t) => t.name === "orphan-tag");
       expect(orphan?.documentCount).toBe(0);
+    });
+  });
+
+  describe("suggestTags", () => {
+    it("should suggest tags based on document content", () => {
+      insertDocumentWithContent(
+        db,
+        "doc-s1",
+        "TypeScript Guide",
+        "TypeScript is a programming language. TypeScript adds types to JavaScript. TypeScript compiler checks types.",
+      );
+
+      const suggestions = suggestTags(db, "doc-s1");
+      expect(suggestions.length).toBeGreaterThan(0);
+      expect(suggestions).toContain("typescript");
+    });
+
+    it("should exclude tags already on the document", () => {
+      insertDocumentWithContent(
+        db,
+        "doc-s2",
+        "React Tutorial",
+        "React components render JSX. React hooks enable state management. React is popular.",
+      );
+      addTagsToDocument(db, "doc-s2", ["react"]);
+
+      const suggestions = suggestTags(db, "doc-s2");
+      expect(suggestions).not.toContain("react");
+    });
+
+    it("should boost known system tags", () => {
+      // Create a known tag in the system
+      insertDocument(db, "doc-other", "Other Doc");
+      addTagsToDocument(db, "doc-other", ["javascript"]);
+
+      insertDocumentWithContent(
+        db,
+        "doc-s3",
+        "Web Development",
+        "JavaScript and frameworks. JavaScript runs in the browser. Performance optimization techniques.",
+      );
+
+      const suggestions = suggestTags(db, "doc-s3");
+      expect(suggestions[0]).toBe("javascript");
+    });
+
+    it("should return empty array for content with only stopwords", () => {
+      insertDocumentWithContent(db, "doc-s4", "a", "the is are was were be an");
+
+      const suggestions = suggestTags(db, "doc-s4");
+      expect(suggestions).toHaveLength(0);
+    });
+
+    it("should respect maxSuggestions limit", () => {
+      insertDocumentWithContent(
+        db,
+        "doc-s5",
+        "Many Topics",
+        "alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima mike november oscar papa",
+      );
+
+      const suggestions = suggestTags(db, "doc-s5", 3);
+      expect(suggestions).toHaveLength(3);
+    });
+
+    it("should throw DocumentNotFoundError for missing document", () => {
+      expect(() => suggestTags(db, "nonexistent")).toThrow(DocumentNotFoundError);
     });
   });
 });


### PR DESCRIPTION
Closes #243

Adds tag suggestion via TF-IDF-like keyword extraction:
- Core: `suggestTags()` in tags.ts — tokenize, stopword filter, TF scoring, known-tag boosting
- MCP: `suggest-tags` tool
- CLI: `libscope tag suggest <docId> [--limit <n>]`
- REST: `GET /api/v1/documents/:id/suggest-tags?limit=5`
- 6 new tests