### PR TITLE
docs: enhance internal and user documentation for issue #415

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -64,9 +64,17 @@ export default defineConfig({
           ],
         },
         {
+          text: "Features",
+          items: [
+            { text: "Web Dashboard", link: "/guide/dashboard" },
+            { text: "Webhooks", link: "/guide/webhooks" },
+          ],
+        },
+        {
           text: "Deep Dives",
           items: [
             { text: "How Search Works", link: "/guide/how-search-works" },
+            { text: "Architecture", link: "/guide/architecture" },
             { text: "Troubleshooting", link: "/guide/troubleshooting" },
           ],
         },

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -36,6 +36,10 @@ src/
 ├── providers/   # Embedding providers (local, Ollama, OpenAI)
 ├── mcp/         # MCP server and tool definitions
 ├── cli/         # CLI entry point and commands
+├── api/         # REST API server and routes
+├── web/         # Web dashboard and knowledge graph
+├── connectors/  # Third-party syncs (Obsidian, Notion, Confluence, Slack, OneNote)
+├── registry/    # Git-backed pack registry system
 ├── config.ts    # Configuration management
 ├── logger.ts    # Structured logging (pino)
 └── errors.ts    # Custom error hierarchy
@@ -44,6 +48,20 @@ tests/
 ├── integration/ # Tests with real SQLite DB
 └── fixtures/    # Test helpers, mock providers, sample data
 ```
+
+For a full module-by-module breakdown and data flow diagrams, see the [Architecture Guide](/guide/architecture).
+
+## Design Principles
+
+**Entry points are thin.** The CLI, MCP server, and REST API are adapters. They parse input and format output. All business logic lives in `src/core/`.
+
+**Errors are typed.** Use the appropriate `LibScopeError` subclass (`DatabaseError`, `ValidationError`, `FetchError`, etc.) rather than throwing plain `Error`. MCP tool handlers must be wrapped with `withErrorHandling()` from `src/mcp/errors.ts`.
+
+**Core modules are testable.** They accept `db` and `provider` as parameters — never import them directly inside a function. This makes it easy to swap in `createTestDb()` and `MockEmbeddingProvider` in tests.
+
+**Migrations are additive.** Never modify an existing migration. Add a new entry in `MIGRATIONS` and increment `SCHEMA_VERSION` in `src/db/schema.ts`.
+
+**No `any`.** Use `unknown` and narrow with type guards. The ESLint rule `no-explicit-any: "error"` is enforced.
 
 ## Making Changes
 

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -1,0 +1,362 @@
+# Architecture
+
+This guide explains how LibScope is structured internally. It is intended for contributors and developers who want to understand or extend the codebase.
+
+## System Layers
+
+LibScope is organized into four distinct layers:
+
+```
+┌─────────────────────────────────────────────┐
+│           Entry Points                       │
+│   CLI (Commander.js)  MCP Server  REST API   │
+└──────────────────┬──────────────────────────┘
+                   │
+┌──────────────────▼──────────────────────────┐
+│           Core Business Logic                │
+│  indexing · search · rag · documents · ...   │
+└──────────────────┬──────────────────────────┘
+                   │
+┌──────────────────▼──────────────────────────┐
+│          Infrastructure                      │
+│   db/ (SQLite)      providers/ (embeddings)  │
+└─────────────────────────────────────────────┘
+```
+
+**Entry points** (`src/cli/`, `src/mcp/`, `src/api/`) are thin adapters. They parse input, call core functions, and format output. They contain no business logic.
+
+**Core** (`src/core/`) contains all business logic. Core modules are plain TypeScript functions — they don't know whether they were called from the CLI, an MCP tool, or the REST API.
+
+**Infrastructure** (`src/db/`, `src/providers/`) handles persistence and external services. The database layer uses better-sqlite3 (synchronous). The provider layer abstracts embedding models behind a common interface.
+
+## Module Map
+
+```
+src/
+├── cli/
+│   ├── index.ts              # main CLI entry (#!/usr/bin/env node)
+│   └── commands/             # each file exports registerCommands(program)
+├── mcp/
+│   ├── server.ts             # MCP entry point — registers all tools
+│   ├── tools/                # each file exports registerTools(server, db, provider)
+│   └── errors.ts             # withErrorHandling() wrapper for MCP tool handlers
+├── api/
+│   ├── server.ts             # Express app factory
+│   ├── routes/               # route handlers
+│   └── openapi.ts            # OpenAPI 3.0 spec
+├── web/
+│   ├── server.ts             # HTTP server (port 3377)
+│   ├── dashboard.ts          # self-contained dashboard HTML
+│   └── graph-api.ts          # knowledge graph data API
+├── core/
+│   ├── indexing.ts           # document chunking and embedding
+│   ├── search.ts             # hybrid vector + FTS5 search
+│   ├── rag.ts                # LLM-based question answering
+│   ├── documents.ts          # document CRUD
+│   ├── versioning.ts         # document version history
+│   ├── topics.ts             # topic hierarchy
+│   ├── tags.ts               # tag management and auto-suggest
+│   ├── links.ts              # cross-document references
+│   ├── ratings.ts            # document/chunk ratings
+│   ├── dedup.ts              # duplicate detection
+│   ├── bulk.ts               # bulk operations
+│   ├── analytics.ts          # search analytics, knowledge gaps
+│   ├── graph.ts              # knowledge graph with cluster detection
+│   ├── packs.ts              # knowledge pack create/install
+│   ├── batch.ts              # parallel batch import
+│   ├── batch-search.ts       # concurrent multi-query search
+│   ├── url-fetcher.ts        # HTTP fetch with retry, proxy, cert handling
+│   ├── spider.ts             # recursive web crawler
+│   ├── link-extractor.ts     # extract links from HTML/Markdown/Wikilinks
+│   ├── repo.ts               # GitHub/GitLab repo cloning and indexing
+│   ├── watcher.ts            # file system watching for auto-reindex
+│   ├── reindex.ts            # re-embedding after provider switch
+│   ├── scheduler.ts          # background task scheduling
+│   ├── webhooks.ts           # event webhooks with HMAC signing
+│   ├── saved-searches.ts     # named query persistence
+│   ├── workspace.ts          # workspace isolation
+│   ├── export.ts             # full knowledge base backup/restore
+│   ├── ttl.ts                # document expiry management
+│   └── parsers/              # file format parsers
+│       ├── markdown.ts       # Markdown + MDX
+│       ├── text.ts           # plain text
+│       ├── pdf.ts            # PDF (optional: pdf-parse)
+│       ├── word.ts           # DOCX (optional: mammoth)
+│       ├── epub.ts           # EPUB (optional: epub2)
+│       ├── pptx.ts           # PowerPoint (optional: pizzip)
+│       ├── html.ts           # HTML
+│       ├── csv.ts            # CSV
+│       ├── json-parser.ts    # JSON
+│       └── yaml.ts           # YAML
+├── db/
+│   ├── connection.ts         # SQLite connection factory (WAL mode, sqlite-vec)
+│   └── schema.ts             # SCHEMA_VERSION, MIGRATIONS, createSchema()
+├── providers/
+│   ├── index.ts              # EmbeddingProvider interface + factory
+│   ├── local.ts              # @xenova/transformers (all-MiniLM-L6-v2)
+│   ├── ollama.ts             # Ollama HTTP API
+│   └── openai.ts             # OpenAI embeddings API
+├── registry/
+│   ├── types.ts              # RegistryEntry, PackSummary, PackManifest
+│   ├── config.ts             # registry list in ~/.libscope/config.json
+│   ├── git.ts                # git clone/pull/commit/push
+│   ├── sync.ts               # registry syncing with auto-sync intervals
+│   ├── search.ts             # pack search across registries
+│   ├── resolve.ts            # pack resolution (version conflicts)
+│   ├── publish.ts            # publishing packs to registries
+│   └── checksum.ts           # SHA-256 verification
+├── connectors/
+│   ├── obsidian.ts           # Obsidian vault sync
+│   ├── notion.ts             # Notion API sync
+│   ├── confluence.ts         # Confluence API sync
+│   ├── slack.ts              # Slack API sync
+│   ├── onenote.ts            # Microsoft Graph API sync
+│   ├── http-utils.ts         # shared retry logic with exponential backoff
+│   └── sync-tracker.ts       # sync history and status in database
+├── config.ts                 # loadConfig() — merges env, project, user, defaults
+├── errors.ts                 # LibScopeError hierarchy
+├── logger.ts                 # pino logger with child logger support
+└── LibScope.ts               # main public API class
+```
+
+## Key Design Patterns
+
+### Error Hierarchy
+
+All errors extend `LibScopeError`, which carries a `code` string and an optional `cause`:
+
+```typescript
+// src/errors.ts
+class LibScopeError extends Error {
+  constructor(message: string, public readonly code: string, options?: ErrorOptions)
+}
+
+// Subclasses:
+DatabaseError        // SQLite failures
+EmbeddingError       // provider failures
+ValidationError      // bad input
+FetchError           // HTTP fetch failures
+ConfigError          // misconfiguration
+DocumentNotFoundError
+ChunkNotFoundError
+TopicNotFoundError
+```
+
+Always throw the most specific subclass. MCP tool handlers must be wrapped with `withErrorHandling()` from `src/mcp/errors.ts` — this converts `LibScopeError` to well-structured MCP error responses.
+
+### Embedding Provider Interface
+
+All embedding providers implement the same interface:
+
+```typescript
+interface EmbeddingProvider {
+  readonly dimensions: number;
+  embed(texts: string[]): Promise<number[][]>;
+}
+```
+
+The factory function in `src/providers/index.ts` returns the correct implementation based on config. Core modules accept an `EmbeddingProvider` and never import a specific provider directly — this makes them testable with the `MockEmbeddingProvider` fixture.
+
+### Database Migrations
+
+Schema migrations in `src/db/schema.ts` follow this pattern:
+
+```typescript
+export const SCHEMA_VERSION = 17;
+
+export const MIGRATIONS: Record<number, string> = {
+  1: "CREATE TABLE ...",
+  // ...
+  17: "ALTER TABLE chunks ADD COLUMN ...",
+};
+```
+
+To add a migration: increment `SCHEMA_VERSION` and add a new entry in `MIGRATIONS` with the new version number as the key. `createSchema()` runs all missing migrations on startup.
+
+### Configuration Merging
+
+`loadConfig()` in `src/config.ts` merges four tiers, highest priority first:
+
+1. Environment variables (`LIBSCOPE_*`)
+2. Project `.libscope.json` (current working directory)
+3. User `~/.libscope/config.json`
+4. Defaults
+
+The result is cached for 30 seconds to avoid repeated file reads. Configuration is passed down to core modules — they never read environment variables directly.
+
+### Connectors Pattern
+
+Each connector in `src/connectors/` follows the same structure:
+
+1. **Auth config** stored in `~/.libscope/connectors/<name>.json` (permissions 0o600)
+2. **Incremental sync** tracked via `sync-tracker.ts` (last sync timestamp in DB)
+3. **Retry logic** from `http-utils.ts` (exponential backoff, configurable retries)
+4. **Disconnect** removes all documents with matching `sourceType` + source identifier
+
+## Data Flow: Indexing
+
+When you index a document (`libscope add` or `submit-document` MCP tool):
+
+```
+Input (file/URL/text)
+  → Parser (markdown.ts / html.ts / pdf.ts / ...)
+  → Raw text
+  → Chunker (indexing.ts) — paragraph-aware, heading breadcrumbs, overlap
+  → Chunks[]
+  → EmbeddingProvider.embed(chunks)
+  → Vectors[]
+  → DB: documents table + chunks table + chunk_embeddings (vector) + chunks_fts (FTS5)
+```
+
+The chunker in `src/core/indexing.ts` splits on paragraph boundaries while respecting heading structure. Each chunk carries a breadcrumb of its parent headings so context is preserved across chunk boundaries.
+
+## Data Flow: Search
+
+```
+Query string
+  → EmbeddingProvider.embed([query]) → query vector
+  ↓
+  ┌── Vector search (sqlite-vec ANN cosine similarity) → ranked chunks
+  │
+  └── FTS5 search (BM25, AND then OR fallback) → ranked chunks
+  ↓
+Reciprocal Rank Fusion (RRF, k=60) → merged ranked list
+  ↓
+Title boost (1.5× if title contains query words)
+  ↓
+MMR diversity reranking (optional, diversity param 0–1)
+  ↓
+Filter by: library, topic, tags, minRating, maxChunksPerDocument
+  ↓
+Paginate (limit, offset)
+  ↓
+Results with scoreExplanation
+```
+
+See [How Search Works](/guide/how-search-works) for more detail.
+
+## Data Flow: RAG (Ask)
+
+```
+Question
+  → search() — retrieve top-K relevant chunks
+  → Build context string from chunks
+  → LLM prompt: "Answer based only on this context: ..."
+  → LLM response (streaming or buffered)
+  → Return { text, sources: cited chunks }
+```
+
+The LLM integration in `src/core/rag.ts` supports OpenAI, Ollama, Anthropic, and a `passthrough` mode where the application handles the LLM call externally.
+
+## Database Schema
+
+Key tables (schema version 17):
+
+| Table              | Purpose                                            |
+| ------------------ | -------------------------------------------------- |
+| `documents`        | Document metadata: title, content, library, topic  |
+| `chunks`           | Document chunks: content, chunk_index, document_id |
+| `chunk_embeddings` | Vector table (sqlite-vec): embedding per chunk     |
+| `chunks_fts`       | FTS5 virtual table: full-text search index         |
+| `topics`           | Topic hierarchy (id, name, parent_id)              |
+| `tags`             | Tag definitions                                    |
+| `document_tags`    | Many-to-many document ↔ tag                        |
+| `ratings`          | Document and chunk ratings (1–5)                   |
+| `document_versions`| Version history for rollback                       |
+| `document_links`   | Typed cross-references between documents           |
+| `search_log`       | Query analytics                                    |
+| `document_hits`    | Per-document result hit analytics                  |
+| `saved_searches`   | Named query persistence                            |
+| `connector_configs`| Connector state (tokens, last sync)                |
+| `webhooks`         | Event webhook configuration                        |
+| `schema_version`   | Current migration version                          |
+
+## How to Add a New CLI Command
+
+1. Add a new file in `src/cli/commands/` (or add to an existing file)
+2. Export a `registerCommands(program: Command): void` function
+3. Import and call it in `src/cli/index.ts`
+4. Call the appropriate `src/core/` functions — don't implement logic in the CLI layer
+
+Example skeleton:
+
+```typescript
+// src/cli/commands/my-feature.ts
+import { Command } from "commander";
+import { myFeatureCore } from "../../core/my-feature.js";
+import { getDb } from "../../db/connection.js";
+
+export function registerCommands(program: Command): void {
+  program
+    .command("my-feature <arg>")
+    .description("Does something useful")
+    .option("--flag <value>", "An option")
+    .action(async (arg, opts) => {
+      const db = getDb();
+      const result = await myFeatureCore(db, arg, opts);
+      console.log(result);
+    });
+}
+```
+
+## How to Add a New MCP Tool
+
+1. Add the tool in an existing file under `src/mcp/tools/` (or create a new file)
+2. Register the tool via `server.tool(name, description, schema, handler)`
+3. Wrap the handler with `withErrorHandling()` from `src/mcp/errors.ts`
+4. Export a `registerTools(server, db, provider)` function and call it in `src/mcp/server.ts`
+
+Example skeleton:
+
+```typescript
+import { withErrorHandling } from "../errors.js";
+import { z } from "zod";
+
+export function registerTools(server, db, provider) {
+  server.tool(
+    "my-tool",
+    "Does something useful",
+    { param: z.string().describe("A parameter") },
+    withErrorHandling(async ({ param }) => {
+      const result = await myCore(db, param);
+      return { content: [{ type: "text", text: JSON.stringify(result) }] };
+    }),
+  );
+}
+```
+
+## How to Add a New Connector
+
+1. Create `src/connectors/my-connector.ts`
+2. Use `http-utils.ts` for HTTP calls with retry
+3. Track sync state with `sync-tracker.ts`
+4. Store auth config in `~/.libscope/connectors/my-connector.json` (chmod 0o600)
+5. Add a CLI command in `src/cli/commands/` under the `connect` subcommand
+6. Add an MCP tool in `src/mcp/tools/`
+
+## How to Add a New Embedding Provider
+
+1. Create `src/providers/my-provider.ts` implementing `EmbeddingProvider`
+2. Export a class with `dimensions: number` and `embed(texts: string[]): Promise<number[][]>`
+3. Add it to the provider factory in `src/providers/index.ts`
+4. Add the provider name to the config type in `src/config.ts`
+
+## Testing Approach
+
+```typescript
+import { createTestDb } from "../fixtures/test-db.js";
+import { MockEmbeddingProvider } from "../fixtures/mock-provider.js";
+import { insertDoc, insertChunk, seedTestDocument } from "../fixtures/helpers.js";
+
+// Fresh in-memory DB with all migrations applied
+const db = createTestDb();
+
+// Deterministic 4-dimensional vectors — no real embedding model required
+const provider = new MockEmbeddingProvider();
+```
+
+- **Unit tests** (`tests/unit/`) — mock all dependencies, test one module at a time, run fast
+- **Integration tests** (`tests/integration/`) — real SQLite DB, full indexing → search → rate workflow
+- Use `createTestDbWithVec()` when you need the vector table (requires sqlite-vec)
+
+Coverage thresholds enforced in CI: 75% statements, 74% branches, 75% functions, 75% lines.

--- a/docs/guide/dashboard.md
+++ b/docs/guide/dashboard.md
@@ -1,0 +1,93 @@
+# Web Dashboard
+
+LibScope includes a local web dashboard for browsing, searching, and managing your knowledge base without the CLI.
+
+## Starting the Dashboard
+
+```bash
+libscope serve --dashboard
+```
+
+This starts an HTTP server at `http://localhost:3377` by default.
+
+```bash
+# Use a custom port
+libscope serve --dashboard --port 8080
+
+# Bind to all interfaces (for LAN access)
+libscope serve --dashboard --host 0.0.0.0 --port 3377
+```
+
+The dashboard is fully self-contained — no external CDN dependencies.
+
+## Features
+
+### Search
+
+The top search bar performs live semantic search as you type. Results update with each query and include:
+
+- Document title and library
+- Matching chunk excerpt with highlighted terms
+- Relevance score and scoring method (hybrid / vector / fts5)
+- Topic breadcrumb
+
+Click any result to open the full document.
+
+### Document Browser
+
+The **Documents** tab lists all indexed documents. You can:
+
+- Filter by library, topic, or tag using the sidebar controls
+- Sort by title, date added, or rating
+- Click a document to view its full content and metadata
+- See incoming and outgoing cross-reference links
+
+### Topic Navigation
+
+The **Topics** panel shows your topic hierarchy. Clicking a topic filters the document list to that topic and its subtopics.
+
+### Knowledge Graph
+
+Navigate to `/graph` (e.g. `http://localhost:3377/graph`) to view an interactive visualization of your knowledge base:
+
+- **Nodes** represent documents
+- **Edges** represent cross-reference links (`link-documents`, `libscope link`)
+- **Clusters** are automatically detected and color-coded by topic
+- Hover a node to see the document title; click to open it in the document browser
+
+The graph is useful for discovering how your documents relate to each other and for finding isolated documents that have no connections.
+
+### Light / Dark Mode
+
+Click the sun/moon icon in the top-right corner to toggle between light and dark mode. The preference is saved in `localStorage`.
+
+## Rate Limiting
+
+The dashboard server applies per-IP rate limiting to prevent abuse when exposed on a network. The defaults are generous for local use; if you hit limits, restart with `--host localhost` to restrict access to your machine.
+
+## Running Alongside the MCP Server
+
+The dashboard and MCP server run on different ports and can be started independently:
+
+```bash
+# Dashboard in one terminal
+libscope serve --dashboard --port 3377
+
+# MCP server in another (or configured in your AI client)
+libscope serve
+```
+
+Or run the REST API and use it as the dashboard's data source:
+
+```bash
+libscope serve --api --port 3378
+libscope serve --dashboard --port 3377
+```
+
+## Security Considerations
+
+The dashboard is designed for **local use only**. If you expose it on a network:
+
+- Use `--host` carefully — binding to `0.0.0.0` exposes it to all network interfaces
+- Consider putting it behind a reverse proxy (nginx, Caddy) with authentication
+- The REST API (`--api`) does require an `X-API-Key` header for write operations; the dashboard uses the same key automatically when running on the same host

