### PR TITLE
fix: accept ssh:// protocol URLs in registry validation

### DIFF
--- a/src/registry/config.ts
+++ b/src/registry/config.ts
@@ -24,11 +24,14 @@ export function validateRegistryName(name: string): void {
 
 /** Validate a git URL (https or ssh). */
 export function validateGitUrl(url: string): void {
-  // Accept https:// URLs and SSH-style git@host:path URLs
+  // Accept https:// URLs, ssh:// URLs, and SCP-style git@host:path URLs
   const isHttps = url.startsWith("https://");
-  const isSsh = /^git@[\w.-]+:/.test(url);
-  if (!isHttps && !isSsh) {
-    throw new ValidationError("Registry URL must use https:// or SSH (git@host:path) format");
+  const isSshProtocol = url.startsWith("ssh://");
+  const isScp = /^git@[\w.-]+:/.test(url);
+  if (!isHttps && !isSshProtocol && !isScp) {
+    throw new ValidationError(
+      "Registry URL must use https://, ssh://, or SSH (git@host:path) format",
+    );
   }
 }
 

--- a/tests/unit/registry/config.test.ts
+++ b/tests/unit/registry/config.test.ts
@@ -78,6 +78,10 @@ describe("registry config", () => {
       expect(() => validateGitUrl("git@github.com:org/repo.git")).not.toThrow();
     });
 
+    it("should accept ssh:// protocol URLs", () => {
+      expect(() => validateGitUrl("ssh://git@bitbucket:7999/mdog/repo.git")).not.toThrow();
+    });
+
     it("should reject http:// URLs", () => {
       expect(() => validateGitUrl("http://github.com/org/repo.git")).toThrow();
     });


### PR DESCRIPTION
## Summary
- Registry URL validation only accepted `https://` and SCP-style `git@host:path` SSH URLs
- Bitbucket Server uses `ssh://git@host:port/path` format, which was rejected
- Users forced to use SCP format with port (`git@host:7999/...`), which git misinterprets as a path — causing password prompts instead of SSH key auth
- Added `ssh://` protocol support to `validateGitUrl()`

## Test plan
- [x] Added unit test for `ssh://` URL validation
- [x] All existing registry config tests pass (26/26)

🤖 Generated with [Claude Code](https://claude.com/claude-code)