### PR TITLE
ci: consolidate and fix CI/CD workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,17 @@ updates:
       minor-and-patch:
         update-types: ["minor", "patch"]
   - package-ecosystem: "pip"
-    directory: "/sdk-python"
+    directory: "/sdk/python"
     schedule:
       interval: "weekly"
   - package-ecosystem: "gomod"
-    directory: "/sdk-go"
+    directory: "/sdk/go"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,14 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_call:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  lint:
+  lint-and-typecheck:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,16 +23,6 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run format:check
-
-  typecheck:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-      - run: npm ci
       - run: npm run typecheck
 
   test:
@@ -50,9 +45,20 @@ jobs:
           name: coverage
           path: coverage/
 
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+
   build:
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, test]
+    needs: [lint-and-typecheck, test]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: "0 6 * * 1"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     paths: ["Dockerfile", "docker-compose.yml", ".dockerignore"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,31 +7,14 @@ on:
 
 permissions:
   contents: write
-  id-token: write
 
 jobs:
   ci:
     uses: ./.github/workflows/ci.yml
 
-  publish:
-    runs-on: ubuntu-latest
-    needs: ci
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-          registry-url: "https://registry.npmjs.org"
-      - run: npm ci
-      - run: npm run build
-      - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
   github-release:
     runs-on: ubuntu-latest
-    needs: publish
+    needs: ci
     steps:
       - uses: actions/checkout@v4
       - name: Create GitHub Release

--- a/.github/workflows/sdk-go.yml
+++ b/.github/workflows/sdk-go.yml
@@ -1,9 +1,9 @@
 name: Go SDK
 on:
   push:
-    paths: ["sdk-go/**"]
+    paths: ["sdk/go/**"]
   pull_request:
-    paths: ["sdk-go/**"]
+    paths: ["sdk/go/**"]
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -15,5 +15,5 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
-      - run: cd sdk-go && go test ./... -v
-      - run: cd sdk-go && go vet ./...
+      - run: cd sdk/go && go test ./... -v
+      - run: cd sdk/go && go vet ./...

--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -1,9 +1,9 @@
 name: Python SDK
 on:
   push:
-    paths: ["sdk-python/**"]
+    paths: ["sdk/python/**"]
   pull_request:
-    paths: ["sdk-python/**"]
+    paths: ["sdk/python/**"]
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - run: cd sdk-python && pip install -e ".[dev]" && pytest -v
+      - run: cd sdk/python && pip install -e ".[dev]" && pytest -v


### PR DESCRIPTION
## Summary

Consolidates and fixes CI/CD workflows across the board.

### 🔴 Bug Fixes
- **Remove duplicate npm publish** — `release-please.yml` and `release.yml` both published to npm on tag push, causing the second to fail with 403. Now release-please owns npm publishing; `release.yml` only creates the GitHub Release.
- **Fix SDK workflow paths** — SDKs live at `sdk/go/` and `sdk/python/`, but workflows watched `sdk-go/**` and `sdk-python/**` (never triggered). Fixed to `sdk/go/**` and `sdk/python/**`.
- **Fix Dependabot paths** — Same `sdk-go` → `sdk/go` and `sdk-python` → `sdk/python` path fixes so Dependabot actually scans SDK dependencies.

### 🟡 Consolidation
- **Merge lint + typecheck into single job** — Eliminates one redundant `npm ci` install, saves ~30s per CI run.
- **Add `workflow_call` trigger to ci.yml** — Enables reuse from `release.yml` (already using it).

### 🟢 New Capabilities
- **Concurrency groups** on ci.yml, docker.yml, codeql.yml — Rapid pushes to a PR cancel stale runs instead of stacking.
- **Dependency review action** on PRs — Blocks merging PRs that introduce dependencies with known high-severity vulnerabilities.
- **GitHub Actions Dependabot** — Keeps action versions (`actions/checkout`, etc.) up to date automatically.

### Files Changed
| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Merge lint+typecheck, add concurrency, dependency-review, workflow_call |
| `.github/workflows/release.yml` | Remove duplicate npm publish job |
| `.github/workflows/sdk-go.yml` | Fix path `sdk-go/` → `sdk/go/` |
| `.github/workflows/sdk-python.yml` | Fix path `sdk-python/` → `sdk/python/` |
| `.github/workflows/docker.yml` | Add concurrency group |
| `.github/workflows/codeql.yml` | Add concurrency group |
| `.github/dependabot.yml` | Fix SDK paths, add github-actions ecosystem |