### PR TITLE
feat: add passthrough LLM mode for ask-question tool

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -112,9 +112,16 @@ function getEnvOverrides(): Partial<LibScopeConfig> {
     };
   }
 
-  if (llmProvider === "openai" || llmProvider === "ollama" || llmProvider === "passthrough" || llmModel) {
+  if (
+    llmProvider === "openai" ||
+    llmProvider === "ollama" ||
+    llmProvider === "passthrough" ||
+    llmModel
+  ) {
     overrides.llm = {
-      ...(llmProvider === "openai" || llmProvider === "ollama" ? { provider: llmProvider } : {}),
+      ...(llmProvider === "openai" || llmProvider === "ollama" || llmProvider === "passthrough"
+        ? { provider: llmProvider }
+        : {}),
       ...(llmModel ? { model: llmModel } : {}),
     };
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,7 +13,7 @@ export interface LibScopeConfig {
     openaiModel?: string;
   };
   llm?: {
-    provider?: "openai" | "ollama";
+    provider?: "openai" | "ollama" | "passthrough";
     model?: string;
     ollamaUrl?: string;
     openaiApiKey?: string;
@@ -112,7 +112,7 @@ function getEnvOverrides(): Partial<LibScopeConfig> {
     };
   }
 
-  if (llmProvider === "openai" || llmProvider === "ollama" || llmModel) {
+  if (llmProvider === "openai" || llmProvider === "ollama" || llmProvider === "passthrough" || llmModel) {
     overrides.llm = {
       ...(llmProvider === "openai" || llmProvider === "ollama" ? { provider: llmProvider } : {}),
       ...(llmModel ? { model: llmModel } : {}),

--- a/src/core/rag.ts
+++ b/src/core/rag.ts
@@ -67,10 +67,15 @@ export function extractSources(results: SearchResult[]): RagSource[] {
 }
 
 interface LlmConfig {
-  provider?: "openai" | "ollama";
+  provider?: "openai" | "ollama" | "passthrough";
   model?: string;
   ollamaUrl?: string;
   openaiApiKey?: string;
+}
+
+/** Returns true if the config is set to passthrough mode (delegate synthesis to the calling LLM). */
+export function isPassthroughMode(config: LibScopeConfig): boolean {
+  return config.llm?.provider === "passthrough";
 }
 
 /** Create an LLM provider from config. */
@@ -86,9 +91,38 @@ export function createLlmProvider(config: LibScopeConfig): LlmProvider {
   }
 
   throw new ConfigError(
-    "No LLM provider configured. Set llm.provider to 'openai' or 'ollama' in your config, " +
+    "No LLM provider configured. Set llm.provider to 'openai', 'ollama', or 'passthrough' in your config, " +
       "or set LIBSCOPE_LLM_PROVIDER environment variable.",
   );
+}
+
+export interface PassthroughResult {
+  contextPrompt: string;
+  sources: RagSource[];
+}
+
+/**
+ * Retrieve relevant chunks and return the formatted context prompt without calling an LLM.
+ * Used in passthrough mode so the calling LLM can synthesize the answer itself.
+ */
+export async function getContextForQuestion(
+  db: Database.Database,
+  embeddingProvider: EmbeddingProvider,
+  options: RagOptions,
+): Promise<PassthroughResult> {
+  const topK = options.topK ?? 5;
+
+  const { results } = await searchDocuments(db, embeddingProvider, {
+    query: options.question,
+    topic: options.topic,
+    library: options.library,
+    limit: topK,
+  });
+
+  return {
+    contextPrompt: buildContextPrompt(options.question, results),
+    sources: extractSources(results),
+  };
 }
 
 function createOpenAiProvider(

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -6,7 +6,13 @@ import { getDatabase, runMigrations, createVectorTable } from "../db/index.js";
 import { getActiveWorkspace, getWorkspacePath } from "../core/workspace.js";
 import { createEmbeddingProvider } from "../providers/index.js";
 import { searchDocuments } from "../core/search.js";
-import { askQuestion, createLlmProvider, type LlmProvider } from "../core/rag.js";
+import {
+  askQuestion,
+  createLlmProvider,
+  getContextForQuestion,
+  isPassthroughMode,
+  type LlmProvider,
+} from "../core/rag.js";
 import { getDocument, listDocuments, deleteDocument, updateDocument } from "../core/documents.js";
 import { rateDocument, getDocumentRatings } from "../core/ratings.js";
 import { indexDocument } from "../core/indexing.js";
@@ -543,9 +549,30 @@ async function main(): Promise<void> {
       library: z.string().optional().describe("Filter by library name"),
     },
     withErrorHandling(async (params) => {
+      if (isPassthroughMode(config)) {
+        const { contextPrompt, sources } = await getContextForQuestion(db, provider, {
+          question: params.question,
+          topK: params.topK,
+          topic: params.topic,
+          library: params.library,
+        });
+
+        const sourcesText =
+          sources.length > 0
+            ? "\n\n**Sources:**\n" +
+              sources
+                .map((s) => `- ${s.title} (score: ${s.score.toFixed(2)}) [${s.documentId}]`)
+                .join("\n")
+            : "";
+
+        return {
+          content: [{ type: "text" as const, text: contextPrompt + sourcesText }],
+        };
+      }
+
       if (!llmProvider) {
         throw new ConfigError(
-          "No LLM provider configured. Set llm.provider to 'openai' or 'ollama' in your config.",
+          "No LLM provider configured. Set llm.provider to 'openai', 'ollama', or 'passthrough' in your config.",
         );
       }
 


### PR DESCRIPTION
Closes #334

## Summary

- Adds `llm.provider = "passthrough"` so `ask-question` returns retrieved context chunks directly to the calling LLM instead of requiring a separate OpenAI/Ollama provider
- Passthrough is the natural design for MCP — the client already has an LLM, so a second one inside libscope is redundant
- Existing `openai`/`ollama` behaviour is unchanged; unconfigured still throws

## Changes

- **`src/config.ts`** — `"passthrough"` added to `llm.provider` union type and `LIBSCOPE_LLM_PROVIDER` env var handling
- **`src/core/rag.ts`** — `isPassthroughMode(config)` helper + `getContextForQuestion()` which retrieves chunks and returns formatted context without an LLM call
- **`src/mcp/server.ts`** — `ask-question` handler checks passthrough first; falls through to existing LLM path otherwise

## Usage

```json
{ "llm": { "provider": "passthrough" } }
```
or `LIBSCOPE_LLM_PROVIDER=passthrough`

## Test plan

- [ ] `ask-question` with `llm.provider = "passthrough"` returns context chunks and sources without error
- [ ] `ask-question` with `openai`/`ollama` still works as before
- [ ] `ask-question` with no provider configured still throws the existing error
- [ ] `LIBSCOPE_LLM_PROVIDER=passthrough` env var is picked up correctly
- [ ] TypeScript build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)