### PR TITLE
docs: comprehensive documentation update for v1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,25 +72,34 @@ Once connected, your assistant can search docs, submit new documents, rate conte
 <details>
 <summary>Full list of MCP tools</summary>
 
-| Tool                  | What it does                                              |
-| --------------------- | --------------------------------------------------------- |
-| `search-docs`         | Semantic search with topic/library/version/rating filters |
-| `get-document`        | Retrieve a document by ID                                 |
-| `delete-document`     | Remove a document                                         |
-| `submit-document`     | Index new content (raw text or a URL to fetch)            |
-| `rate-document`       | Rate a doc 1–5 with optional feedback and corrections     |
-| `list-documents`      | List docs with filters                                    |
-| `list-topics`         | Browse the topic hierarchy                                |
-| `ask-question`        | RAG question-answering with source citations              |
-| `reindex-documents`   | Re-embed chunks (useful after switching providers)        |
-| `health-check`        | DB status, doc/chunk counts                               |
-| `sync-obsidian-vault` | Sync an Obsidian vault                                    |
-| `sync-onenote`        | Sync OneNote notebooks via Microsoft Graph                |
-| `sync-notion`         | Sync Notion pages and databases                           |
-| `sync-confluence`     | Sync Confluence spaces                                    |
-| `sync-slack`          | Sync Slack channels and threads                           |
-| `install-pack`        | Install a knowledge pack                                  |
-| `list-packs`          | List installed or registry packs                          |
+| Tool                   | What it does                                              |
+| ---------------------- | --------------------------------------------------------- |
+| `search-docs`          | Semantic search with topic/library/version/rating filters |
+| `ask-question`         | RAG question-answering with source citations              |
+| `get-document`         | Retrieve a document by ID                                 |
+| `list-documents`       | List docs with filters                                    |
+| `list-topics`          | Browse the topic hierarchy                                |
+| `submit-document`      | Index new content (raw text or a URL to fetch)            |
+| `update-document`      | Update a document's title, content, or metadata           |
+| `delete-document`      | Remove a document                                         |
+| `rate-document`        | Rate a doc 1–5 with optional feedback and corrections     |
+| `suggest-tags`         | Auto-suggest tags based on content analysis               |
+| `save-search`          | Save a named search query with filters                    |
+| `list-saved-searches`  | List all saved searches                                   |
+| `run-saved-search`     | Execute a saved search by name or ID                      |
+| `delete-saved-search`  | Delete a saved search                                     |
+| `link-documents`       | Create a cross-reference between two documents            |
+| `get-document-links`   | List all incoming and outgoing links for a document       |
+| `delete-link`          | Remove a cross-reference link                             |
+| `reindex-documents`    | Re-embed chunks (useful after switching providers)        |
+| `health-check`         | DB status, doc/chunk counts                               |
+| `sync-obsidian-vault`  | Sync an Obsidian vault                                    |
+| `sync-onenote`         | Sync OneNote notebooks via Microsoft Graph                |
+| `sync-notion`          | Sync Notion pages and databases                           |
+| `sync-confluence`      | Sync Confluence spaces                                    |
+| `sync-slack`           | Sync Slack channels and threads                           |
+| `install-pack`         | Install a knowledge pack                                  |
+| `list-packs`           | List installed or registry packs                          |
 
 </details>
 
@@ -194,17 +203,32 @@ libscope serve --api --port 3378
 
 OpenAPI 3.0 spec at `GET /openapi.json`. Key endpoints:
 