--- a/docs/guide/mcp-setup.md
+++ b/docs/guide/mcp-setup.md
@@ -80,7 +80,7 @@ If you're using [workspaces](/guide/configuration#workspaces), pass the workspac
 
 ## Available Tools
 
-Once connected, your AI assistant gets access to all 26 of LibScope's MCP tools. See the [MCP Tools Reference](/reference/mcp-tools) for full parameter details.
+Once connected, your AI assistant gets access to all 31 of LibScope's MCP tools. See the [MCP Tools Reference](/reference/mcp-tools) for full parameter details.
 
 **Search & Q&A**
 - **`search-docs`** — semantic search with topic/library/version/rating filters
@@ -105,6 +105,10 @@ Once connected, your AI assistant gets access to all 26 of LibScope's MCP tools.
 - **`save-search`** — save a named query with filters
 - **`list-saved-searches`** — list saved searches
 - **`run-saved-search`** — execute a saved search
+- **`delete-saved-search`** — delete a saved search
+
+**Similar Content**
+- **`get-related`** — find chunks semantically similar to a given chunk
 
 **Connectors** — trigger syncs directly from your AI assistant:
 - **`sync-obsidian-vault`**, **`sync-notion`**, **`sync-confluence`**, **`sync-slack`**, **`sync-onenote`**

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -90,3 +90,152 @@ LibScope uses SQLite WAL mode which supports concurrent reads but only one write
 ```bash
 libscope db reset    # removes all indexed content (keeps config)
 ```
