### PR TITLE
fix(quality): eliminate negated conditions in ternary expressions (S7735)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1385,7 +1385,7 @@ tagCmd
         console.log("No tags found. Add tags with: libscope tag add <docId> <tags...>");
       } else {
         for (const t of allTags) {
-          console.log(`  ${t.name} (${t.documentCount} doc${t.documentCount !== 1 ? "s" : ""})`);
+          console.log(`  ${t.name} (${t.documentCount} doc${t.documentCount === 1 ? "" : "s"})`);
         }
       }
     } finally {

--- a/src/connectors/docs.ts
+++ b/src/connectors/docs.ts
@@ -302,7 +302,7 @@ export function extractElementByPattern(
     if (matchesAttr) {
       const contentStart = m.index + m[0].length;
       const closeIdx = findClosingTagIndex(html, tagName, contentStart);
-      return closeIdx === -1 ? null : html.slice(contentStart, closeIdx);
+      return closeIdx >= 0 ? html.slice(contentStart, closeIdx) : null;
     }
   }
 

--- a/src/core/link-extractor.ts
+++ b/src/core/link-extractor.ts
@@ -201,7 +201,7 @@ export function extractWikilinks(content: string): string[] {
     if (!inner.includes("[[")) {
       // [[PageName|alias]] → extract PageName (before the pipe)
       const pipeIdx = inner.indexOf("|");
-      const pageName = (pipeIdx === -1 ? inner : inner.slice(0, pipeIdx)).trim();
+      const pageName = (pipeIdx >= 0 ? inner.slice(0, pipeIdx) : inner).trim();
       if (pageName) {
         seen.add(pageName);
       }

--- a/src/core/spider.ts
+++ b/src/core/spider.ts
@@ -234,7 +234,7 @@ function scanPastTag(input: string, start: number): number {
     if (ch === ">") return i + 1;
     if (ch === '"' || ch === "'") {
       const close = input.indexOf(ch, i + 1);
-      i = close === -1 ? input.length : close + 1;
+      i = close >= 0 ? close + 1 : input.length;
     } else {
       i++;
     }


### PR DESCRIPTION
## Summary
- Flips 4 ternaries from negative-condition to positive-condition form (pure semantic-preserving refactor)
- `src/cli/index.ts`: `documentCount !== 1 ? "s" : ""` → `=== 1 ? "" : "s"`
- `src/connectors/docs.ts`: `closeIdx === -1 ? null : slice(...)` → `!== -1 ? slice(...) : null`
- `src/core/link-extractor.ts`: `pipeIdx === -1 ? inner : slice(...)` → `!== -1 ? slice(...) : inner`
- `src/core/spider.ts`: `close === -1 ? input.length : close + 1` → `!== -1 ? close + 1 : input.length`

Closes #471

## Test plan
- [x] `npm run typecheck` passes
- [x] All 1488 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)