### PR TITLE
chore(claude): commit .claude/settings.json and allow gh commands for subagents

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,53 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run build)",
+      "Bash(npm run build:*)",
+      "Bash(npm test)",
+      "Bash(npm run test:*)",
+      "Bash(npm run lint)",
+      "Bash(npm run lint:fix)",
+      "Bash(npm run typecheck)",
+      "Bash(npm run format)",
+      "Bash(npm run format:check)",
+      "Bash(git status)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git add*)",
+      "Bash(git commit*)",
+      "Bash(git branch*)",
+      "Bash(git checkout*)",
+      "Bash(git stash*)",
+      "Bash(npx tsc --noEmit*)",
+      "Bash(npx prettier*)",
+      "Bash(gh pr*)",
+      "Bash(gh issue*)",
+      "Bash(gh run*)",
+      "Bash(gh api*)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/format-ts.sh"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/guard-bash.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Commits `.claude/settings.json` to the repo (it was previously untracked/floating)
- Adds `gh pr*`, `gh issue*`, `gh run*`, `gh api*` to the allowlist so agents running in isolated worktrees can create PRs without manual intervention
- The hooks (`format-ts.sh`, `guard-bash.sh`) and CLAUDE.md are already committed — this completes the Claude Code project configuration

## Why this matters
Agents running in `--isolation worktree` mode get a fresh git checkout, so they never saw the untracked `.claude/settings.json`. Without it, every agent had to ask the user to create the PR manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)