+
+---
+
+## Connector Issues
+
+### Notion sync returns no pages
+
+- Verify your integration token has access to the pages you want to sync — in Notion, you must explicitly share pages with your integration
+- Check that the token starts with `secret_` (internal integrations) or is a valid OAuth token
+- Try syncing a specific page ID first: `libscope connect notion --token $NOTION_TOKEN`
+
+### Confluence sync fails with 401
+
+- Ensure you are using an API token (not your password) — generate one at [id.atlassian.com](https://id.atlassian.com/manage-profile/security/api-tokens)
+- The `--email` flag must match the Atlassian account that owns the token
+- Verify the `--url` uses your full Atlassian domain: `https://your-org.atlassian.net`
+
+### Slack sync fails with `missing_scope` error
+
+Your Slack bot token is missing required OAuth scopes. Add the following in your Slack app settings under **OAuth & Permissions**:
+
+- `channels:history`
+- `channels:read`
+- `groups:history` (for private channels)
+- `users:read` (for author names)
+
+Reinstall the app to your workspace after adding scopes.
+
+### OneNote sync prompts for authentication every time
+
+OneNote uses device code auth which caches a refresh token. If the cache is missing or expired:
+
+1. Ensure `ONENOTE_CLIENT_ID` is set to your Azure AD app registration client ID
+2. The token is cached in `~/.libscope/connectors/onenote.json` — delete this file to force re-authentication
+3. Ensure your app registration has `Notes.Read` (or `Notes.ReadWrite`) permission granted in Azure
+
+### Obsidian sync misses some notes
+
+- Check your `--exclude` patterns — glob patterns use `/` as separator even on Windows
+- Obsidian notes in the `.obsidian/` config folder are automatically excluded
+- Notes without the `.md` extension are skipped; check your vault for unusual extensions
+
+---
+
+## REST API Issues
+
+### `401 Unauthorized` from API
+
+The REST API requires an `X-API-Key` header for write operations. Retrieve your key:
+
+```bash
+libscope config show
+```
+
+Then include it in requests:
+
+```bash
+curl -H "X-API-Key: <your-key>" http://localhost:3378/api/v1/documents
+```
+
+### `429 Too Many Requests`
+
+The API applies rate limiting per IP. If you're hitting limits during bulk operations, use the batch endpoints:
+
+- `POST /api/v1/batch-search` — up to 20 queries at once
+- `POST /api/v1/bulk/delete`, `/bulk/retag`, `/bulk/move` — process many documents in one request
+
+### CORS errors when calling from a browser
+
+The REST API allows CORS by default for localhost origins. If you're calling from a different origin, you can either:
+
+- Run your frontend on the same host as the API
+- Use a reverse proxy that adds the appropriate `Access-Control-Allow-Origin` header
+
+---
+
+## Indexing Issues
+
+### PDF or DOCX files are not indexed
+
+Optional parser dependencies may not be installed. Install them:
+
+```bash
+npm install -g pdf-parse   # for .pdf files
+npm install -g mammoth     # for .docx files
+npm install -g epub2       # for .epub files
+```
+
+Or install all optional parsers at once:
+
+```bash
+npm install -g libscope --include=optional
+```
+
+### URL indexing fails with SSL errors
+
+If you are fetching from a server with a self-signed certificate:
+
+```bash
+libscope config set indexing.allowSelfSignedCerts true
+# or
+export LIBSCOPE_ALLOW_SELF_SIGNED_CERTS=true
+```
+
+For internal/private URLs (RFC 1918 address ranges):
+
+```bash
+libscope config set indexing.allowPrivateUrls true
+# or
+export LIBSCOPE_ALLOW_PRIVATE_URLS=true
+```
+
+### Import is very slow for large directories
+
+Use `import-batch` with parallelism instead of `import`:
+
+```bash
+libscope import-batch ./docs/ --concurrency 8 --library my-lib
+```
+
+The default `import` command is sequential. `import-batch` processes files in parallel.
+
+---
+
+## LLM / RAG Issues
+
+### `ask` returns "No LLM provider configured"
+
+The `ask` command requires an LLM provider. Configure one:
+
+```bash
+# OpenAI
+libscope config set llm.provider openai
+export LIBSCOPE_OPENAI_API_KEY=sk-...
+
+# Ollama (must be running locally)
+libscope config set llm.provider ollama
+
+# Anthropic
+libscope config set llm.provider anthropic
+export LIBSCOPE_ANTHROPIC_API_KEY=sk-ant-...
+```
+
+### Answers are low quality or hallucinated
+
+- Index more relevant documents — the quality of RAG answers depends on what's in the knowledge base
+- Increase `--top-k` to retrieve more context chunks: `libscope ask "..." --top-k 10`
+- Switch to a more capable embedding provider (OpenAI `text-embedding-3-small` outperforms the local model)
+- Switch to a more capable LLM model: `libscope config set llm.model gpt-4o`

--- a/docs/guide/webhooks.md
+++ b/docs/guide/webhooks.md
@@ -1,0 +1,155 @@
+# Webhooks
+
+LibScope can send HTTP POST notifications to external URLs when documents are created, updated, or deleted. This lets you integrate LibScope with CI pipelines, Slack bots, or any other HTTP-capable service.
+
+## Creating a Webhook
+
+### Via REST API
+
+```bash
+curl -X POST http://localhost:3378/api/v1/webhooks \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://hooks.example.com/libscope",
+    "events": ["document.created", "document.updated", "document.deleted"],
+    "secret": "my-hmac-secret"
+  }'
+```
+
+### Via CLI
+
+Webhook management is available through the REST API only. Start the API server first:
+
+```bash
+libscope serve --api --port 3378
+```
+
+## Supported Events
+
+| Event               | Fired when                                     |
+| ------------------- | ---------------------------------------------- |
+| `document.created`  | A new document is indexed                      |
+| `document.updated`  | A document's content or metadata is updated    |
+| `document.deleted`  | A document is deleted                          |
+
+## Payload Format
+
+Every webhook delivery sends a `POST` request with `Content-Type: application/json`. The body is a JSON object:
+
+```json
+{
+  "event": "document.created",
+  "timestamp": "2026-03-18T12:00:00.000Z",
+  "data": {
+    "id": "doc_abc123",
+    "title": "Auth Guide",
+    "library": "my-lib",
+    "version": "2.0.0",
+    "topic": "security",
+    "sourceType": "manual",
+    "url": null,
+    "createdAt": "2026-03-18T12:00:00.000Z",
+    "updatedAt": "2026-03-18T12:00:00.000Z"
+  }
+}
+```
+
+For `document.deleted`, the `data` object contains only `id` and `title`.
+
+## Verifying Signatures
+
+When you create a webhook with a `secret`, LibScope signs every delivery with HMAC-SHA256. The signature is sent in the `X-LibScope-Signature` header:
+
+```
+X-LibScope-Signature: sha256=abc123...
+```
+
+To verify in Node.js:
+
+```typescript
+import { createHmac, timingSafeEqual } from "crypto";
+
+function verifySignature(secret: string, body: string, header: string): boolean {
+  const expected = "sha256=" + createHmac("sha256", secret).update(body).digest("hex");
+  const received = Buffer.from(header);
+  const expectedBuf = Buffer.from(expected);
+  if (received.length !== expectedBuf.length) return false;
+  return timingSafeEqual(received, expectedBuf);
+}
+
+// Express example
+app.post("/webhook", (req, res) => {
+  const rawBody = JSON.stringify(req.body); // or use express.raw()
+  const sig = req.headers["x-libscope-signature"] as string;
+  if (!verifySignature("my-hmac-secret", rawBody, sig)) {
+    return res.status(401).send("Invalid signature");
+  }
+  // handle event
+  res.status(200).send("ok");
+});
+```
+
+Use `timingSafeEqual` to prevent timing attacks — never use `===` for comparing signatures.
+
+## Testing a Webhook
+
+Send a test ping to verify your endpoint is reachable:
+
+```bash
+curl -X POST http://localhost:3378/api/v1/webhooks/<webhook-id>/test
+```
+
+This sends a `POST` to your webhook URL with `event: "ping"` and no `data` payload.
+
+## Managing Webhooks
+
+```bash
+# List all webhooks
+curl http://localhost:3378/api/v1/webhooks
+
+# Delete a webhook
+curl -X DELETE http://localhost:3378/api/v1/webhooks/<webhook-id>
+```
+
+## Delivery Behavior
+
+- Deliveries are attempted synchronously as part of the request that triggered the event
+- Failed deliveries (non-2xx response or network error) are logged but not retried automatically
+- Webhook secrets are stored hashed and cannot be retrieved after creation — store them securely
+
+## Example: Notify Slack on New Documents
+
+Create a Slack incoming webhook at `https://api.slack.com/messaging/webhooks`, then write a small relay:
+
+```typescript
+// relay.ts — receives LibScope events, forwards to Slack
+import express from "express";
+import fetch from "node-fetch";
+
+const app = express();
+app.use(express.json());
+
+app.post("/relay", async (req, res) => {
+  const { event, data } = req.body;
+  if (event === "document.created") {
+    await fetch(process.env.SLACK_WEBHOOK_URL!, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        text: `New doc indexed: *${data.title}* (library: ${data.library ?? "—"})`,
+      }),
+    });
+  }
+  res.status(200).send("ok");
+});
+
+app.listen(4000);
+```
+
+Then register the relay as a LibScope webhook:
+
+```bash
+curl -X POST http://localhost:3378/api/v1/webhooks \
+  -H "Content-Type: application/json" \
+  -d '{"url": "http://localhost:4000/relay", "events": ["document.created"]}'
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ features:
     details: Vector similarity search powered by sqlite-vec, with FTS5 full-text fallback. Find what you need, even when you don't know the exact words.
   - icon: 🤖
     title: MCP Integration
-    details: 26 tools for AI assistants out of the box. Works with Claude, Cursor, VS Code, and any MCP-compatible client.
+    details: 31 tools for AI assistants out of the box. Works with Claude, Cursor, VS Code, and any MCP-compatible client.
   - icon: 🔗
     title: Connectors
     details: Pull in docs from Obsidian, Notion, Confluence, Slack, OneNote, and GitHub/GitLab. Keep everything in one place.

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -83,19 +83,16 @@ Update an existing document's title, content, or metadata. Changing content trig
 | `url`        | string |          | New source URL (pass `null` to clear)   |
 | `topicId`    | string |          | New topic ID (pass `null` to clear)     |
 
-## update-document
+## get-related
 
-Update an existing document's title, content, or metadata. Changing content triggers re-chunking and re-embedding.
+Find document chunks that are semantically similar to a given chunk (more-like-this).
 
-| Parameter    | Type   | Required | Description                             |
-| ------------ | ------ | -------- | --------------------------------------- |
-| `documentId` | string | ✅       | The document ID to update               |
-| `title`      | string |          | New title                               |
-| `content`    | string |          | New content (triggers re-chunking)      |
-| `library`    | string |          | New library name (pass `null` to clear) |
-| `version`    | string |          | New version (pass `null` to clear)      |
-| `url`        | string |          | New source URL (pass `null` to clear)   |
-| `topicId`    | string |          | New topic ID (pass `null` to clear)     |
+| Parameter   | Type   | Required | Description                        |
+| ----------- | ------ | -------- | ---------------------------------- |
+| `chunkId`   | string | ✅       | The source chunk ID                |
+| `limit`     | number |          | Max results (default: 10)          |
+| `library`   | string |          | Filter results by library          |
+| `topic`     | string |          | Filter results by topic            |
 
 ## rate-document
 


### PR DESCRIPTION
- Add architecture guide (docs/guide/architecture.md) explaining system layers, module map, key design patterns, data flows, and how-to guides for adding CLI commands, MCP tools, connectors, and embedding providers
- Add web dashboard guide (docs/guide/dashboard.md) covering startup, search, document browser, topic navigation, knowledge graph, and security considerations
- Add webhooks guide (docs/guide/webhooks.md) covering event types, payload format, HMAC signature verification, and a Slack example
- Enhance contributing guide with design principles and expanded project structure, linking to the new architecture guide
- Expand troubleshooting guide with connector-specific issues (Notion, Confluence, Slack, OneNote, Obsidian), REST API issues, indexing issues, and LLM/RAG issues
- Fix duplicate update-document section in MCP tools reference
- Add missing get-related MCP tool to reference and mcp-setup docs
- Fix incorrect tool count (26 → 31) in mcp-setup.md and index.md
- Update VitePress sidebar to include new dashboard, webhooks, and architecture pages

Closes #415

https://claude.ai/code/session_01XX42U8C37gcSUqnRz94j2W