### PR TITLE
feat: add get-related chunk similarity lookup (more-like-this)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -495,7 +495,9 @@ program
         }
 
         const { sourceChunk, chunks } = result;
-        console.log(`\nRelated to chunk: ${sourceChunk.id} from document ${sourceChunk.documentId}`);
+        console.log(
+          `\nRelated to chunk: ${sourceChunk.id} from document ${sourceChunk.documentId}`,
+        );
 
         if (chunks.length === 0) {
           console.log("No related chunks found.");

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -104,12 +104,12 @@ export interface SearchResult {
 
 export interface RelatedChunksOptions {
   chunkId: string;
-  limit?: number;           // default 10
+  limit?: number; // default 10
   excludeDocumentId?: string; // exclude the source document (default: auto-detected from chunkId)
   topic?: string;
   library?: string;
   tags?: string[];
-  minScore?: number;        // default 0.0
+  minScore?: number; // default 0.0
   includeLinkedDocuments?: boolean; // blend in explicit document_links (default false)
 }
 
@@ -885,9 +885,7 @@ export function getRelatedChunks(
   const EmbeddingRowSchema = z.object({ embedding: z.instanceof(Buffer) });
   const embeddingRow = validateRow(
     EmbeddingRowSchema.optional(),
-    db
-      .prepare(`SELECT embedding FROM chunk_embeddings WHERE chunk_id = ?`)
-      .get(chunkId),
+    db.prepare(`SELECT embedding FROM chunk_embeddings WHERE chunk_id = ?`).get(chunkId),
     "getRelatedChunks.embedding",
   );
   if (!embeddingRow) {
@@ -995,11 +993,9 @@ export function getRelatedChunks(
         FROM document_links
         WHERE source_id = ? OR target_id = ?`,
       )
-      .all(
-        sourceChunk.documentId,
-        sourceChunk.documentId,
-        sourceChunk.documentId,
-      ) as { linked_doc_id: string }[];
+      .all(sourceChunk.documentId, sourceChunk.documentId, sourceChunk.documentId) as {
+      linked_doc_id: string;
+    }[];
 
     const LinkedChunkSchema = z.object({
       id: z.string(),

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -183,30 +183,47 @@ async function main(): Promise<void> {
     "Find chunks semantically similar to a given chunk (more-like-this). Returns related content seeded from an existing chunk's stored embedding without requiring a text query.",
     {
       chunkId: z.string().describe("ID of the source chunk to find related content for"),
-      limit: z.number().min(1).max(50).optional().describe("Number of results to return (default 10)"),
+      limit: z
+        .number()
+        .min(1)
+        .max(50)
+        .optional()
+        .describe("Number of results to return (default 10)"),
       topic: z.string().optional().describe("Filter results to a specific topic"),
       library: z.string().optional().describe("Filter results to a specific library"),
       tags: z.array(z.string()).optional().describe("Filter results to documents with these tags"),
-      minScore: z.number().min(0).max(1).optional().describe("Minimum similarity score threshold (0-1)"),
-      includeLinkedDocuments: z.boolean().optional().describe("Also include explicitly linked documents even if below similarity threshold"),
+      minScore: z
+        .number()
+        .min(0)
+        .max(1)
+        .optional()
+        .describe("Minimum similarity score threshold (0-1)"),
+      includeLinkedDocuments: z
+        .boolean()
+        .optional()
+        .describe("Also include explicitly linked documents even if below similarity threshold"),
     },
-    withErrorHandling(({ chunkId, limit, topic, library, tags, minScore, includeLinkedDocuments }) => {
-      const result = getRelatedChunks(db, {
-        chunkId,
-        ...(limit !== undefined && { limit }),
-        ...(topic !== undefined && { topic }),
-        ...(library !== undefined && { library }),
-        ...(tags !== undefined && { tags }),
-        ...(minScore !== undefined && { minScore }),
-        ...(includeLinkedDocuments !== undefined && { includeLinkedDocuments }),
-      });
-      return {
-        content: [{
-          type: "text" as const,
-          text: JSON.stringify(result, null, 2),
-        }],
-      };
-    }),
+    withErrorHandling(
+      ({ chunkId, limit, topic, library, tags, minScore, includeLinkedDocuments }) => {
+        const result = getRelatedChunks(db, {
+          chunkId,
+          ...(limit !== undefined && { limit }),
+          ...(topic !== undefined && { topic }),
+          ...(library !== undefined && { library }),
+          ...(tags !== undefined && { tags }),
+          ...(minScore !== undefined && { minScore }),
+          ...(includeLinkedDocuments !== undefined && { includeLinkedDocuments }),
+        });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      },
+    ),
   );
 
   // Tool: get-document

--- a/tests/unit/get-related.test.ts
+++ b/tests/unit/get-related.test.ts
@@ -24,9 +24,9 @@ describe("getRelatedChunks", () => {
 
   describe("error handling", () => {
     it("throws when chunkId does not exist", () => {
-      expect(() =>
-        getRelatedChunks(db, { chunkId: "nonexistent-chunk-id" }),
-      ).toThrow("Chunk not found: nonexistent-chunk-id");
+      expect(() => getRelatedChunks(db, { chunkId: "nonexistent-chunk-id" })).toThrow(
+        "Chunk not found: nonexistent-chunk-id",
+      );
     });
 
     it("throws when chunk exists but has no embedding", () => {


### PR DESCRIPTION
Closes #395

## Summary

- **`getRelatedChunks()` in `src/core/search.ts`** — new exported function that fetches a chunk's stored embedding from `chunk_embeddings`, runs an ANN vector search via sqlite-vec directly (no embedding provider call), excludes the source document by default, and optionally blends in explicitly linked documents at a boosted score
- **`get-related` MCP tool in `src/mcp/server.ts`** — exposes `getRelatedChunks` as an MCP tool with schema fields for `chunkId`, `limit`, `topic`, `library`, `tags`, `minScore`, `includeLinkedDocuments`
- **`related <chunkId>` CLI command in `src/cli/index.ts`** — `libscope related <chunkId>` with `--limit`, `--topic`, `--library`, `--min-score`, `--tags` options; output matches `search` command style
- **`tests/unit/get-related.test.ts`** — 9 unit tests covering: chunk-not-found error, no-embedding error, sourceChunk metadata, excludeDocumentId behavior, includeLinkedDocuments SQL logic, minScore filtering, limit

## Key design decisions

- `getRelatedChunks` is **synchronous** (matches all other DB functions in this codebase)
- Uses **direct SQL** with `embedding MATCH ?` (sqlite-vec ANN) rather than delegating to `searchDocuments`, skipping the embedding provider entirely — fast, offline-capable, and guaranteed to use the same embedding space
- Uses `validateRow`/`validateRows` + Zod schemas (consistent with existing codebase patterns)
- `includeLinkedDocuments` fetches linked doc chunks via plain SQL and boosts their score to 0.6 so they surface even when below the vector similarity threshold

## Test plan
- [x] All 9 unit tests pass (`vitest run tests/unit/get-related.test.ts`)
- [x] TypeScript type-checks cleanly (`tsc --noEmit`)
- [ ] Manual: `libscope related <chunkId>` with an indexed workspace
- [ ] Manual: MCP `get-related` tool via Claude Desktop / MCP client

🤖 Generated with [Claude Code](https://claude.com/claude-code)