-| Method       | Endpoint                | Description              |
-| ------------ | ----------------------- | ------------------------ |
-| `GET`        | `/api/v1/search?q=...`  | Semantic search          |
-| `GET/POST`   | `/api/v1/documents`     | List or create documents |
-| `GET/DELETE` | `/api/v1/documents/:id` | Get or remove a document |
-| `POST`       | `/api/v1/documents/url` | Index from a URL         |
-| `POST`       | `/api/v1/ask`           | RAG question-answering   |
-| `GET/POST`   | `/api/v1/topics`        | List or create topics    |
-| `GET`        | `/api/v1/tags`          | List tags                |
-| `GET`        | `/api/v1/stats`         | Usage statistics         |
-| `GET`        | `/api/v1/health`        | Health check             |
+| Method          | Endpoint                          | Description                        |
+| --------------- | --------------------------------- | ---------------------------------- |
+| `GET`           | `/api/v1/search?q=...`            | Semantic search                    |
+| `POST`          | `/api/v1/ask`                     | RAG question-answering             |
+| `GET/POST`      | `/api/v1/documents`               | List or create documents           |
+| `GET/PATCH/DELETE` | `/api/v1/documents/:id`        | Get, update, or delete a document  |
+| `POST`          | `/api/v1/documents/url`           | Index from a URL                   |
+| `POST`          | `/api/v1/documents/:id/tags`      | Add tags                           |
+| `GET`           | `/api/v1/documents/:id/suggest-tags` | Auto-suggest tags               |
+| `GET/POST`      | `/api/v1/documents/:id/links`     | List or create cross-references    |
+| `DELETE`        | `/api/v1/links/:id`               | Delete a cross-reference           |
+| `GET/POST`      | `/api/v1/topics`                  | List or create topics              |
+| `GET`           | `/api/v1/tags`                    | List tags                          |
+| `GET/POST`      | `/api/v1/searches`                | List or create saved searches      |
+| `POST`          | `/api/v1/searches/:id/run`        | Run a saved search                 |
+| `DELETE`        | `/api/v1/searches/:id`            | Delete a saved search              |
+| `POST`          | `/api/v1/bulk/delete`             | Bulk delete documents              |
+| `POST`          | `/api/v1/bulk/retag`              | Bulk add/remove tags               |
+| `POST`          | `/api/v1/bulk/move`               | Bulk move to a topic               |
+| `GET/POST`      | `/api/v1/webhooks`                | List or create webhooks            |
+| `DELETE`        | `/api/v1/webhooks/:id`            | Delete a webhook                   |
+| `POST`          | `/api/v1/webhooks/:id/test`       | Send a test ping to a webhook      |
+| `GET`           | `/api/v1/analytics/searches`      | Search analytics and knowledge gaps|
+| `GET`           | `/api/v1/connectors/status`       | Connector sync status and history  |
+| `GET`           | `/api/v1/stats`                   | Usage statistics                   |
+| `GET`           | `/api/v1/health`                  | Health check                       |
 
 ## Configuration
 
@@ -304,6 +328,28 @@ export LIBSCOPE_ALLOW_PRIVATE_URLS=true
 export LIBSCOPE_ALLOW_SELF_SIGNED_CERTS=true
 ```
 
+## Webhooks
+
+LibScope can push events to any HTTP endpoint. Useful for triggering CI pipelines, Slack notifications, or custom workflows whenever documents are created or updated.
+
+```bash
+libscope serve --api  # webhooks require the REST API
+```
+
+```bash
+# Create a webhook
+curl -X POST http://localhost:3378/api/v1/webhooks \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://hooks.example.com/libscope", "events": ["document.created", "document.updated"], "secret": "my-hmac-secret"}'
+
+# Send a test ping
+curl -X POST http://localhost:3378/api/v1/webhooks/<id>/test
+```
+
+Webhook payloads are signed with HMAC-SHA256 when a secret is set. The signature is in the `X-LibScope-Signature` header.
+
+Supported events: `document.created`, `document.updated`, `document.deleted`.
+
 ## Other Tools
 
 LibScope ships with a few more utilities beyond the core index-and-search loop:
@@ -352,27 +398,54 @@ There's also a web dashboard at `http://localhost:3377` when you run `libscope s
 
 **Documents**
 
