### PR TITLE
fix: set git identity in integration registry tests for CI

### DIFF
--- a/tests/integration/registry/registry-conflict.test.ts
+++ b/tests/integration/registry/registry-conflict.test.ts
@@ -7,6 +7,14 @@ import { execSync } from "node:child_process";
 import { initLogger } from "../../../src/logger.js";
 import type { RegistryEntry, PackSummary } from "../../../src/registry/types.js";
 
+const gitEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "test",
+  GIT_AUTHOR_EMAIL: "test@test.com",
+  GIT_COMMITTER_NAME: "test",
+  GIT_COMMITTER_EMAIL: "test@test.com",
+};
+
 let tempHome: string = join(tmpdir(), `libscope-conflict-int-test-${process.pid}`);
 mkdirSync(tempHome, { recursive: true });
 
@@ -81,7 +89,7 @@ function createBareRepoWithPacks(dir: string, packs: PackSummary[]): string {
     );
   }
 
-  execSync("git add . && git commit -m 'init'", { cwd: workDir, stdio: "pipe" });
+  execSync("git add . && git commit -m 'init'", { cwd: workDir, stdio: "pipe", env: gitEnv });
   execSync("git push", { cwd: workDir, stdio: "pipe" });
   return bareDir;
 }

--- a/tests/integration/registry/registry-lifecycle.test.ts
+++ b/tests/integration/registry/registry-lifecycle.test.ts
@@ -7,6 +7,14 @@ import { execSync } from "node:child_process";
 import { initLogger } from "../../../src/logger.js";
 import type { RegistryEntry, PackSummary } from "../../../src/registry/types.js";
 
+const gitEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "test",
+  GIT_AUTHOR_EMAIL: "test@test.com",
+  GIT_COMMITTER_NAME: "test",
+  GIT_COMMITTER_EMAIL: "test@test.com",
+};
+
 let tempHome: string = join(tmpdir(), `libscope-lifecycle-test-${process.pid}`);
 mkdirSync(tempHome, { recursive: true });
 
@@ -98,7 +106,7 @@ function createBareRegistryRepo(dir: string, packs: PackSummary[]): string {
     );
   }
 
-  execSync("git add . && git commit -m 'init'", { cwd: workDir, stdio: "pipe" });
+  execSync("git add . && git commit -m 'init'", { cwd: workDir, stdio: "pipe", env: gitEnv });
   execSync("git push", { cwd: workDir, stdio: "pipe" });
 
   return bareDir;
@@ -234,6 +242,7 @@ describe("integration: registry lifecycle", () => {
     execSync("git add . && git commit -m 'add new pack' && git push", {
       cwd: workDir,
       stdio: "pipe",
+      env: gitEnv,
     });
 
     // Re-sync

--- a/tests/integration/registry/registry-offline.test.ts
+++ b/tests/integration/registry/registry-offline.test.ts
@@ -7,6 +7,14 @@ import { execSync } from "node:child_process";
 import { initLogger } from "../../../src/logger.js";
 import type { RegistryEntry, PackSummary } from "../../../src/registry/types.js";
 
+const gitEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "test",
+  GIT_AUTHOR_EMAIL: "test@test.com",
+  GIT_COMMITTER_NAME: "test",
+  GIT_COMMITTER_EMAIL: "test@test.com",
+};
+
 let tempHome: string = join(tmpdir(), `libscope-offline-test-${process.pid}`);
 mkdirSync(tempHome, { recursive: true });
 
@@ -41,7 +49,7 @@ function createBareRepo(dir: string, packs: PackSummary[] = []): string {
   const workDir = join(dir, `work-${randomUUID()}`);
   execSync(`git clone "${bareDir}" "${workDir}"`, { stdio: "pipe" });
   writeFileSync(join(workDir, "index.json"), JSON.stringify(packs), "utf-8");
-  execSync("git add . && git commit -m 'init'", { cwd: workDir, stdio: "pipe" });
+  execSync("git add . && git commit -m 'init'", { cwd: workDir, stdio: "pipe", env: gitEnv });
   execSync("git push", { cwd: workDir, stdio: "pipe" });
   return bareDir;
 }

--- a/tests/integration/registry/registry-publish.test.ts
+++ b/tests/integration/registry/registry-publish.test.ts
@@ -7,6 +7,14 @@ import { execSync } from "node:child_process";
 import { initLogger } from "../../../src/logger.js";
 import type { RegistryEntry, PackSummary, PackManifest } from "../../../src/registry/types.js";
 
+const gitEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "test",
+  GIT_AUTHOR_EMAIL: "test@test.com",
+  GIT_COMMITTER_NAME: "test",
+  GIT_COMMITTER_EMAIL: "test@test.com",
+};
+
 let tempHome: string = join(tmpdir(), `libscope-publish-test-${process.pid}`);
 mkdirSync(tempHome, { recursive: true });
 
@@ -47,7 +55,7 @@ function createBareRepo(dir: string): string {
   writeFileSync(join(workDir, "index.json"), "[]", "utf-8");
   mkdirSync(join(workDir, "packs"), { recursive: true });
   writeFileSync(join(workDir, "packs", ".gitkeep"), "", "utf-8");
-  execSync("git add . && git commit -m 'init'", { cwd: workDir, stdio: "pipe" });
+  execSync("git add . && git commit -m 'init'", { cwd: workDir, stdio: "pipe", env: gitEnv });
   execSync("git push", { cwd: workDir, stdio: "pipe" });
   return bareDir;
 }


### PR DESCRIPTION
## Summary
- Same git identity fix as #400 and #401, applied to the 4 integration test files:
  - `registry-lifecycle.test.ts`
  - `registry-conflict.test.ts`
  - `registry-publish.test.ts`
  - `registry-offline.test.ts`
- Adds `GIT_AUTHOR/COMMITTER` env vars to all `execSync` git commit calls

## Test plan
- [x] All 29 integration registry tests pass locally
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)