### PR TITLE
chore: add development branch workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,4 +14,5 @@ Refer to [agents.md](../agents.md) at the repository root for full architecture,
 - Tests use `MockEmbeddingProvider` and in-memory SQLite (no sqlite-vec in tests).
 - Run `npm run typecheck && npm run test:coverage && npm run lint` before considering work complete. Use `test:coverage` (not `test`) — CI enforces coverage thresholds (statements ≥ 75%, branches ≥ 74%, functions ≥ 75%, lines ≥ 75%) and will reject PRs that drop below them.
 - Before creating a PR, use a `code-review` sub-agent to self-review your diff. Fix any issues it finds before opening the PR.
+- **Branch workflow:** All feature branches and PRs target `development`. Only `development` can be merged into `main`. When creating branches, branch from `development`. When creating PRs, set the base to `development`.
 - **PR lifecycle is mandatory.** After pushing a PR, always: (1) wait for CI/CD to complete, (2) check if it passed, (3) fix failures and re-push if needed, (4) read and address all review comments, (5) verify CI is green again. A PR is not done until all checks pass and all review comments are resolved. See the "Pull Request Lifecycle" section in `agents.md` for the full workflow.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "development"
     schedule:
       interval: "weekly"
     groups:
@@ -9,14 +10,17 @@ updates:
         update-types: ["minor", "patch"]
   - package-ecosystem: "pip"
     directory: "/sdk/python"
+    target-branch: "development"
     schedule:
       interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/sdk/go"
+    target-branch: "development"
     schedule:
       interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "development"
     schedule:
       interval: "weekly"
     groups:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, development]
   pull_request:
-    branches: [main]
+    branches: [main, development]
   workflow_call:
 
 concurrency:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [main]
+    branches: [main, development]
   pull_request:
-    branches: [main]
+    branches: [main, development]
   schedule:
     - cron: "0 6 * * 1"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,7 @@
 name: Docker
 on:
   push:
-    branches: [main]
+    branches: [main, development]
     tags: ["v*"]
   pull_request:
     paths: ["Dockerfile", "docker-compose.yml", ".dockerignore"]

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -1,0 +1,17 @@
+name: Merge Gate
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  enforce-source-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify PR source is development branch
+        run: |
+          if [ "${{ github.head_ref }}" != "development" ]; then
+            echo "::error::Only the 'development' branch can be merged into main. This PR is from '${{ github.head_ref }}'."
+            exit 1
+          fi
+          echo "✅ Source branch is 'development' — merge allowed."

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,5 +1,5 @@
 {
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- .",
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ] || git diff --quiet HEAD^ HEAD -- .",
   "installCommand": "cd .. && npm install --include=dev --ignore-scripts",
   "buildCommand": "cd .. && npx vitepress build docs",
   "outputDirectory": ".vitepress/dist"


### PR DESCRIPTION
## Summary

Establishes a two-branch workflow: **development** (fast iteration) → **main** (releases only).

### What changed

| Change | Detail |
|--------|--------|
| `.github/workflows/merge-gate.yml` | **New** — blocks PRs to main unless source is `development` |
| `.github/workflows/ci.yml` | Runs on both `main` and `development` |
| `.github/workflows/codeql.yml` | Runs on both `main` and `development` |
| `.github/workflows/docker.yml` | Builds on both `main` and `development` |
| `.github/dependabot.yml` | All ecosystems target `development` |
| `.github/copilot-instructions.md` | Documents branch workflow convention |

### Rulesets configured

- **Main Rules**: requires PR + `enforce-source-branch` check + squash-only merges
- **Development Rules**: requires PR + CI status checks (lint, test, build)
- **Default branch** set to `development`

### Flow

```
feature-branch → PR → development → PR → main → release
```

All 8 existing open PRs have been retargeted to `development`.