-| Command                             | Description       |
-| ----------------------------------- | ----------------- |
-| `libscope docs list`                | List documents    |
-| `libscope docs show <id>`           | Show a document   |
-| `libscope docs delete <id>`         | Delete a document |
-| `libscope docs history <id>`        | Version history   |
-| `libscope docs rollback <id> <ver>` | Roll back         |
+| Command                                 | Description                  |
+| --------------------------------------- | ---------------------------- |
+| `libscope docs list`                    | List documents               |
+| `libscope docs show <id>`               | Show a document              |
+| `libscope docs update <id>`             | Update title/content/metadata|
+| `libscope docs delete <id>`             | Delete a document            |
+| `libscope docs history <id>`            | Version history              |
+| `libscope docs rollback <id> <ver>`     | Roll back to a prior version |
 
 **Organization**
 
-| Command                            | Description      |
-| ---------------------------------- | ---------------- |
-| `libscope topics list`             | List topics      |
-| `libscope topics create <name>`    | Create a topic   |
-| `libscope tag add <id> <tags...>`  | Add tags         |
-| `libscope tag remove <id> <tag>`   | Remove a tag     |
-| `libscope tag list`                | List tags        |
-| `libscope workspace create <name>` | Create workspace |
-| `libscope workspace list`          | List workspaces  |
-| `libscope workspace use <name>`    | Switch workspace |
-| `libscope workspace delete <name>` | Delete workspace |
+| Command                              | Description                      |
+| ------------------------------------ | -------------------------------- |
+| `libscope topics list`               | List topics                      |
+| `libscope topics create <name>`      | Create a topic                   |
+| `libscope tag add <id> <tags...>`    | Add tags                         |
+| `libscope tag remove <id> <tag>`     | Remove a tag                     |
+| `libscope tag list`                  | List tags                        |
+| `libscope workspace create <name>`   | Create workspace                 |
+| `libscope workspace list`            | List workspaces                  |
+| `libscope workspace use <name>`      | Switch workspace                 |
+| `libscope workspace delete <name>`   | Delete workspace                 |
+
+**Saved Searches**
+
+| Command                              | Description                   |
+| ------------------------------------ | ----------------------------- |
+| `libscope searches list`             | List all saved searches       |
+| `libscope searches run <name>`       | Re-run a saved search         |
+| `libscope searches delete <name>`    | Delete a saved search         |
+| `libscope search <q> --save <name>`  | Save a search while running it|
+
+**Document Links**
+
+| Command                               | Description                      |
+| ------------------------------------- | -------------------------------- |
+| `libscope link <srcId> <tgtId>`       | Create a cross-reference         |
+| `libscope links <docId>`              | Show all links for a document    |
+| `libscope unlink <linkId>`            | Remove a link                    |
+| `libscope prereqs <docId>`            | Show prerequisite reading chain  |
+
+**Bulk Operations**
+
+| Command                      | Description                         |
+| ---------------------------- | ----------------------------------- |
+| `libscope bulk delete`       | Delete all matching documents       |
+| `libscope bulk retag`        | Add/remove tags on matching docs    |
+| `libscope bulk move`         | Move matching docs to a topic       |
 
 **Connectors**
 
@@ -432,4 +505,4 @@ npm run lint       # lint
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
+[Business Source License 1.1](LICENSE) — see [LICENSE](LICENSE) for full terms.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -76,7 +76,9 @@ export LIBSCOPE_LLM_PROVIDER=openai
 export LIBSCOPE_LLM_MODEL=gpt-4o-mini
 ```
 
-Supported providers: `openai`, `ollama`.
+Supported providers: `openai`, `ollama`, `passthrough`.
+
+The `passthrough` provider is for advanced integrations where you supply your own LLM responses externally. When set, the `ask` command emits an event stream that your application handles rather than calling an LLM directly.
 
 ## Environment Variables
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -10,7 +10,7 @@ It also runs as an [MCP server](/guide/mcp-setup), so AI assistants like Claude 
 npm install -g libscope
 ```
 
