### PR TITLE
refactor: decompose src/api/routes.ts (complexity 306 → ≤15)

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -692,13 +692,11 @@ function extractOptionalString(
   key: string,
 ): string | null | undefined {
   if (body[key] === undefined) return undefined;
-  return typeof body[key] === "string" ? (body[key] as string) : null;
+  return typeof body[key] === "string" ? body[key] : null;
 }
 
 /** Parse metadata fields from an update request body. */
-function parseUpdateMetadata(
-  body: Record<string, unknown>,
-):
+function parseUpdateMetadata(body: Record<string, unknown>):
   | {
       library?: string | null;
       version?: string | null;
@@ -961,6 +959,27 @@ function isBulkPath(segments: string[]): boolean {
 // Segment-based route dispatcher (document/:id, links, searches, webhooks, bulk)
 // ---------------------------------------------------------------------------
 
+/** Dispatch single-document CRUD routes (GET/DELETE/PATCH /documents/:id). */
+async function dispatchDocumentCrudRoutes(
+  ctx: RouteContext,
+  docId: string,
+  method: string,
+): Promise<boolean> {
+  if (method === "GET") {
+    handleGetDocument(ctx, docId);
+    return true;
+  }
+  if (method === "DELETE") {
+    handleDeleteDocument(ctx, docId);
+    return true;
+  }
+  if (method === "PATCH") {
+    await handleUpdateDocument(ctx, docId);
+    return true;
+  }
+  return false;
+}
+
 /** Dispatch document-related segment routes (tags, suggest, CRUD, links). */
 async function dispatchDocumentRoutes(
   ctx: RouteContext,
@@ -978,18 +997,7 @@ async function dispatchDocumentRoutes(
     return true;
   }
   const docId = matchDocumentId(segments);
-  if (docId && method === "GET") {
-    handleGetDocument(ctx, docId);
-    return true;
-  }
-  if (docId && method === "DELETE") {
-    handleDeleteDocument(ctx, docId);
-    return true;
-  }
-  if (docId && method === "PATCH") {
-    await handleUpdateDocument(ctx, docId);
-    return true;
-  }
+  if (docId) return dispatchDocumentCrudRoutes(ctx, docId, method);
   const linksDocId = matchDocumentLinks(segments);
   if (linksDocId && method === "GET") {
     handleGetDocumentLinks(ctx, linksDocId);
@@ -1002,6 +1010,33 @@ async function dispatchDocumentRoutes(
   const linkId = matchLinkId(segments);
   if (linkId && method === "DELETE") {
     handleDeleteLink(ctx, linkId);
+    return true;
+  }
+  return false;
+}
+
+/** Dispatch webhook segment routes. */
+async function dispatchWebhookRoutes(
+  ctx: RouteContext,
+  segments: string[],
+  method: string,
+): Promise<boolean> {
+  if (isApiV1Path(segments, "webhooks") && method === "GET") {
+    handleListWebhooks(ctx);
+    return true;
+  }
+  if (isApiV1Path(segments, "webhooks") && method === "POST") {
+    await handleCreateWebhook(ctx);
+    return true;
+  }
+  const webhookTestId = matchWebhookTest(segments);
+  if (webhookTestId && method === "POST") {
+    await handleTestWebhook(ctx, webhookTestId);
+    return true;
+  }
+  const webhookId = matchWebhookId(segments);
+  if (webhookId && method === "DELETE") {
+    handleDeleteWebhook(ctx, webhookId);
     return true;
   }
   return false;
@@ -1036,25 +1071,7 @@ async function dispatchMiscSegmentRoutes(
     handleDeleteSavedSearch(ctx, savedSearchId);
     return true;
   }
-  if (isApiV1Path(segments, "webhooks") && method === "GET") {
-    handleListWebhooks(ctx);
-    return true;
-  }
-  if (isApiV1Path(segments, "webhooks") && method === "POST") {
-    await handleCreateWebhook(ctx);
-    return true;
-  }
-  const webhookTestId = matchWebhookTest(segments);
-  if (webhookTestId && method === "POST") {
-    await handleTestWebhook(ctx, webhookTestId);
-    return true;
-  }
-  const webhookId = matchWebhookId(segments);
-  if (webhookId && method === "DELETE") {
-    handleDeleteWebhook(ctx, webhookId);
-    return true;
-  }
-  return false;
+  return dispatchWebhookRoutes(ctx, segments, method);
 }
 
 async function dispatchSegmentRoutes(


### PR DESCRIPTION
## Summary

- Decomposed the monolithic `handleRequest` function in `src/api/routes.ts` (cognitive complexity 306, 20x over the threshold of 15) into ~35 small, focused handler functions
- Introduced a `RouteContext` interface to bundle common parameters (`req`, `res`, `db`, `provider`, `url`, `start`) and eliminate repetitive argument passing
- Extracted shared parameter-parsing helpers: `parseOptionalInt`, `parseClampedInt`, `parseClampedIntOrUndefined`, `elapsed`, `requireJsonBody`
- Split routing into two dispatcher functions (`dispatchPathnameRoutes` for simple paths, `dispatchSegmentRoutes` for parameterized paths) to keep the main `handleRequest` under 15 complexity
- Extracted error classification into `handleRouteError`

### Extracted handler functions

| Handler | Endpoint |
|---------|----------|
| `handleOpenApiSpec` | `GET /openapi.json` |
| `handleHealthCheck` | `GET /api/v1/health` |
| `handleSearch` | `GET /api/v1/search` |
| `handleBatchSearch` | `POST /api/v1/batch-search` |
| `handleListDocuments` | `GET /api/v1/documents` |
| `handleCreateDocument` | `POST /api/v1/documents` |
| `handleIndexFromUrl` | `POST /api/v1/documents/url` |
| `handleSpiderUrl` | (sub-handler for spider mode) |
| `handleAsk` | `POST /api/v1/ask` |
| `handleAskStream` | (sub-handler for SSE streaming) |
| `handleListTopics` | `GET /api/v1/topics` |
| `handleCreateTopic` | `POST /api/v1/topics` |
| `handleListTags` | `GET /api/v1/tags` |
| `handleAddTagsToDocument` | `POST /api/v1/documents/:id/tags` |
| `handleSuggestTags` | `GET /api/v1/documents/:id/suggest-tags` |
| `handleSearchAnalytics` | `GET /api/v1/analytics/searches` |
| `handleConnectorStatus` | `GET /api/v1/connectors/status` |
| `handleScheduleStatus` | `GET /api/v1/connectors/schedules` |
| `handleStats` | `GET /api/v1/stats` |
| `handleGetDocument` | `GET /api/v1/documents/:id` |
| `handleDeleteDocument` | `DELETE /api/v1/documents/:id` |
| `handleUpdateDocument` | `PATCH /api/v1/documents/:id` |
| `handleGetDocumentLinks` | `GET /api/v1/documents/:id/links` |
| `handleCreateDocumentLink` | `POST /api/v1/documents/:id/links` |
| `handleDeleteLink` | `DELETE /api/v1/links/:id` |
| `handleRunSavedSearch` | `POST /api/v1/searches/:id/run` |
| `handleListSavedSearches` | `GET /api/v1/searches` |
| `handleCreateSavedSearch` | `POST /api/v1/searches` |
| `handleDeleteSavedSearch` | `DELETE /api/v1/searches/:id` |
| `handleBulkOperation` | `POST /api/v1/bulk/:operation` |
| `handleListWebhooks` | `GET /api/v1/webhooks` |
| `handleCreateWebhook` | `POST /api/v1/webhooks` |
| `handleTestWebhook` | `POST /api/v1/webhooks/:id/test` |
| `handleDeleteWebhook` | `DELETE /api/v1/webhooks/:id` |

### Validation helpers extracted
- `validateUrlMetadata` — URL scheme validation for PATCH
- `validatePositiveInt` / `validateNonNegativeInt` — spider option validation
- `buildSpiderOptions` — spider option assembly

## Test plan

- [x] All 72 API unit tests pass (`api.test.ts` + `api-server.test.ts`)
- [x] Full test suite passes (1351 tests, 73 files)
- [x] TypeScript typecheck passes (no new errors)
- [x] Prettier formatting applied

Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)