### PR TITLE
refactor: reduce cognitive complexity in src/cli/

### DIFF
--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -99,6 +99,62 @@ async function syncAllRegistriesAction(): Promise<void> {
   }
 }
 
+/** Format an error for console output. */
+function formatError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Require git to be available, exiting if not. */
+async function requireGit(): Promise<void> {
+  if (!(await checkGitAvailable())) {
+    console.error("Error: git is not installed or not in PATH.");
+    process.exit(1);
+  }
+}
+
+/** Derive or validate the registry name from URL/option. Returns the name or exits. */
+function resolveRegistryName(url: string, explicitName?: string): string {
+  if (explicitName) return explicitName;
+
+  const derived = deriveNameFromUrl(url);
+  try {
+    validateRegistryName(derived);
+  } catch {
+    console.error(
+      `Error: Could not derive a valid registry name from URL (got "${derived}"). ` +
+        "Please provide a name using --name.",
+    );
+    process.exit(1);
+  }
+  return derived;
+}
+
+/** Parse and validate a non-negative integer option. Exits on invalid input. */
+function parseNonNegativeInt(value: string, optionName: string): number {
+  const n = parseInt(value, 10);
+  if (isNaN(n) || n < 0) {
+    console.error(`Error: "${optionName}" must be a non-negative integer.`);
+    process.exit(1);
+  }
+  return n;
+}
+
+/** Perform the initial clone/sync after adding a registry. */
+async function initialSync(name: string, url: string): Promise<void> {
+  const cacheDir = getRegistryCacheDir(name);
+  console.log(`Cloning registry to ${cacheDir}...`);
+  try {
+    await cloneRegistry(url, cacheDir);
+    const index = readIndex(cacheDir);
+    console.log(`Synced: ${index.length} pack(s) available.`);
+  } catch (syncErr) {
+    console.warn(
+      `Warning: initial sync failed (${formatError(syncErr)}). ` +
+        'You can retry with "libscope registry sync".',
+    );
+  }
+}
+
 /** Register all `registry` subcommands on the given Commander program. */
 export function registerRegistryCommands(program: Command): void {
   const registryCmd = program
@@ -123,80 +179,30 @@ export function registerRegistryCommands(program: Command): void {
           sync: boolean;
         },
       ) => {
-        if (!(await checkGitAvailable())) {
-          console.error("Error: git is not installed or not in PATH.");
-          process.exit(1);
-          return;
-        }
+        await requireGit();
 
-        let name: string;
-        if (opts.name) {
-          name = opts.name;
-        } else {
-          const derived = deriveNameFromUrl(url);
-          try {
-            validateRegistryName(derived);
-          } catch {
-            console.error(
-              `Error: Could not derive a valid registry name from URL (got "${derived}"). ` +
-                "Please provide a name using --name.",
-            );
-            process.exit(1);
-            return;
-          }
-          name = derived;
-        }
-        const priority = parseInt(opts.priority, 10);
-        const syncInterval = parseInt(opts.syncInterval, 10);
-
-        if (isNaN(priority) || priority < 0) {
-          console.error('Error: "--priority" must be a non-negative integer.');
-          process.exit(1);
-          return;
-        }
-        if (isNaN(syncInterval) || syncInterval < 0) {
-          console.error('Error: "--sync-interval" must be a non-negative integer.');
-          process.exit(1);
-          return;
-        }
+        const name = resolveRegistryName(url, opts.name);
+        const priority = parseNonNegativeInt(opts.priority, "--priority");
+        const syncInterval = parseNonNegativeInt(opts.syncInterval, "--sync-interval");
 
         try {
           validateRegistryName(name);
           validateGitUrl(url);
         } catch (err) {
-          console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+          console.error(`Error: ${formatError(err)}`);
           process.exit(1);
           return;
         }
 
         try {
-          addRegistry({
-            name,
-            url,
-            syncInterval,
-            priority,
-            lastSyncedAt: null,
-          });
-
+          addRegistry({ name, url, syncInterval, priority, lastSyncedAt: null });
           console.log(`Registry "${name}" added (${url}).`);
 
-          // Initial sync
           if (opts.sync !== false) {
-            const cacheDir = getRegistryCacheDir(name);
-            console.log(`Cloning registry to ${cacheDir}...`);
-            try {
-              await cloneRegistry(url, cacheDir);
-              const index = readIndex(cacheDir);
-              console.log(`Synced: ${index.length} pack(s) available.`);
-            } catch (syncErr) {
-              console.warn(
-                `Warning: initial sync failed (${syncErr instanceof Error ? syncErr.message : String(syncErr)}). ` +
-                  'You can retry with "libscope registry sync".',
-              );
-            }
+            await initialSync(name, url);
           }
         } catch (err) {
-          console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+          console.error(`Error: ${formatError(err)}`);
           process.exit(1);
         }
       },