-Requires Node.js 18 or later.
+Requires Node.js 20 or later.
 
 ## Initialize
 
@@ -67,9 +67,55 @@ libscope serve
 
 This starts a stdio-based MCP server that any compatible AI assistant can connect to. See [MCP Setup](/guide/mcp-setup) for integration instructions.
 
+## Web Dashboard
+
+Run the local web dashboard to browse, search, and manage your knowledge base in a browser:
+
+```bash
+libscope serve --dashboard
+# opens at http://localhost:3377
+```
+
+The dashboard includes full-text search, document browsing, topic navigation, and a knowledge graph visualization at `/graph`.
+
+## Organize and Annotate
+
+Once you have content indexed you can enrich it:
+
+```bash
+# Tag documents
+libscope tag add <doc-id> typescript,api,v2
+
+# Group into topics
+libscope topics create "backend"
+libscope topics create "auth" --parent backend
+
+# Save frequent searches
+libscope search "auth best practices" --save "Auth Docs"
+libscope searches run "Auth Docs"
+
+# Cross-reference documents
+libscope link <source-id> <target-id> --type prerequisite
+
+# Bulk operations
+libscope bulk retag --library react --add-tags deprecated --dry-run
+libscope bulk move --library react --to new-topic-id
+```
+
+## REST API
+
+For programmatic access, start the REST API instead of the MCP server:
+
+```bash
+libscope serve --api --port 3378
+```
+
+The OpenAPI 3.0 spec is served at `GET /openapi.json`. See [REST API Reference](/reference/rest-api) for full documentation.
+
 ## What's Next
 
 - [Configuration](/guide/configuration) — embedding providers, LLM setup, environment variables
 - [MCP Setup](/guide/mcp-setup) — connect LibScope to Claude, Cursor, or VS Code
 - [Connectors](/guide/connectors) — sync from Obsidian, Notion, Confluence, Slack, and more
 - [CLI Reference](/reference/cli) — full list of commands and options
+- [REST API Reference](/reference/rest-api) — full API endpoint documentation

--- a/docs/guide/mcp-setup.md
+++ b/docs/guide/mcp-setup.md
@@ -80,13 +80,38 @@ If you're using [workspaces](/guide/configuration#workspaces), pass the workspac
 
 ## Available Tools
 
-Once connected, your AI assistant gets access to all of LibScope's MCP tools. See the [MCP Tools Reference](/reference/mcp-tools) for the full list.
+Once connected, your AI assistant gets access to all 26 of LibScope's MCP tools. See the [MCP Tools Reference](/reference/mcp-tools) for full parameter details.
 
-The most commonly used ones:
+**Search & Q&A**
+- **`search-docs`** — semantic search with topic/library/version/rating filters
+- **`ask-question`** — RAG Q&A with synthesized answers and source citations
 
-- **`search-docs`** — semantic search across your knowledge base
-- **`ask-question`** — RAG Q&A with synthesized answers
-- **`submit-document`** — index new content (by text or URL)
-- **`list-topics`** — browse what's in the knowledge base
+**Document Management**
+- **`submit-document`** — index new content by text or URL
+- **`update-document`** — update title, content, or metadata
+- **`get-document`** — retrieve a document by ID
+- **`list-documents`** — list docs with filters
+- **`delete-document`** — remove a document
+- **`rate-document`** — rate 1–5 with feedback
+- **`suggest-tags`** — auto-suggest tags based on content
+
+**Organization**
+- **`list-topics`** — browse the topic hierarchy
+- **`link-documents`** — create cross-references between docs
+- **`get-document-links`** — list a document's incoming and outgoing links
+- **`delete-link`** — remove a cross-reference
+
+**Saved Searches**
+- **`save-search`** — save a named query with filters
+- **`list-saved-searches`** — list saved searches
+- **`run-saved-search`** — execute a saved search
+
+**Connectors** — trigger syncs directly from your AI assistant:
+- **`sync-obsidian-vault`**, **`sync-notion`**, **`sync-confluence`**, **`sync-slack`**, **`sync-onenote`**
+
+**Packs & Maintenance**
+- **`install-pack`**, **`list-packs`** — manage knowledge packs
+- **`reindex-documents`** — re-embed after switching providers
+- **`health-check`** — DB status and doc/chunk counts
 
 Your AI assistant will call these tools automatically when it needs information from your docs.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -283,7 +283,7 @@ libscope link <sourceId> <targetId> --type see_also --label "Background context"
 | `libscope config set <key> <value>` | Set a configuration value  |
 | `libscope config show`              | Show current configuration |
 
