### PR TITLE
fix: skip Vercel preview deployments on non-main branches

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,5 +1,5 @@
 {
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- .",
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ] || git diff --quiet HEAD^ HEAD -- .",
   "installCommand": "cd .. && npm install --include=dev --ignore-scripts",
   "buildCommand": "cd .. && npx vitepress build docs",
   "outputDirectory": ".vitepress/dist"


### PR DESCRIPTION
## Problem

Vercel Hobby plan rate-limits deployments. Every push to every PR branch triggers a Vercel deployment attempt, even when docs haven't changed, exhausting the quota and blocking CI checks.

## Fix

Update `docs/vercel.json` `ignoreCommand` to:

```sh
[ "$VERCEL_GIT_COMMIT_REF" != "main" ] || git diff --quiet HEAD^ HEAD -- .
```

**Logic:**
- Non-`main` branches → exit 0 → skip build (no quota consumed)
- `main` branch → only build if `docs/` files actually changed in the commit

Preview deployments for a docs site aren't useful, so this is safe to skip entirely on PR branches.