### PR TITLE
docs: update VitePress config for v1.3.0

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,4 +1,8 @@
 import { defineConfig } from "vitepress";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const { version } = require("../../package.json");
 
 export default defineConfig({
   title: "LibScope",
@@ -23,7 +27,7 @@ export default defineConfig({
       { text: "Guide", link: "/guide/getting-started" },
       { text: "Reference", link: "/reference/cli" },
       {
-        text: "v1.3.0",
+        text: `v${version}`,
         items: [
           {
             text: "Changelog",


### PR DESCRIPTION
- Updates nav version badge from v1.1.0 to v1.3.0
- Fixes footer license from MIT to Business Source License 1.1

This will trigger a Vercel redeploy of the docs site.