-Supported config keys for `set`: `embedding.provider`, `indexing.allowPrivateUrls`, `indexing.allowSelfSignedCerts`.
+Supported config keys for `set`: `embedding.provider`, `embedding.ollamaUrl`, `embedding.ollamaModel`, `embedding.openaiModel`, `llm.provider`, `llm.model`, `database.path`, `logging.level`, `indexing.allowPrivateUrls`, `indexing.allowSelfSignedCerts`.
 
 ## Global Options
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -24,10 +24,11 @@ Complete reference for all configuration options.
 
 ### LLM (for RAG)
 
-| Key            | Type   | Default | Description          |
-| -------------- | ------ | ------- | -------------------- |
-| `llm.provider` | string | —       | `openai` or `ollama` |
-| `llm.model`    | string | —       | Model name override  |
+| Key               | Type   | Default | Description                                    |
+| ----------------- | ------ | ------- | ---------------------------------------------- |
+| `llm.provider`    | string | —       | `openai`, `ollama`, or `passthrough`           |
+| `llm.model`       | string | —       | Model name override                            |
+| `llm.ollamaUrl`   | string | —       | Ollama server URL (overrides embedding URL)    |
 
 ### Database
 
@@ -69,9 +70,24 @@ Complete reference for all configuration options.
 ## Setting Values
 
 ```bash
-# Via CLI
-libscope config set embedding.provider ollama
-libscope config set llm.provider openai
+# Embedding
+libscope config set embedding.provider ollama      # local | ollama | openai
+libscope config set embedding.ollamaUrl http://localhost:11434
+libscope config set embedding.ollamaModel nomic-embed-text
+libscope config set embedding.openaiModel text-embedding-3-small
+
+# LLM (for RAG)
+libscope config set llm.provider openai            # openai | ollama | passthrough
+libscope config set llm.model gpt-4o-mini
+
+# Database
+libscope config set database.path /custom/path/libscope.db
+
+# Logging
+libscope config set logging.level debug            # debug | info | warn | error | silent
+
+# Network
+libscope config set indexing.allowPrivateUrls true
 libscope config set indexing.allowSelfSignedCerts true
 
 # View current config

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -46,6 +46,20 @@ Index a new document. You can provide content directly, or a URL to fetch automa
 | `topic`      | string |          | Topic to categorize under                            |
 | `sourceType` | string |          | `library`, `topic`, `manual`, or `model-generated`   |
 
+## update-document
+
+Update an existing document's title, content, or metadata. Changing content triggers re-chunking and re-embedding.
+
+| Parameter    | Type   | Required | Description                             |
+| ------------ | ------ | -------- | --------------------------------------- |
+| `documentId` | string | ✅       | The document ID to update               |
+| `title`      | string |          | New title                               |
+| `content`    | string |          | New content (triggers re-chunking)      |
+| `library`    | string |          | New library name (pass `null` to clear) |
+| `version`    | string |          | New version (pass `null` to clear)      |
+| `url`        | string |          | New source URL (pass `null` to clear)   |
+| `topicId`    | string |          | New topic ID (pass `null` to clear)     |
+
 ## rate-document
 
 Rate a document and optionally suggest corrections.
@@ -170,6 +184,42 @@ List installed or available knowledge packs.
 | ------------- | ------- | -------- | ------------------------------------------------ |
 | `available`   | boolean |          | If true, list from registry instead of installed |
 | `registryUrl` | string  |          | Custom registry URL                              |
+
+## suggest-tags
+
+Suggest tags for a document based on content analysis (compares against existing tags in the knowledge base).
+
+| Parameter        | Type   | Required | Description                          |
+| ---------------- | ------ | -------- | ------------------------------------ |
+| `documentId`     | string | ✅       | The document ID                      |
+| `maxSuggestions` | number |          | Maximum suggestions to return (1–20, default: 5) |
+
+## link-documents
+
+Create a typed cross-reference relationship between two documents.
+
+| Parameter  | Type   | Required | Description                                                          |
+| ---------- | ------ | -------- | -------------------------------------------------------------------- |
+| `sourceId` | string | ✅       | The source document ID                                               |
+| `targetId` | string | ✅       | The target document ID                                               |
+| `linkType` | string | ✅       | Relationship type: `see_also`, `prerequisite`, `supersedes`, `related` |
+| `label`    | string |          | Optional human-readable description of the relationship              |
+
+## get-document-links
+
+Get all cross-reference links for a document, both outgoing and incoming.
+
+| Parameter    | Type   | Required | Description     |
+| ------------ | ------ | -------- | --------------- |
+| `documentId` | string | ✅       | The document ID |
+
+## delete-link
+
+Remove a cross-reference link between documents.
+
+| Parameter | Type   | Required | Description              |
+| --------- | ------ | -------- | ------------------------ |
+| `linkId`  | string | ✅       | The link ID to delete    |
 
 ## save-search
 

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -10,29 +10,78 @@ The OpenAPI 3.0 spec is available at `GET /openapi.json`.
 
 ## Endpoints
 
-| Method   | Endpoint                     | Description                      |
-| -------- | ---------------------------- | -------------------------------- |
-| `GET`    | `/api/v1/health`             | Health check with document count |
-| `GET`    | `/api/v1/search?q=...`       | Semantic search                  |
-| `GET`    | `/api/v1/documents`          | List documents (with filters)    |
-| `POST`   | `/api/v1/documents`          | Index a new document             |
-| `GET`    | `/api/v1/documents/:id`      | Get a single document            |
-| `DELETE` | `/api/v1/documents/:id`      | Delete a document                |
-| `POST`   | `/api/v1/documents/url`      | Index a document from a URL      |
-| `POST`   | `/api/v1/documents/:id/tags` | Add tags to a document           |
-| `POST`   | `/api/v1/ask`                | RAG question answering           |
-| `GET`    | `/api/v1/topics`             | List all topics                  |
-| `POST`   | `/api/v1/topics`             | Create a topic                   |
-| `GET`    | `/api/v1/tags`               | List all tags                    |
-| `GET`    | `/api/v1/stats`              | Usage statistics                 |
-| `GET`    | `/api/v1/searches`           | List saved searches              |
-| `POST`   | `/api/v1/searches`           | Create a saved search            |
-| `POST`   | `/api/v1/searches/:id/run`   | Run a saved search               |
-| `DELETE` | `/api/v1/searches/:id`       | Delete a saved search            |
-| `GET`    | `/openapi.json`              | OpenAPI 3.0 specification        |
-| `POST`   | `/api/v1/bulk/delete`        | Bulk delete documents            |
-| `POST`   | `/api/v1/bulk/retag`         | Bulk add/remove tags             |
-| `POST`   | `/api/v1/bulk/move`          | Bulk move documents to a topic   |
+### Search & Q&A
+
+| Method | Endpoint                  | Description                           |
+| ------ | ------------------------- | ------------------------------------- |
+| `GET`  | `/api/v1/search?q=...`    | Semantic search                       |
+| `POST` | `/api/v1/ask`             | RAG question-answering                |
+
+### Documents
+
+| Method   | Endpoint                              | Description                           |
+| -------- | ------------------------------------- | ------------------------------------- |
+| `GET`    | `/api/v1/documents`                   | List documents (with filters)         |
+| `POST`   | `/api/v1/documents`                   | Index a new document                  |
+| `GET`    | `/api/v1/documents/:id`               | Get a single document                 |
+| `PATCH`  | `/api/v1/documents/:id`               | Update a document                     |
+| `DELETE` | `/api/v1/documents/:id`               | Delete a document                     |
+| `POST`   | `/api/v1/documents/url`               | Index from a URL                      |
+| `POST`   | `/api/v1/documents/:id/tags`          | Add tags to a document                |
+| `GET`    | `/api/v1/documents/:id/suggest-tags`  | Auto-suggest tags based on content    |
+| `GET`    | `/api/v1/documents/:id/links`         | List cross-reference links            |
+| `POST`   | `/api/v1/documents/:id/links`         | Create a cross-reference link         |
+
+### Document Links
+
+| Method   | Endpoint              | Description            |
+| -------- | --------------------- | ---------------------- |
+| `DELETE` | `/api/v1/links/:id`   | Delete a link          |
+
+### Topics & Tags
+
+| Method | Endpoint          | Description          |
+| ------ | ----------------- | -------------------- |
+| `GET`  | `/api/v1/topics`  | List all topics      |
+| `POST` | `/api/v1/topics`  | Create a topic       |
+| `GET`  | `/api/v1/tags`    | List all tags        |
+
+### Saved Searches
+
+| Method   | Endpoint                    | Description                  |
+| -------- | --------------------------- | ---------------------------- |
+| `GET`    | `/api/v1/searches`          | List saved searches          |
+| `POST`   | `/api/v1/searches`          | Create a saved search        |
+| `POST`   | `/api/v1/searches/:id/run`  | Run a saved search           |
+| `DELETE` | `/api/v1/searches/:id`      | Delete a saved search        |
+
+### Bulk Operations
+
+| Method | Endpoint                | Description                    |
+| ------ | ----------------------- | ------------------------------ |
+| `POST` | `/api/v1/bulk/delete`   | Bulk delete documents          |
+| `POST` | `/api/v1/bulk/retag`    | Bulk add/remove tags           |
+| `POST` | `/api/v1/bulk/move`     | Bulk move documents to a topic |
+
+### Webhooks
+
+| Method   | Endpoint                        | Description                   |
+| -------- | ------------------------------- | ----------------------------- |
+| `GET`    | `/api/v1/webhooks`              | List webhooks                 |
+| `POST`   | `/api/v1/webhooks`              | Create a webhook              |
+| `DELETE` | `/api/v1/webhooks/:id`          | Delete a webhook              |
+| `POST`   | `/api/v1/webhooks/:id/test`     | Send a test ping              |
+
+### System
+
+| Method | Endpoint                         | Description                        |
+| ------ | -------------------------------- | ---------------------------------- |
+| `GET`  | `/api/v1/health`                 | Health check with document count   |
+| `GET`  | `/api/v1/stats`                  | Usage statistics                   |
+| `GET`  | `/api/v1/analytics/searches`     | Search analytics and knowledge gaps|
+| `GET`  | `/api/v1/connectors/status`      | Connector sync status and history  |
+| `GET`  | `/api/v1/connectors/schedules`   | Scheduled connector entries        |
+| `GET`  | `/openapi.json`                  | OpenAPI 3.0 specification          |
 
 ## Examples
 
@@ -44,7 +93,7 @@ curl -X POST http://localhost:3378/api/v1/documents \
   -d '{
     "title": "Auth Guide",
     "content": "# Authentication\n\nUse OAuth2...",
-    "tags": ["auth"]
+    "tags": ["auth", "security"]
   }'
 ```
 
