### PR TITLE
fix: set git identity in registry sync test for CI

### DIFF
--- a/tests/unit/registry/sync.test.ts
+++ b/tests/unit/registry/sync.test.ts
@@ -54,7 +54,14 @@ function createBareRepo(dir: string, packs: PackSummary[] = []): string {
   const workDir = join(dir, `work-${randomUUID()}`);
   execSync(`git clone "${bareDir}" "${workDir}"`, { stdio: "pipe" });
   writeFileSync(join(workDir, "index.json"), JSON.stringify(packs), "utf-8");
-  execSync("git add . && git commit -m 'init'", { cwd: workDir, stdio: "pipe" });
+  const gitEnv = {
+    ...process.env,
+    GIT_AUTHOR_NAME: "test",
+    GIT_AUTHOR_EMAIL: "test@test.com",
+    GIT_COMMITTER_NAME: "test",
+    GIT_COMMITTER_EMAIL: "test@test.com",
+  };
+  execSync("git add . && git commit -m 'init'", { cwd: workDir, stdio: "pipe", env: gitEnv });
   execSync("git push", { cwd: workDir, stdio: "pipe" });
   return bareDir;
 }


### PR DESCRIPTION
## Summary
- The `createBareRepo` test helper in `tests/unit/registry/sync.test.ts` runs `git commit` without setting author identity, which fails on CI runners that lack global git config.
- Passes `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`, `GIT_COMMITTER_EMAIL` env vars to the commit command.
- Fixes CI failures on PRs #396, #397, and #398.

## Test plan
- [x] `npx vitest run tests/unit/registry/sync.test.ts` passes locally (9/9 tests)
- [ ] CI passes on this PR
- [ ] After merge, rebase open PRs to pick up the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)