### PR TITLE
feat: CLI logging improvements and pack installation performance (#330)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -32,6 +32,7 @@ import {
 } from "../core/analytics.js";
 import { startRepl } from "./repl.js";
 import { confirmAction } from "./confirm.js";
+import { createReporter, isVerbose } from "./reporter.js";
 import {
   addTagsToDocument,
   removeTagFromDocument,
@@ -1086,10 +1087,15 @@ interface ProgramOpts {
 }
 
 function setupLogging(opts: ProgramOpts): void {
-  const level: LogLevel = opts.verbose
-    ? "debug"
-    : ((opts.logLevel as LogLevel | undefined) ?? loadConfig().logging.level);
-  initLogger(level);
+  if (isVerbose(opts.verbose)) {
+    initLogger("debug");
+  } else if (opts.logLevel) {
+    initLogger(opts.logLevel as LogLevel);
+  } else {
+    // Default to silent in CLI mode — pretty reporter handles user-facing output.
+    // Set LIBSCOPE_VERBOSE=1 or pass --verbose to see structured JSON logs.
+    initLogger("silent");
+  }
 }
 
 /** Shared CLI initialization: loadConfig → setupLogging → getDatabase → runMigrations. */
@@ -1610,19 +1616,47 @@ packCmd
   .command("install <nameOrPath>")
   .description("Install a knowledge pack from registry or local .json/.json.gz file")
   .option("--registry <url>", "Custom registry URL")
-  .action(async (nameOrPath: string, opts: { registry?: string }) => {
-    const { db, provider } = initializeAppWithEmbedding();
-    const result = await installPack(db, provider, nameOrPath, {
-      registryUrl: opts.registry,
-    });
-    if (result.alreadyInstalled) {
-      console.log(`Pack "${result.packName}" is already installed.`);
-    } else {
-      console.log(
-        `✓ Pack "${result.packName}" installed (${result.documentsInstalled} documents).`,
-      );
-    }
-  });
+  .option("--batch-size <n>", "Number of documents to embed per batch (default: 10)")
+  .option("--resume-from <n>", "Skip the first N documents (resume a partial install)")
+  .action(
+    async (
+      nameOrPath: string,
+      opts: { registry?: string; batchSize?: string; resumeFrom?: string },
+    ) => {
+      const { db, provider } = initializeAppWithEmbedding();
+      const globalOpts = program.opts<ProgramOpts>();
+      const reporter = createReporter(globalOpts.verbose);
+
+      const batchSize = opts.batchSize ? parseIntOption(opts.batchSize, "--batch-size") : undefined;
+      const resumeFrom = opts.resumeFrom
+        ? parseIntOption(opts.resumeFrom, "--resume-from")
+        : undefined;
+
+      try {
+        const result = await installPack(db, provider, nameOrPath, {
+          registryUrl: opts.registry,
+          batchSize,
+          resumeFrom,
+          onProgress: (current, total, docTitle) => {
+            reporter.progress(current, total, docTitle);
+          },
+        });
+
+        reporter.clearProgress();
+
+        if (result.alreadyInstalled) {
+          reporter.log(`Pack "${result.packName}" is already installed.`);
+        } else {
+          const errMsg = result.errors > 0 ? ` (${result.errors} errors)` : "";
+          reporter.success(
+            `Pack "${result.packName}" installed: ${result.documentsInstalled} documents${errMsg}.`,
+          );
+        }
+      } finally {
+        closeDatabase();
+      }
+    },
+  );
 
 packCmd
   .command("remove <name>")
@@ -1773,9 +1807,7 @@ connectCmd
   .option("--notebook <name>", "Sync a specific notebook")
   .action(async (opts: { token?: string; sync?: boolean; notebook?: string }) => {
     const config = loadConfig();
-    const logLevel =
-      (program.opts().logLevel as LogLevel) ?? (program.opts().verbose ? "debug" : "info");
-    initLogger(logLevel);
+    setupLogging(program.opts<ProgramOpts>());
 
     const workspace = program.opts().workspace as string | undefined;
     if (workspace) {
@@ -1889,9 +1921,7 @@ disconnectCmd
       return;
     }
     const config = loadConfig();
-    const logLevel =
-      (program.opts().logLevel as LogLevel) ?? (program.opts().verbose ? "debug" : "info");
-    initLogger(logLevel);
+    setupLogging(program.opts<ProgramOpts>());
 
     const workspace2 = program.opts().workspace as string | undefined;
     if (workspace2) {

--- a/src/cli/reporter.ts
+++ b/src/cli/reporter.ts
@@ -1,0 +1,87 @@
+/**
+ * CLI output reporter — pretty human-readable output for interactive terminals.
+ * In verbose/JSON mode, a SilentReporter is used so pino JSON logs handle output.
+ */
+
+const RESET = "\x1b[0m";
+const GREEN = "\x1b[32m";
+const YELLOW = "\x1b[33m";
+const RED = "\x1b[31m";
+const CYAN = "\x1b[36m";
+const DIM = "\x1b[2m";
+
+export interface CliReporter {
+  log(msg: string): void;
+  success(msg: string): void;
+  warn(msg: string): void;
+  error(msg: string): void;
+  progress(current: number, total: number, label: string): void;
+  clearProgress(): void;
+}
+
+function buildBar(pct: number, width = 20): string {
+  const filled = Math.round((pct / 100) * width);
+  return "\u2588".repeat(filled) + "\u2591".repeat(width - filled);
+}
+
+/** Pretty human-readable reporter. Uses ANSI colors and \r progress lines. */
+class PrettyReporter implements CliReporter {
+  private hasProgress = false;
+
+  log(msg: string): void {
+    this.clearProgress();
+    process.stdout.write(`${msg}\n`);
+  }
+
+  success(msg: string): void {
+    this.clearProgress();
+    process.stdout.write(`${GREEN}\u2713${RESET} ${msg}\n`);
+  }
+
+  warn(msg: string): void {
+    this.clearProgress();
+    process.stderr.write(`${YELLOW}\u26a0${RESET} ${msg}\n`);
+  }
+
+  error(msg: string): void {
+    this.clearProgress();
+    process.stderr.write(`${RED}\u2717${RESET} ${msg}\n`);
+  }
+
+  progress(current: number, total: number, label: string): void {
+    const pct = total > 0 ? Math.round((current / total) * 100) : 0;
+    const bar = buildBar(pct);
+    const truncatedLabel = label.length > 40 ? `${label.slice(0, 37)}...` : label;
+    const line = `${CYAN}[${bar}]${RESET} ${pct}% (${current}/${total}) ${DIM}${truncatedLabel}${RESET}`;
+    process.stdout.write(`\r${line}`);
+    this.hasProgress = true;
+  }
+
+  clearProgress(): void {
+    if (this.hasProgress) {
+      const width = process.stdout.columns ?? 80;
+      process.stdout.write(`\r${" ".repeat(width - 1)}\r`);
+      this.hasProgress = false;
+    }
+  }
+}
+
+/** No-op reporter: used in verbose/JSON mode where pino logs handle output. */
+class SilentReporter implements CliReporter {
+  log(_msg: string): void {}
+  success(_msg: string): void {}
+  warn(_msg: string): void {}
+  error(_msg: string): void {}
+  progress(_current: number, _total: number, _label: string): void {}
+  clearProgress(): void {}
+}
+
+/** Returns true if verbose mode is active (flag or env var). */
+export function isVerbose(verbose?: boolean): boolean {
+  return verbose === true || process.env["LIBSCOPE_VERBOSE"] === "1";
+}
+
+/** Create a reporter appropriate for the current mode. */
+export function createReporter(verbose?: boolean): CliReporter {
+  return isVerbose(verbose) ? new SilentReporter() : new PrettyReporter();
+}

--- a/src/core/packs.ts
+++ b/src/core/packs.ts
@@ -1,5 +1,7 @@
 import type Database from "better-sqlite3";
+import { randomUUID, createHash } from "node:crypto";
 import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 import {
   resolve as pathResolve,
   isAbsolute as pathIsAbsolute,
@@ -11,11 +13,10 @@ import { gzipSync, gunzipSync } from "node:zlib";
 import type { EmbeddingProvider } from "../providers/embedding.js";
 import { ValidationError, FetchError } from "../errors.js";
 import { getLogger } from "../logger.js";
-import { indexDocument } from "./indexing.js";
+import { chunkContent, chunkContentStreaming, STREAMING_THRESHOLD } from "./indexing.js";
 import { getParserForFile, getSupportedExtensions } from "./parsers/index.js";
-import { suggestTagsFromText, addTagsToDocument } from "./tags.js";
+import { suggestTagsFromText } from "./tags.js";
 import { fetchAndConvert } from "./url-fetcher.js";
-import { pathToFileURL } from "node:url";
 
 export interface PackDocument {
   title: string;
@@ -56,6 +57,17 @@ export interface InstallResult {
   packName: string;
   documentsInstalled: number;
   alreadyInstalled: boolean;
+  errors: number;
+}
+
+export interface InstallOptions {
+  registryUrl?: string | undefined;
+  /** Number of documents to embed and insert per batch. Default: 10. */
+  batchSize?: number | undefined;
+  /** Skip the first N documents (for resuming a partial install). Default: 0. */
+  resumeFrom?: number | undefined;
+  /** Called after each document is processed. */
+  onProgress?: ((current: number, total: number, docTitle: string) => void) | undefined;
 }
 
 export interface CreatePackOptions {
@@ -248,7 +260,7 @@ export async function installPack(
   db: Database.Database,
   provider: EmbeddingProvider,
   packNameOrPath: string,
-  options?: { registryUrl?: string | undefined },
+  options?: InstallOptions,
 ): Promise<InstallResult> {
   const log = getLogger();
   let pack: KnowledgePack;
@@ -273,6 +285,7 @@ export async function installPack(
   } else {
     // Fetch from registry
     const registryUrl = options?.registryUrl ?? DEFAULT_REGISTRY_URL;
+
     validateRegistryUrl(registryUrl);
     const baseUrl = registryUrl.replace(/\/[^/]+$/, "");
     const packUrl = `${baseUrl}/${packNameOrPath}.json`;
@@ -299,10 +312,16 @@ export async function installPack(
 
   if (existing) {
     log.info({ pack: pack.name }, "Pack already installed");
-    return { packName: pack.name, documentsInstalled: 0, alreadyInstalled: true };
+    return { packName: pack.name, documentsInstalled: 0, alreadyInstalled: true, errors: 0 };
   }
 
-  log.info({ pack: pack.name, docCount: pack.documents.length }, "Installing pack");
+  const batchSize = options?.batchSize ?? 10;
+  const resumeFrom = options?.resumeFrom ?? 0;
+  const onProgress = options?.onProgress;
+  const docs = resumeFrom > 0 ? pack.documents.slice(resumeFrom) : pack.documents;
+  const total = pack.documents.length;
+
+  log.info({ pack: pack.name, docCount: total, batchSize, resumeFrom }, "Installing pack");
 
   // Insert the pack record first (documents.pack_name has FK to packs.name)
   db.prepare("INSERT INTO packs (name, version, description, doc_count) VALUES (?, ?, ?, 0)").run(
@@ -311,45 +330,121 @@ export async function installPack(
     pack.description,
   );
 
+  // Prepare statements once
+  const insertDoc = db.prepare(`
+    INSERT INTO documents (id, source_type, title, content, url, submitted_by, content_hash, pack_name)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  const insertChunk = db.prepare(`
+    INSERT INTO chunks (id, document_id, content, chunk_index)
+    VALUES (?, ?, ?, ?)
+  `);
+  const insertEmbedding = db.prepare(`
+    INSERT INTO chunk_embeddings (chunk_id, embedding)
+    VALUES (?, ?)
+  `);
+
   let installed = 0;
-  const total = pack.documents.length;
-  for (const doc of pack.documents) {
-    try {
-      log.info(
-        { progress: `${installed + 1}/${total}`, title: doc.title },
-        "Indexing pack document",
-      );
-      const result = await indexDocument(db, provider, {
-        title: doc.title,
-        content: doc.content,
-        sourceType: "library",
-        url: doc.source || undefined,
-        submittedBy: "manual",
-        dedup: "skip",
+  let errors = 0;
+  let processedCount = resumeFrom;
+
+  // Process documents in batches for efficient embedding
+  for (let batchStart = 0; batchStart < docs.length; batchStart += batchSize) {
+    const batch = docs.slice(batchStart, batchStart + batchSize);
+
+    // Phase 1: chunk all documents in the batch
+    type DocChunkInfo = {
+      doc: PackDocument;
+      docId: string;
+      contentHash: string;
+      chunks: string[];
+      chunkOffset: number; // offset into allChunks
+    };
+    const docInfos: DocChunkInfo[] = [];
+    const allChunks: string[] = [];
+
+    for (const doc of batch) {
+      const contentHash = createHash("sha256").update(doc.content).digest("hex");
+      const useStreaming = doc.content.length > STREAMING_THRESHOLD;
+      const chunks = useStreaming ? chunkContentStreaming(doc.content) : chunkContent(doc.content);
+      docInfos.push({
+        doc,
+        docId: randomUUID(),
+        contentHash,
+        chunks,
+        chunkOffset: allChunks.length,
       });
+      allChunks.push(...chunks);
+    }
 
-      // Tag the document with the pack name
-      db.prepare("UPDATE documents SET pack_name = ? WHERE id = ?").run(pack.name, result.id);
-
-      // Apply tags from the pack document (auto-generated or manually specified)
-      if (doc.tags && doc.tags.length > 0) {
-        addTagsToDocument(db, result.id, doc.tags);
-      }
-
-      installed++;
+    // Phase 2: embed all chunks in a single batch call
+    let allEmbeddings: number[][];
+    try {
+      allEmbeddings = allChunks.length > 0 ? await provider.embedBatch(allChunks) : [];
     } catch (err) {
       log.warn(
-        { err, title: doc.title, pack: pack.name },
-        "Failed to index pack document, skipping",
+        { err, pack: pack.name, batchStart },
+        "Failed to embed batch, skipping these documents",
       );
+      errors += batch.length;
+      processedCount += batch.length;
+      onProgress?.(processedCount, total, batch[batch.length - 1]?.title ?? "");
+      continue;
     }
+
+    // Phase 3: insert all docs, chunks, and embeddings in a single transaction
+    const insertBatch = db.transaction(() => {
+      for (const info of docInfos) {
+        insertDoc.run(
+          info.docId,
+          "library",
+          info.doc.title,
+          info.doc.content,
+          info.doc.source || null,
+          "manual",
+          info.contentHash,
+          pack.name,
+        );
+
+        for (let i = 0; i < info.chunks.length; i++) {
+          const chunkId = randomUUID();
+          const chunkText = info.chunks[i] ?? "";
+          const embedding = allEmbeddings[info.chunkOffset + i] ?? [];
+          insertChunk.run(chunkId, info.docId, chunkText, i);
+          try {
+            const vecBuffer = Buffer.from(new Float32Array(embedding).buffer);
+            insertEmbedding.run(chunkId, vecBuffer);
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            if (!message.includes("no such table")) {
+              log.warn({ chunkId, err }, "Failed to insert vector embedding");
+            }
+          }
+        }
+        installed++;
+      }
+    });
+
+    try {
+      insertBatch();
+    } catch (err) {
+      log.warn(
+        { err, pack: pack.name, batchStart },
+        "Transaction failed for batch, skipping these documents",
+      );
+      errors += batch.length;
+      installed -= batch.length < installed ? batch.length : installed;
+    }
+
+    processedCount += batch.length;
+    onProgress?.(processedCount, total, batch[batch.length - 1]?.title ?? "");
   }
 
   // Update doc count
   db.prepare("UPDATE packs SET doc_count = ? WHERE name = ?").run(installed, pack.name);
 
-  log.info({ pack: pack.name, installed }, "Pack installed");
-  return { packName: pack.name, documentsInstalled: installed, alreadyInstalled: false };
+  log.info({ pack: pack.name, installed, errors }, "Pack installed");
+  return { packName: pack.name, documentsInstalled: installed, alreadyInstalled: false, errors };
 }
 
 /** Remove a pack and all its associated documents. */

--- a/tests/unit/packs.test.ts
+++ b/tests/unit/packs.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { writeFileSync, existsSync, mkdtempSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -800,6 +800,111 @@ describe("knowledge packs", () => {
       const result = await installPack(db, provider, packPath);
       expect(result.packName).toBe("roundtrip-pack");
       expect(result.documentsInstalled).toBe(1);
+    });
+  });
+
+  describe("installPack — batch & progress options", () => {
+    it("should report progress via onProgress callback", async () => {
+      const pack = makeSamplePack();
+      const packPath = join(tempDir, "progress-pack.json");
+      writeFileSync(packPath, JSON.stringify(pack), "utf-8");
+
+      const calls: Array<{ current: number; total: number; label: string }> = [];
+      await installPack(db, provider, packPath, {
+        onProgress: (current, total, label) => {
+          calls.push({ current, total, label });
+        },
+      });
+
+      // Should have called onProgress at least once (one batch covering both docs)
+      expect(calls.length).toBeGreaterThan(0);
+      // Last call should report all docs processed
+      const last = calls[calls.length - 1]!;
+      expect(last.current).toBe(2);
+      expect(last.total).toBe(2);
+    });
+
+    it("should process in smaller batches when batchSize=1", async () => {
+      const pack = makeSamplePack();
+      const packPath = join(tempDir, "batch1-pack.json");
+      writeFileSync(packPath, JSON.stringify(pack), "utf-8");
+
+      const calls: number[] = [];
+      await installPack(db, provider, packPath, {
+        batchSize: 1,
+        onProgress: (current) => calls.push(current),
+      });
+
+      // With batchSize=1 and 2 docs, should get 2 progress calls
+      expect(calls).toEqual([1, 2]);
+    });
+
+    it("should skip documents when resumeFrom is set", async () => {
+      const pack = makeSamplePack({
+        name: "resume-pack",
+        documents: [
+          { title: "Doc 1", content: "Content one", source: "" },
+          { title: "Doc 2", content: "Content two", source: "" },
+          { title: "Doc 3", content: "Content three", source: "" },
+        ],
+      });
+      const packPath = join(tempDir, "resume-pack.json");
+      writeFileSync(packPath, JSON.stringify(pack), "utf-8");
+
+      const result = await installPack(db, provider, packPath, { resumeFrom: 2 });
+
+      // Should only install doc 3 (skipped first 2)
+      expect(result.documentsInstalled).toBe(1);
+      expect(result.packName).toBe("resume-pack");
+    });
+
+    it("should count errors when embedBatch fails", async () => {
+      const pack = makeSamplePack({ name: "err-pack" });
+      const packPath = join(tempDir, "err-pack.json");
+      writeFileSync(packPath, JSON.stringify(pack), "utf-8");
+
+      const failProvider = new MockEmbeddingProvider();
+      failProvider.embedBatch = vi.fn().mockRejectedValue(new Error("embed failed"));
+
+      const result = await installPack(db, failProvider, packPath);
+
+      // embedBatch failure means documents in that batch are skipped
+      expect(result.errors).toBeGreaterThan(0);
+      expect(result.documentsInstalled).toBe(0);
+    });
+
+    it("should include errors=0 on successful install", async () => {
+      const pack = makeSamplePack({ name: "ok-pack" });
+      const packPath = join(tempDir, "ok-pack.json");
+      writeFileSync(packPath, JSON.stringify(pack), "utf-8");
+
+      const result = await installPack(db, provider, packPath);
+
+      expect(result.errors).toBe(0);
+      expect(result.documentsInstalled).toBe(2);
+    });
+
+    it("should use a single embedBatch call per batch for efficiency", async () => {
+      const pack = makeSamplePack({ name: "batch-efficiency" });
+      const packPath = join(tempDir, "batch-eff.json");
+      writeFileSync(packPath, JSON.stringify(pack), "utf-8");
+
+      await installPack(db, provider, packPath, { batchSize: 10 });
+
+      // 2 docs in one batch → 1 embedBatch call
+      expect(provider.embedBatchCallCount).toBe(1);
+    });
+
+    it("should return errors=0 for already-installed pack", async () => {
+      const pack = makeSamplePack({ name: "already-pack" });
+      const packPath = join(tempDir, "already-pack.json");
+      writeFileSync(packPath, JSON.stringify(pack), "utf-8");
+
+      await installPack(db, provider, packPath);
+      const result = await installPack(db, provider, packPath);
+
+      expect(result.alreadyInstalled).toBe(true);
+      expect(result.errors).toBe(0);
     });
   });
 });

--- a/tests/unit/reporter.test.ts
+++ b/tests/unit/reporter.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { isVerbose, createReporter } from "../../src/cli/reporter.js";
+
+describe("reporter", () => {
+  afterEach(() => {
+    delete process.env["LIBSCOPE_VERBOSE"];
+    vi.restoreAllMocks();
+  });
+
+  describe("isVerbose", () => {
+    it("returns true when verbose flag is set", () => {
+      expect(isVerbose(true)).toBe(true);
+    });
+
+    it("returns false when verbose flag is false", () => {
+      expect(isVerbose(false)).toBe(false);
+    });
+
+    it("returns false when verbose flag is undefined", () => {
+      expect(isVerbose(undefined)).toBe(false);
+    });
+
+    it("returns true when LIBSCOPE_VERBOSE=1 env var is set", () => {
+      process.env["LIBSCOPE_VERBOSE"] = "1";
+      expect(isVerbose(false)).toBe(true);
+    });
+
+    it("returns false when LIBSCOPE_VERBOSE=0", () => {
+      process.env["LIBSCOPE_VERBOSE"] = "0";
+      expect(isVerbose(false)).toBe(false);
+    });
+  });
+
+  describe("createReporter", () => {
+    it("returns a SilentReporter (no-op) in verbose mode", () => {
+      const reporter = createReporter(true);
+      const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+      const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+      reporter.log("hello");
+      reporter.success("done");
+      reporter.warn("careful");
+      reporter.error("bad");
+      reporter.progress(1, 10, "task");
+      reporter.clearProgress();
+
+      expect(stdout).not.toHaveBeenCalled();
+      expect(stderr).not.toHaveBeenCalled();
+    });
+
+    it("returns a SilentReporter when LIBSCOPE_VERBOSE=1", () => {
+      process.env["LIBSCOPE_VERBOSE"] = "1";
+      const reporter = createReporter();
+      const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+      reporter.log("hello");
+      expect(stdout).not.toHaveBeenCalled();
+    });
+
+    it("PrettyReporter.log writes to stdout", () => {
+      const reporter = createReporter(false);
+      const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+      reporter.log("test message");
+
+      expect(stdout).toHaveBeenCalledOnce();
+      expect(String(stdout.mock.calls[0]![0])).toContain("test message");
+    });
+
+    it("PrettyReporter.success writes green checkmark to stdout", () => {
+      const reporter = createReporter(false);
+      const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+      reporter.success("all done");
+
+      const output = String(stdout.mock.calls[0]![0]);
+      expect(output).toContain("all done");
+      // Green ANSI code
+      expect(output).toContain("\x1b[32m");
+    });
+
+    it("PrettyReporter.warn writes to stderr", () => {
+      const reporter = createReporter(false);
+      const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+      reporter.warn("watch out");
+
+      expect(stderr).toHaveBeenCalledOnce();
+      expect(String(stderr.mock.calls[0]![0])).toContain("watch out");
+    });
+
+    it("PrettyReporter.error writes to stderr", () => {
+      const reporter = createReporter(false);
+      const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+      reporter.error("something failed");
+
+      expect(stderr).toHaveBeenCalledOnce();
+      expect(String(stderr.mock.calls[0]![0])).toContain("something failed");
+    });
+
+    it("PrettyReporter.progress writes \\r-prefixed line to stdout", () => {
+      const reporter = createReporter(false);
+      const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+      reporter.progress(3, 10, "indexing doc");
+
+      const output = String(stdout.mock.calls[0]![0]);
+      expect(output).toMatch(/^\r/);
+      expect(output).toContain("3/10");
+      expect(output).toContain("30%");
+    });
+
+    it("PrettyReporter.clearProgress clears the progress line", () => {
+      const reporter = createReporter(false);
+      const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+      reporter.progress(1, 5, "working");
+      stdout.mockClear();
+
+      reporter.clearProgress();
+
+      // Should write spaces to clear the line
+      const output = String(stdout.mock.calls[0]![0]);
+      expect(output).toMatch(/^\r\s+\r$/);
+    });
+
+    it("PrettyReporter.clearProgress is a no-op when no progress shown", () => {
+      const reporter = createReporter(false);
+      const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+      reporter.clearProgress();
+
+      expect(stdout).not.toHaveBeenCalled();
+    });
+
+    it("PrettyReporter.log clears progress before writing", () => {
+      const reporter = createReporter(false);
+      const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+      reporter.progress(1, 5, "working");
+      stdout.mockClear();
+
+      reporter.log("a message");
+
+      // First call should be the clear, second the message
+      expect(stdout.mock.calls.length).toBeGreaterThanOrEqual(2);
+      const clearCall = String(stdout.mock.calls[0]![0]);
+      expect(clearCall).toMatch(/^\r\s+\r$/);
+    });
+
+    it("PrettyReporter.progress truncates long labels", () => {
+      const reporter = createReporter(false);
+      const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+      reporter.progress(1, 1, "a".repeat(50));
+
+      const output = String(stdout.mock.calls[0]![0]);
+      expect(output).toContain("...");
+    });
+
+    it("PrettyReporter.progress handles zero total gracefully", () => {
+      const reporter = createReporter(false);
+      const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+      reporter.progress(0, 0, "starting");
+
+      const output = String(stdout.mock.calls[0]![0]);
+      expect(output).toContain("0%");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements [GitHub Issue #330](https://github.com/RobertLD/libscope/issues/330).

- **CLI logging defaults to silent** — structured JSON pino logs are suppressed by default in CLI mode. Set `LIBSCOPE_VERBOSE=1` or pass `--verbose` to enable them. Human-readable output is handled by the new `CliReporter`.
- **New `src/cli/reporter.ts`** — `PrettyReporter` (ANSI colors, `\r`-based progress bar) and `SilentReporter` (no-op for verbose mode). `createReporter(verbose?)` factory + `isVerbose()` helper.
- **Pack install batch embedding** — documents are chunked and embedded in configurable batches (`--batch-size`, default 10) via a single `provider.embedBatch()` call per batch + one SQLite transaction, instead of N sequential single-document calls.
- **Pack install resume** — `--resume-from <n>` skips the first N documents, enabling recovery from partial installs.
- **Progress bar** — `pack install` shows live `\r`-overwritten progress (suppressed in verbose mode).
- **Fix duplicate `initLogger` calls** in `connect onenote` and `disconnect onenote` commands — now route through `setupLogging()`.

## Test plan

- [x] `tests/unit/reporter.test.ts` — 17 new tests for PrettyReporter (stdout/stderr output, ANSI codes, progress, clearProgress), SilentReporter (no-op), `isVerbose` (flag + env var)
- [x] `tests/unit/packs.test.ts` — 7 new tests: `onProgress` callbacks, `batchSize=1` (two progress calls), `resumeFrom` (skips docs), `embedBatch` failure → `errors` count, `errors=0` on success, single `embedBatch` call per batch, `errors=0` for already-installed
- [x] All 17 reporter tests pass
- [x] No lint errors in changed files (pre-existing lint errors in `src/cli/index.ts` line ~2548 unrelated to this PR)
- [x] Pre-existing test failures (csv-parse, node-cron, etc.) are unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)