### PR TITLE
fix(quality): prefer Number.parseInt/parseFloat/isNaN over globals (S7773)

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -642,7 +642,7 @@ async function handleAddTagsToDocument(ctx: RouteContext, docId: string): Promis
 
 function handleSuggestTags(ctx: RouteContext, docId: string): void {
   const limitRaw = ctx.url.searchParams.get("limit");
-  const limit = limitRaw ? parseInt(limitRaw, 10) : 5;
+  const limit = limitRaw ? Number.parseInt(limitRaw, 10) : 5;
   const suggestions = suggestTags(ctx.db, docId, limit);
   sendJson(ctx.res, 200, { documentId: docId, suggestions }, elapsed(ctx.start));
 }

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -131,8 +131,8 @@ function resolveRegistryName(url: string, explicitName?: string): string {
 
 /** Parse and validate a non-negative integer option. Exits on invalid input. */
 function parseNonNegativeInt(value: string, optionName: string): number {
-  const n = parseInt(value, 10);
-  if (isNaN(n) || n < 0) {
+  const n = Number.parseInt(value, 10);
+  if (Number.isNaN(n) || n < 0) {
     console.error(`Error: "${optionName}" must be a non-negative integer.`);
     process.exit(1);
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -119,7 +119,7 @@ const _pkg = _require("../../package.json") as { version: string };
 
 /** Parse a CLI option string as an integer, exiting with an error if the value is not a valid number. */
 function parseIntOption(value: string, name: string): number {
-  const n = parseInt(value, 10);
+  const n = Number.parseInt(value, 10);
   if (Number.isNaN(n)) {
     console.error(`Error: "${value}" is not a valid number for ${name}`);
     process.exit(1);
@@ -273,8 +273,8 @@ async function promptRegistryChoice(
     });
   });
 
-  const choice = parseInt(answer, 10) - 1;
-  if (isNaN(choice) || choice < 0 || choice >= sources.length) return -1;
+  const choice = Number.parseInt(answer, 10) - 1;
+  if (Number.isNaN(choice) || choice < 0 || choice >= sources.length) return -1;
   return choice;
 }
 
@@ -877,7 +877,7 @@ program
       const { db } = initializeApp();
       try {
         const limit = parseIntOption(opts.limit, "--limit");
-        const minScore = opts.minScore !== undefined ? parseFloat(opts.minScore) : undefined;
+        const minScore = opts.minScore !== undefined ? Number.parseFloat(opts.minScore) : undefined;
         const tags = opts.tags ? opts.tags.split(",").map((t) => t.trim()) : undefined;
 
         let result;
@@ -1400,7 +1400,7 @@ tagCmd
   .action((documentId: string, opts: { limit: string }) => {
     const { db } = initializeApp();
     try {
-      const limit = parseInt(opts.limit, 10);
+      const limit = Number.parseInt(opts.limit, 10);
       const suggestions = suggestTags(db, documentId, limit);
       if (suggestions.length === 0) {
         console.log("No tag suggestions found for this document.");
@@ -1760,7 +1760,7 @@ program
     try {
       console.log("Scanning for duplicates...\n");
       const groups = await findDuplicates(db, provider, {
-        threshold: parseFloat(opts.threshold),
+        threshold: Number.parseFloat(opts.threshold),
         strategy: opts.strategy as "exact" | "semantic" | "both",
       });
 

--- a/src/connectors/onenote.ts
+++ b/src/connectors/onenote.ts
@@ -90,7 +90,7 @@ async function rateLimitedFetch(url: string, options: RequestInit): Promise<Resp
 
     if (response.status === 429) {
       const retryAfter = response.headers.get("Retry-After");
-      const parsed = retryAfter ? parseInt(retryAfter, 10) : NaN;
+      const parsed = retryAfter ? Number.parseInt(retryAfter, 10) : NaN;
       const delayMs = Number.isNaN(parsed) ? Math.pow(2, attempt) * 1000 : parsed * 1000;
       log.warn({ attempt, delayMs }, "Rate limited (429), backing off");
       lastError = new LibScopeError(
@@ -183,38 +183,38 @@ export function convertOneNoteHtml(html: string): string {
   let processed = html;
 
   // Remove style attributes
-  processed = processed.replace(/ style="[^"]*"/gi, "");
+  processed = processed.replaceAll(/ style="[^"]*"/gi, "");
 
   // Remove OneNote metadata divs
-  processed = processed.replace(/<div[^>]*data-id="[^"]*"[^>]*>[\s\S]*?<\/div>/gi, "");
+  processed = processed.replaceAll(/<div[^>]*data-id="[^"]*"[^>]*>[\s\S]*?<\/div>/gi, "");
 
   // cite → blockquote
-  processed = processed.replace(/<cite>([\s\S]*?)<\/cite>/gi, "<blockquote>$1</blockquote>");
+  processed = processed.replaceAll(/<cite>([\s\S]*?)<\/cite>/gi, "<blockquote>$1</blockquote>");
 
   // Completed checkboxes — replace with plain text marker before nhm
-  processed = processed.replace(
+  processed = processed.replaceAll(
     /<p[^>]*data-tag="to-do:completed"[^>]*>([\s\S]*?)<\/p>/gi,
     "CHECKDONE7X9Z $1\n",
   );
 
   // Uncompleted checkboxes
-  processed = processed.replace(
+  processed = processed.replaceAll(
     /<p[^>]*data-tag="to-do"[^>]*>([\s\S]*?)<\/p>/gi,
     "CHECKTODO7X9Z $1\n",
   );
 
   // Ink annotations → placeholder token
-  processed = processed.replace(
+  processed = processed.replaceAll(
     /<div[^>]*class="[^"]*InkNode[^"]*"[^>]*>[\s\S]*?<\/div>/gi,
     "INKPLACEHOLDER7X9Z",
   );
-  processed = processed.replace(/<ink[^>]*>[\s\S]*?<\/ink>/gi, "INKPLACEHOLDER7X9Z");
+  processed = processed.replaceAll(/<ink[^>]*>[\s\S]*?<\/ink>/gi, "INKPLACEHOLDER7X9Z");
 
   // Embedded images → placeholder token
-  processed = processed.replace(/<img[^>]*>/gi, "IMGPLACEHOLDER7X9Z");
+  processed = processed.replaceAll(/<img[^>]*>/gi, "IMGPLACEHOLDER7X9Z");
 
   // Embedded files → [attached: filename] token
-  processed = processed.replace(
+  processed = processed.replaceAll(
     /<object[^>]*data-attachment="([^"]*)"[^>]*>[\s\S]*?<\/object>/gi,
     "FILEATTACH7X9Z$1ENDATTACH7X9Z",
   );
@@ -227,7 +227,7 @@ export function convertOneNoteHtml(html: string): string {
   md = md.replaceAll(/CHECKTODO7X9Z\s*/g, "- [ ] ");
   md = md.replaceAll("INKPLACEHOLDER7X9Z", "[handwritten content]");
   md = md.replaceAll("IMGPLACEHOLDER7X9Z", "[image]");
-  md = md.replace(/FILEATTACH7X9Z([^\s]+?)ENDATTACH7X9Z/g, "[attached: $1]");
+  md = md.replaceAll(/FILEATTACH7X9Z([^\s]+?)ENDATTACH7X9Z/g, "[attached: $1]");
 
   return md;
 }

--- a/src/core/repo.ts
+++ b/src/core/repo.ts
@@ -155,11 +155,11 @@ async function handleRateLimit(response: Response): Promise<boolean> {
   const resetHeader = response.headers.get("x-ratelimit-reset");
 
   const isRateLimited = response.status === 429;
-  const isApproaching = remaining !== null && parseInt(remaining, 10) < RATE_LIMIT_THRESHOLD;
+  const isApproaching = remaining !== null && Number.parseInt(remaining, 10) < RATE_LIMIT_THRESHOLD;
 
   if (!isRateLimited && !isApproaching) return false;
 
-  const resetTime = resetHeader ? parseInt(resetHeader, 10) * 1000 : Date.now() + 60_000;
+  const resetTime = resetHeader ? Number.parseInt(resetHeader, 10) * 1000 : Date.now() + 60_000;
   const waitMs = Math.max(resetTime - Date.now(), 1000);
   const log = getLogger();
   log.warn({ remaining, waitMs }, "Rate limit approaching, backing off");

--- a/src/registry/git.ts
+++ b/src/registry/git.ts
@@ -16,7 +16,7 @@ const execFile = promisify(execFileCb);
 
 /** Default timeout for git operations (60 seconds), capped at 5 minutes. */
 const GIT_TIMEOUT_MS = Math.min(
-  parseInt(process.env.LIBSCOPE_GIT_TIMEOUT_MS ?? "60000", 10) || 60000,
+  Number.parseInt(process.env.LIBSCOPE_GIT_TIMEOUT_MS ?? "60000", 10) || 60000,
   300000, // cap at 5 minutes
 );
 

--- a/src/registry/publish.ts
+++ b/src/registry/publish.ts
@@ -96,8 +96,8 @@ function validateSemver(version: string): void {
 function bumpPatchVersion(version: string): string {
   const parts = version.split(".");
   if (parts.length !== 3) return "1.0.1";
-  const patch = parseInt(parts[2]!, 10);
-  return `${parts[0]}.${parts[1]}.${isNaN(patch) ? 1 : patch + 1}`;
+  const patch = Number.parseInt(parts[2]!, 10);
+  return `${parts[0]}.${parts[1]}.${Number.isNaN(patch) ? 1 : patch + 1}`;
 }
 
 /** Gzip magic number: first two bytes of a gzip stream. */

--- a/src/registry/sync.ts
+++ b/src/registry/sync.ts
@@ -27,8 +27,8 @@ function acquireSyncLock(cacheDir: string): string | null {
   if (existsSync(lockPath)) {
     try {
       const content = readFileSync(lockPath, "utf-8").trim();
-      const pid = parseInt(content, 10);
-      if (!isNaN(pid)) {
+      const pid = Number.parseInt(content, 10);
+      if (!Number.isNaN(pid)) {
         // Check whether the PID is still alive
         try {
           process.kill(pid, 0);

--- a/src/web/graph-api.ts
+++ b/src/web/graph-api.ts
@@ -10,8 +10,8 @@ export async function handleGraphRequest(
 ): Promise<void> {
   const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
 
-  const rawThreshold = parseFloat(url.searchParams.get("threshold") ?? "0.85");
-  const rawMaxNodes = parseInt(url.searchParams.get("maxNodes") ?? "200", 10);
+  const rawThreshold = Number.parseFloat(url.searchParams.get("threshold") ?? "0.85");
+  const rawMaxNodes = Number.parseInt(url.searchParams.get("maxNodes") ?? "200", 10);
   const topic = url.searchParams.get("topic") ?? undefined;
   const tag = url.searchParams.get("tag") ?? undefined;
 


### PR DESCRIPTION
## Summary
- Replaces all bare `parseInt`, `parseFloat`, and `isNaN` calls with `Number.*` equivalents across 9 source files
- Each `isNaN → Number.isNaN` replacement verified to operate on a numeric value (result of `parseInt`/`parseFloat`), not a raw string, so the coercion difference is irrelevant
- Files: `src/api/routes.ts`, `src/cli/commands/registry.ts`, `src/cli/index.ts`, `src/connectors/onenote.ts`, `src/core/repo.ts`, `src/registry/git.ts`, `src/registry/publish.ts`, `src/registry/sync.ts`, `src/web/graph-api.ts`

Closes #469

## Test plan
- [x] `npm run typecheck` passes
- [x] All 1488 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)