@@ -226,14 +232,12 @@ export function registerRegistryCommands(program: Command): void {
         try {
           rmSync(cacheDir, { recursive: true, force: true });
         } catch (rmErr) {
-          console.warn(
-            `Warning: could not remove cache directory (${rmErr instanceof Error ? rmErr.message : String(rmErr)})`,
-          );
+          console.warn(`Warning: could not remove cache directory (${formatError(rmErr)})`);
         }
 
         console.log(`Registry "${name}" removed.`);
       } catch (err) {
-        console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+        console.error(`Error: ${formatError(err)}`);
         process.exit(1);
       }
     });
@@ -274,11 +278,7 @@ export function registerRegistryCommands(program: Command): void {
     .command("sync [name]")
     .description("Sync one or all registries (git fetch + fast-forward)")
     .action(async (name?: string) => {
-      if (!(await checkGitAvailable())) {
-        console.error("Error: git is not installed or not in PATH.");
-        process.exit(1);
-        return;
-      }
+      await requireGit();
 
       if (name) {
         await syncSingleRegistry(name);
@@ -332,11 +332,7 @@ export function registerRegistryCommands(program: Command): void {
     .command("create <path>")
     .description("Initialize a new registry git repo with canonical folder structure")
     .action(async (rawPath: string) => {
-      if (!(await checkGitAvailable())) {
-        console.error("Error: git is not installed or not in PATH.");
-        process.exit(1);
-        return;
-      }
+      await requireGit();
 
       const resolved = pathResolve(rawPath);
       try {
@@ -344,7 +340,7 @@ export function registerRegistryCommands(program: Command): void {
         console.log(`Registry repo initialized at ${resolved}`);
         console.log("Push to a git remote, then add it with 'libscope registry add <url>'.");
       } catch (err) {
-        console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+        console.error(`Error: ${formatError(err)}`);
         process.exit(1);
       }
     });
@@ -362,11 +358,7 @@ export function registerRegistryCommands(program: Command): void {
         packFile: string,
         opts: { registry: string; version?: string; message?: string; submit?: boolean },
       ) => {
-        if (!(await checkGitAvailable())) {
-          console.error("Error: git is not installed or not in PATH.");
-          process.exit(1);
-          return;
-        }
+        await requireGit();
 
         const resolved = pathResolve(packFile);
 
@@ -394,7 +386,7 @@ export function registerRegistryCommands(program: Command): void {
             );
           }
         } catch (err) {
-          console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+          console.error(`Error: ${formatError(err)}`);
           process.exit(1);
         }
       },
@@ -413,11 +405,7 @@ export function registerRegistryCommands(program: Command): void {
         packName: string,
         opts: { registry: string; version: string; message?: string; yes?: boolean },
       ) => {
-        if (!(await checkGitAvailable())) {
-          console.error("Error: git is not installed or not in PATH.");
-          process.exit(1);
-          return;
-        }
+        await requireGit();
 
         if (
           !(await confirmAction(
@@ -438,7 +426,7 @@ export function registerRegistryCommands(program: Command): void {
           });
           console.log(`Pack "${packName}@${opts.version}" unpublished from "${opts.registry}".`);
         } catch (err) {
-          console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+          console.error(`Error: ${formatError(err)}`);
           process.exit(1);
         }
       },

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -98,6 +98,7 @@ import {
   parsePackSpecifier,
   resolvePackFromRegistries,
   verifyResolvedPackChecksum,
+  type ResolvedPack,
 } from "../registry/resolve.js";
 import { loadRegistries } from "../registry/config.js";
 import { createInterface } from "node:readline";
@@ -121,6 +122,216 @@ function parseIntOption(value: string, name: string): number {
     process.exit(1);
   }
   return n;
+}
+
+// ---------------------------------------------------------------------------
+// Extracted helpers to reduce cognitive complexity (SonarCloud S3776)
+// ---------------------------------------------------------------------------
+
+/** Truncate a string and add "..." suffix if it exceeds maxLen. */
+function previewText(text: string, maxLen: number): string {
+  return text.length > maxLen ? text.slice(0, maxLen) + "..." : text;
+}
+
+/** Print context-before chunks for a search result. */
+function printContextBefore(contextBefore: Array<{ content: string }> | undefined): void {
+  if (!contextBefore || contextBefore.length === 0) return;
+  for (const c of contextBefore) {
+    console.log(`  \u2191 ${previewText(c.content, 120)}`);
+  }
+  console.log("  \u2500 \u2500 \u2500");
+}
+
+/** Print context-after chunks for a search result. */
+function printContextAfter(contextAfter: Array<{ content: string }> | undefined): void {
+  if (!contextAfter || contextAfter.length === 0) return;
+  console.log("  \u2500 \u2500 \u2500");
+  for (const c of contextAfter) {
+    console.log(`  \u2193 ${previewText(c.content, 120)}`);
+  }
+}
+
+/** Print a single search result with optional context chunks. */
+function printSearchResult(r: {
+  title: string;
+  score: number;
+  library?: string | null;
+  url?: string | null;
+  content: string;
+  contextBefore?: Array<{ content: string }> | undefined;
+  contextAfter?: Array<{ content: string }> | undefined;
+}): void {
+  console.log(`\n\u2500\u2500 ${r.title} (score: ${r.score.toFixed(2)}) \u2500\u2500`);
+  if (r.library) console.log(`  Library: ${r.library}`);
+  if (r.url) console.log(`  Source: ${r.url}`);
+  printContextBefore(r.contextBefore);
+  console.log(`  ${previewText(r.content, 200)}`);
+  printContextAfter(r.contextAfter);
+}
+
+/** Print a single related-chunk result. */
+function printRelatedChunk(r: {
+  title: string;
+  score: number;
+  chunkId: string;
+  library?: string | null;
+  url?: string | null;
+  content: string;
+}): void {
+  console.log(`\n\u2500\u2500 ${r.title} (score: ${r.score.toFixed(2)}) \u2500\u2500`);
+  console.log(`  Chunk ID: ${r.chunkId}`);
+  if (r.library) console.log(`  Library: ${r.library}`);
+  if (r.url) console.log(`  Source: ${r.url}`);
+  console.log(`  ${previewText(r.content, 200)}`);
+}
+
+/** Build search filters from CLI options. */
+function buildSearchFilters(opts: {
+  topic?: string;
+  library?: string;
+  source?: string;
+}): Record<string, unknown> | undefined {
+  const filters: Record<string, unknown> = {};
+  if (opts.topic) filters.topic = opts.topic;
+  if (opts.library) filters.library = opts.library;
+  if (opts.source) filters.source = opts.source;
+  return Object.keys(filters).length > 0 ? filters : undefined;
+}
+
+/** Report the result of a pack install operation. */
+function reportInstallResult(
+  result: {
+    packName: string;
+    documentsInstalled: number;
+    alreadyInstalled: boolean;
+    errors: number;
+  },
+  reporter: { log(msg: string): void; success(msg: string): void },
+  registryName?: string,
+): void {
+  if (result.alreadyInstalled) {
+    reporter.log(`Pack "${result.packName}" is already installed.`);
+    return;
+  }
+  const errMsg = result.errors > 0 ? ` (${result.errors} errors)` : "";
+  const from = registryName ? ` from ${registryName}` : "";
+  reporter.success(
+    `Pack "${result.packName}" installed${from}: ${result.documentsInstalled} documents${errMsg}.`,
+  );
+}
+
+/** Install a resolved registry pack -- verify checksum, install, and report. */
+async function installResolvedPack(
+  db: ReturnType<typeof getDatabase>,
+  provider: EmbeddingProvider,
+  resolved: ResolvedPack,
+  installOpts: {
+    batchSize?: number | undefined;
+    resumeFrom?: number | undefined;
+    concurrency?: number | undefined;
+  },
+  reporter: {
+    log(msg: string): void;
+    success(msg: string): void;
+    progress(c: number, t: number, l: string): void;
+    clearProgress(): void;
+  },
+): Promise<void> {
+  await verifyResolvedPackChecksum(resolved);
+  const result = await installPack(db, provider, resolved.dataPath, {
+    ...installOpts,
+    onProgress: (current, total, docTitle) => {
+      reporter.progress(current, total, docTitle);
+    },
+  });
+  reporter.clearProgress();
+  reportInstallResult(result, reporter, resolved.registryName);
+}
+
+/**
+ * Prompt user to choose a registry when there is a conflict.
+ * Returns the chosen source index or -1 on invalid input.
+ */
+async function promptRegistryChoice(
+  packName: string,
+  sources: Array<{ registryName: string; version: string; priority: number }>,
+): Promise<number> {
+  console.log(`Pack "${packName}" found in multiple registries:`);
+  for (let i = 0; i < sources.length; i++) {
+    const s = sources[i]!;
+    console.log(`  [${i + 1}] ${s.registryName} (v${s.version}, priority: ${s.priority})`);
+  }
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  const answer = await new Promise<string>((resolve) => {
+    rl.question("Select registry [1]: ", (ans) => {
+      rl.close();
+      resolve(ans.trim() || "1");
+    });
+  });
+
+  const choice = parseInt(answer, 10) - 1;
+  if (isNaN(choice) || choice < 0 || choice >= sources.length) return -1;
+  return choice;
+}
+
+/**
+ * Handle the conflict case where a pack exists in multiple registries.
+ * Returns true if the install was handled (or process exited).
+ */
+async function handlePackConflict(
+  conflict: {
+    sources: Array<{ registryName: string; version: string; priority: number }>;
+  },
+  packName: string,
+  version: string | undefined,
+  opts: { yes?: boolean },
+  db: ReturnType<typeof getDatabase>,
+  provider: EmbeddingProvider,
+  installOpts: {
+    batchSize?: number | undefined;
+    resumeFrom?: number | undefined;
+    concurrency?: number | undefined;
+  },
+  reporter: {
+    log(msg: string): void;
+    success(msg: string): void;
+    progress(c: number, t: number, l: string): void;
+    clearProgress(): void;
+  },
+): Promise<boolean> {
+  if (opts.yes) {
+    const names = conflict.sources.map((s) => s.registryName).join(", ");
+    reporter.log(
+      `Error: Pack "${packName}" found in multiple registries: ${names}. ` +
+        "Use --from-registry <name> to disambiguate.",
+    );
+    closeDatabase();
+    process.exit(1);
+    return true;
+  }
+
+  const choice = await promptRegistryChoice(packName, conflict.sources);
+  if (choice < 0) {
+    reporter.log("Invalid selection. Cancelled.");
+    closeDatabase();
+    process.exit(1);
+    return true;
+  }
+
+  const chosen = conflict.sources[choice]!;
+  const retryResult = resolvePackFromRegistries(packName, {
+    version,
+    registryName: chosen.registryName,
+    conflictResolution: { strategy: "explicit", registryName: chosen.registryName },
+  });
+
+  if (retryResult.resolved) {
+    await installResolvedPack(db, provider, retryResult.resolved, installOpts, reporter);
+    return true;
+  }
+
+  return false;
 }
 
 const program = new Command();
@@ -413,41 +624,13 @@ program
         } else {
           console.log(`\nShowing ${results.length} of ${totalCount} results:\n`);
           for (const r of results) {
-            console.log(`\n── ${r.title} (score: ${r.score.toFixed(2)}) ──`);
-            if (r.library) console.log(`  Library: ${r.library}`);
-            if (r.url) console.log(`  Source: ${r.url}`);
-
-            if (r.contextBefore && r.contextBefore.length > 0) {
-              for (const c of r.contextBefore) {
-                const preview = c.content.slice(0, 120);
-                console.log(`  ↑ ${preview}${c.content.length > 120 ? "..." : ""}`);
-              }
-              console.log("  ─ ─ ─");
-            }
-
-            console.log(`  ${r.content.slice(0, 200)}${r.content.length > 200 ? "..." : ""}`);
-
-            if (r.contextAfter && r.contextAfter.length > 0) {
-              console.log("  ─ ─ ─");
-              for (const c of r.contextAfter) {
-                const preview = c.content.slice(0, 120);
-                console.log(`  ↓ ${preview}${c.content.length > 120 ? "..." : ""}`);
-              }
-            }
+            printSearchResult(r);
           }
         }
 
         if (opts.save) {
-          const filters: Record<string, unknown> = {};
-          if (opts.topic) filters.topic = opts.topic;
-          if (opts.library) filters.library = opts.library;
-          if (opts.source) filters.source = opts.source;
-          const saved = createSavedSearch(
-            db,
-            opts.save,
-            query,
-            Object.keys(filters).length > 0 ? filters : undefined,
-          );
+          const filters = buildSearchFilters(opts);
+          const saved = createSavedSearch(db, opts.save, query, filters);
           console.log(`\n✓ Search saved as "${saved.name}" (${saved.id})`);
         }
       } finally {
@@ -508,11 +691,7 @@ program
         } else {
           console.log(`\nShowing ${chunks.length} related chunks:\n`);
           for (const r of chunks) {
-            console.log(`\n── ${r.title} (score: ${r.score.toFixed(2)}) ──`);
-            console.log(`  Chunk ID: ${r.chunkId}`);
-            if (r.library) console.log(`  Library: ${r.library}`);
-            if (r.url) console.log(`  Source: ${r.url}`);
-            console.log(`  ${r.content.slice(0, 200)}${r.content.length > 200 ? "..." : ""}`);
+            printRelatedChunk(r);
           }
         }
       } finally {
@@ -1730,6 +1909,8 @@ packCmd
         return;
       }
 
+      const installOpts = { batchSize, resumeFrom, concurrency };
+
       try {
         // Check if this is a local file or URL-based registry install
         const isLocalFile = nameOrPath.endsWith(".json") || nameOrPath.endsWith(".json.gz");
@@ -1754,96 +1935,21 @@ packCmd
           }
 
           if (conflict && !resolved) {
-            // Multiple registries have this pack — prompt or fail
-            if (opts.yes) {
-              const names = conflict.sources.map((s) => s.registryName).join(", ");
-              reporter.log(
-                `Error: Pack "${packName}" found in multiple registries: ${names}. ` +
-                  "Use --from-registry <name> to disambiguate.",
-              );
-              closeDatabase();
-              process.exit(1);
-              return;
-            }
-
-            // Interactive prompt
-            console.log(`Pack "${packName}" found in multiple registries:`);
-            for (let i = 0; i < conflict.sources.length; i++) {
-              const s = conflict.sources[i]!;
-              console.log(
-                `  [${i + 1}] ${s.registryName} (v${s.version}, priority: ${s.priority})`,
-              );
-            }
-
-            const rl = createInterface({ input: process.stdin, output: process.stdout });
-            const answer = await new Promise<string>((resolve) => {
-              rl.question("Select registry [1]: ", (ans) => {
-                rl.close();
-                resolve(ans.trim() || "1");
-              });
-            });
-
-            const choice = parseInt(answer, 10) - 1;
-            if (isNaN(choice) || choice < 0 || choice >= conflict.sources.length) {
-              reporter.log("Invalid selection. Cancelled.");
-              closeDatabase();
-              process.exit(1);
-              return;
-            }
-
-            const chosen = conflict.sources[choice]!;
-            const retryResult = resolvePackFromRegistries(packName, {
+            const handled = await handlePackConflict(
+              conflict,
+              packName,
               version,
-              registryName: chosen.registryName,
-              conflictResolution: { strategy: "explicit", registryName: chosen.registryName },
-            });
-
-            if (retryResult.resolved) {
-              // Verify checksum before installing from registry cache
-              await verifyResolvedPackChecksum(retryResult.resolved);
-              // Install from resolved local path
-              const result = await installPack(db, provider, retryResult.resolved.dataPath, {
-                batchSize,
-                resumeFrom,
-                concurrency,
-                onProgress: (current, total, docTitle) => {
-                  reporter.progress(current, total, docTitle);
-                },
-              });
-              reporter.clearProgress();
-              if (result.alreadyInstalled) {
-                reporter.log(`Pack "${result.packName}" is already installed.`);
-              } else {
-                const errMsg = result.errors > 0 ? ` (${result.errors} errors)` : "";
-                reporter.success(
-                  `Pack "${result.packName}" installed from ${chosen.registryName}: ${result.documentsInstalled} documents${errMsg}.`,
-                );
-              }
-              return;
-            }
+              opts,
+              db,
+              provider,
+              installOpts,
+              reporter,
+            );
+            if (handled) return;
           }
 
           if (resolved) {
-            // Verify checksum before installing from registry cache
-            await verifyResolvedPackChecksum(resolved);
-            // Install from resolved local path
-            const result = await installPack(db, provider, resolved.dataPath, {
-              batchSize,
-              resumeFrom,
-              concurrency,
-              onProgress: (current, total, docTitle) => {
-                reporter.progress(current, total, docTitle);
-              },
-            });
-            reporter.clearProgress();
-            if (result.alreadyInstalled) {
-              reporter.log(`Pack "${result.packName}" is already installed.`);
-            } else {
-              const errMsg = result.errors > 0 ? ` (${result.errors} errors)` : "";
-              reporter.success(
-                `Pack "${result.packName}" installed from ${resolved.registryName}: ${result.documentsInstalled} documents${errMsg}.`,
-              );
-            }
+            await installResolvedPack(db, provider, resolved, installOpts, reporter);
             return;
           }
 
@@ -1853,24 +1959,14 @@ packCmd
         // Original URL-based or local file install
         const result = await installPack(db, provider, nameOrPath, {
           registryUrl: opts.registry,
-          batchSize,
-          resumeFrom,
-          concurrency,
+          ...installOpts,
           onProgress: (current, total, docTitle) => {
             reporter.progress(current, total, docTitle);
           },
         });
 
         reporter.clearProgress();
-
-        if (result.alreadyInstalled) {
-          reporter.log(`Pack "${result.packName}" is already installed.`);
-        } else {
-          const errMsg = result.errors > 0 ? ` (${result.errors} errors)` : "";
-          reporter.success(
-            `Pack "${result.packName}" installed: ${result.documentsInstalled} documents${errMsg}.`,
-          );
-        }
+        reportInstallResult(result, reporter);
       } finally {
         closeDatabase();
       }