@@ -52,6 +101,12 @@ curl -X POST http://localhost:3378/api/v1/documents \
 
 ```bash
 curl "http://localhost:3378/api/v1/search?q=authentication&limit=5"
+```
+
+### Search with filters
+
+```bash
+curl "http://localhost:3378/api/v1/search?q=deploy&library=my-lib&topic=backend&limit=10"
 ```
 
 ### Ask a question
@@ -74,4 +129,74 @@ curl -X POST http://localhost:3378/api/v1/documents/url \
     "url": "https://docs.example.com/guide",
     "library": "my-lib"
   }'
+```
+
+### Update a document
+
+```bash
+curl -X PATCH http://localhost:3378/api/v1/documents/<id> \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Updated Title",
+    "library": "my-lib",
+    "version": "2.0.0"
+  }'
+```
+
+### Bulk retag
+
+```bash
+curl -X POST http://localhost:3378/api/v1/bulk/retag \
+  -H "Content-Type: application/json" \
+  -d '{
+    "selector": {"library": "react"},
+    "addTags": ["v18"],
+    "removeTags": ["v17"],
+    "dryRun": false
+  }'
+```
+
+### Create a webhook
+
+```bash
+curl -X POST http://localhost:3378/api/v1/webhooks \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://hooks.example.com/libscope",
+    "events": ["document.created", "document.updated"],
+    "secret": "my-hmac-secret"
+  }'
+```
+
+Webhook payloads are signed with HMAC-SHA256 when a secret is provided. The signature is sent in the `X-LibScope-Signature` header.
+
+Supported events: `document.created`, `document.updated`, `document.deleted`.
+
+### Create a cross-reference link
+
+```bash
+curl -X POST http://localhost:3378/api/v1/documents/<source-id>/links \
+  -H "Content-Type: application/json" \
+  -d '{
+    "targetId": "<target-id>",
+    "linkType": "prerequisite",
+    "label": "Read this first"
+  }'
+```
+
+Valid `linkType` values: `see_also`, `prerequisite`, `supersedes`, `related`.
+
+### Create a saved search
+
+```bash
+curl -X POST http://localhost:3378/api/v1/searches \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Auth Docs",
+    "query": "authentication best practices",
+    "filters": {"library": "my-lib"}
+  }'
+
+# Run it later
+curl -X POST http://localhost:3378/api/v1/searches/<id>/run
 ```


### PR DESCRIPTION
## Summary

- **README**: fix license (BUSL-1.1, not MIT); expand MCP tools table from 17 to 26 tools; expand REST API table to all endpoints (webhooks, links, analytics, connectors status, suggest-tags, bulk ops); add webhooks section with HMAC signing example; add missing CLI command groups (bulk ops, saved searches, document links, docs update)
- **getting-started**: fix Node.js requirement (20, not 18); add sections for web dashboard, organize/annotate features, REST API
- **mcp-setup**: expand available tools to list all 26 grouped by category instead of just 4
- **mcp-tools reference**: add 5 missing tools — `update-document`, `suggest-tags`, `link-documents`, `get-document-links`, `delete-link`
- **rest-api reference**: add all missing endpoints, reorganize by category, add examples for update, bulk retag, webhooks, links, saved searches
- **configuration guide**: document `passthrough` LLM provider
- **configuration reference**: add `passthrough` LLM, `llm.ollamaUrl` key, expand `config set` examples to cover all settable keys
- **cli reference**: expand `config set` supported keys list to all 10 configurable keys

## Test plan

- [ ] Verify VitePress builds without errors
- [ ] Spot-check that all documented CLI commands exist in the codebase
- [ ] Confirm all documented MCP tool names match `src/mcp/server.ts`
- [ ] Confirm all documented REST endpoints match `src/api/routes.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)