### PR TITLE
fix(security): force flatted >=3.4.2 to patch prototype pollution CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3869,9 +3869,9 @@
       "license": "SEE LICENSE IN LICENSE.txt"
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     ]
   },
   "overrides": {
-    "esbuild": "^0.25.0"
+    "esbuild": "^0.25.0",
+    "flatted": ">=3.4.2"
   }
 }


### PR DESCRIPTION
## Summary

- Adds `"flatted": ">=3.4.2"` to the `overrides` section of `package.json` to force the patched version of `flatted` across all transitive dependencies
- Fixes CVE-2026-33228 / GHSA-rf6f-7fwh-wjgh (prototype pollution in `flatted` <= 3.4.1)
- Dependency chain: `eslint -> file-entry-cache -> flat-cache -> flatted@3.3.3` (now overridden to `3.4.2`)

## Test plan

- [x] `npm ls flatted` confirms `flatted@3.4.2 overridden`
- [x] `npm run typecheck` passes with zero errors
- [x] `npm test` -- 77 test files, 1488 tests, all pass

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)
