### PR TITLE
fix(quality): reduce cognitive complexity of spiderUrl generator (S3776)

### DIFF
--- a/src/core/spider.ts
+++ b/src/core/spider.ts
@@ -491,15 +491,7 @@ export async function* spiderUrl(
     if (visited.has(url)) continue;
     visited.add(url);
 
-    if (depth > 0) {
-      const skipped = await shouldSkipNonSeedUrl(url, config, robotsCache, stats, log);
-      if (skipped) continue;
-    }
-
-    if (stats.pagesFetched >= config.maxPages) {
-      stats.abortReason = "maxPages";
-      break;
-    }
+    if (depth > 0 && (await shouldSkipNonSeedUrl(url, config, robotsCache, stats, log))) continue;
 
     const raw = await fetchSpiderPage(url, config, stats, log);
     if (!raw) continue;


### PR DESCRIPTION
## Summary
- Flattens `if (depth > 0) { if (skipped) continue; }` into a single guarded `continue`
- Removes a redundant inner `maxPages` check (already guarded by the while-loop condition)
- Reduces cognitive complexity of `spiderUrl` from 21 → 14 (threshold: 15)

Resolves SonarCloud CRITICAL issue typescript:S3776 in `src/core/spider.ts`.

Closes #473

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm test` passes
- [ ] SonarCloud scan shows S3776 resolved for spider.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)