### PR TITLE
fix: always target main branch in release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,9 +19,8 @@ jobs:
         id: release
         with:
           release-type: node
-          # Use a PAT so the created PR triggers CI workflows.
-          # GITHUB_TOKEN cannot trigger other workflows (GitHub security restriction).
-          token: ${{ secrets.GH_TOKEN }}
+          target-branch: main
+          token: ${{ secrets.GH_TOKEN || github.token }}
 
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds `target-branch: main` so release-please always creates its version-bump PR against `main`, not the repo default branch (`development`). Also falls back to `github.token` if `GH_TOKEN` secret is not set.