### PR DESCRIPTION
## Summary

Reduces cognitive complexity (SonarCloud S3776) in 4 functions across `src/cli/` to meet the threshold of 15 or below.

### Functions fixed

1. **`src/cli/index.ts` — pack install action (was 53)**: Extracted `reportInstallResult()`, `installResolvedPack()`, `promptRegistryChoice()`, and `handlePackConflict()` helpers. The main handler now delegates conflict resolution and install reporting to these focused functions.

2. **`src/cli/index.ts` — search action (was 50)**: Extracted `printSearchResult()`, `printContextBefore()`, `printContextAfter()`, `previewText()`, and `buildSearchFilters()` helpers. Each search result's context/display logic is now in its own function.

3. **`src/cli/index.ts` — related action (was 23)**: Extracted `printRelatedChunk()` helper to handle per-chunk display with metadata.

4. **`src/cli/commands/registry.ts` — registry add action (was 19)**: Extracted `requireGit()`, `resolveRegistryName()`, `parseNonNegativeInt()`, `initialSync()`, and `formatError()` helpers. Also applied `requireGit()` and `formatError()` across other registry subcommands for consistency.

### Verification

- All 1351 tests pass (`npx vitest run`)
- No new TypeScript errors (`npm run typecheck`)
- Formatted with Prettier (`npx prettier --write 'src/cli/**/*.ts'`)

Closes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)