### PR TITLE
fix: export TreeSitterChunker from libscope/lite

### DIFF
--- a/src/lite/index.ts
+++ b/src/lite/index.ts
@@ -1,4 +1,6 @@
 export { LibScopeLite } from "./core.js";
+export { TreeSitterChunker } from "./chunker-treesitter.js";
+export type { CodeChunk } from "./chunker-treesitter.js";
 export type {
   LiteOptions,
   LiteDoc,


### PR DESCRIPTION
TreeSitterChunker was compiled into the dist but not re-exported from the \`./lite\` entry point. Consumers using the package exports map (Node16 module resolution) could not import it, forcing whole-file indexing instead of code-aware chunking.

## Changes
- Export \`TreeSitterChunker\` and \`CodeChunk\` from \`src/lite/index.ts\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)